### PR TITLE
fix(breakpoints): changed breakpoints to fit the material spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,16 @@ We can associate breakpoints with mediaQuery definitions using breakpoint **alia
 
 | breakpoint | mediaQuery |
 |--------|--------|
-| ""    | `screen`                                                |
-| xs    | `screen and (max-width: 479px)`                         |
-| gt-xs | `screen and (min-width: 480px)`                         |
-| sm    | `screen and (max-width: 599px)`                         |
-| gt-sm | `screen and (min-width: 600px)`                         |
-| md    | `screen and (min-width: 600px) and (max-width: 959px)`  |
-| gt-md | `screen and (min-width: 960px)`                         |
-| lg    | `screen and (min-width: 960px) and (max-width: 1279px)` |
-| gt-lg | `screen and (min-width: 1280px)`                        |
-| xl    | `screen and (min-width: 1280px) and (max-width: 1919px)`|
-| gt-xl | `screen and (min-width: 1920px)`                        |
+| ""    | 'screen'                                                |
+| xs    | 'screen and (max-width: 599px)'                         |
+| gt-xs | 'screen and (min-width: 600px)'                         |
+| sm    | 'screen and (min-width: 600px) and (max-width: 959px)'  |
+| gt-sm | 'screen and (min-width: 960px)'                         |
+| md    | 'screen and (min-width: 960px) and (max-width: 1279px)' |
+| gt-md | 'screen and (min-width: 1280px)'                        |
+| lg    | 'screen and (min-width: 1280px) and (max-width: 1919px)'|
+| gt-lg | 'screen and (min-width: 1920px)'                        |
+| xl    | 'screen and (min-width: 1920px)'                        |
                       
 <br/>
 

--- a/src/mediaQuery/services/BreakPointsService.es6.js
+++ b/src/mediaQuery/services/BreakPointsService.es6.js
@@ -3,17 +3,16 @@ class BreakPointsService {
 
   constructor() {
     this.breakpoints = [
-        new BreakPoint(''      ,''     ,'screen'                                                ),
-        new BreakPoint('xs'    ,'Xs'   ,'screen and (max-width: 479px)'                         ),
-        new BreakPoint('gt-xs' ,'GtXs' ,'screen and (min-width: 480px)'                         ),
-        new BreakPoint('sm'    ,'Sm'   ,'screen and (max-width: 599px)'                         ),
-        new BreakPoint('gt-sm' ,'GtSm' ,'screen and (min-width: 600px)'                         ),
-        new BreakPoint('md'    ,'Md'   ,'screen and (min-width: 600px) and (max-width: 959px)'  ),
-        new BreakPoint('gt-md' ,'GtMd' ,'screen and (min-width: 960px)'                         ),
-        new BreakPoint('lg'    ,'Lg'   ,'screen and (min-width: 960px) and (max-width: 1279px)' ),
-        new BreakPoint('gt-lg' ,'GtLg' ,'screen and (min-width: 1280px)'                        ),
-        new BreakPoint('xl'    ,'Xl'   ,'screen and (min-width: 1280px) and (max-width: 1919px)'),
-        new BreakPoint('gt-xl' ,'GtXl' ,'screen and (min-width: 1920px)'                        )
+        new BreakPoint(''     , ''    , 'screen'                                                ),
+        new BreakPoint('xs'   , 'Xs'  , 'screen and (max-width: 599px)'                         ),
+        new BreakPoint('gt-xs', 'GtXs', 'screen and (min-width: 600px)'                         ),
+        new BreakPoint('sm'   , 'Sm'  , 'screen and (min-width: 600px) and (max-width: 959px)'  ),
+        new BreakPoint('gt-sm', 'GtSm', 'screen and (min-width: 960px)'                         ),
+        new BreakPoint('md'   , 'Md'  , 'screen and (min-width: 960px) and (max-width: 1279px)' ),
+        new BreakPoint('gt-md', 'GtMd', 'screen and (min-width: 1280px)'                        ),
+        new BreakPoint('lg'   , 'Lg'  , 'screen and (min-width: 1280px) and (max-width: 1919px)'),
+        new BreakPoint('gt-lg', 'GtLg', 'screen and (min-width: 1920px)'                        ), // The same as xl
+        new BreakPoint('xl'   , 'Xl'  , 'screen and (min-width: 1920px)'                        )
     ];
   }
 


### PR DESCRIPTION
`gt-xl` was deleted because `xl` is defined from 1920px - ∞,
also `gt-lg` and `xl` are basically the same.

As seen in [spec ](https://www.google.com/design/spec/layout/adaptive-ui.html#adaptive-ui-breakpoints)
