### PR TITLE
chore: fix per-commit publishing for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
   - ./tools/scripts/ci/build-and-test.sh
 
 after_success:
-  - ./scripts/ci/after-success.sh
+  - ./tools/scripts/ci/after-success.sh
 
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "style-loader": "^0.13.1",
     "stylelint": "^7.5.0",
     "symlink-or-copy": "^1.0.1",
-    "travis-after-modes": "0.0.5",
+    "travis-after-modes": "0.0.6-2",
     "ts-helpers": "1.1.2",
     "ts-node": "^0.7.3",
     "tslint": "^4.0.0-dev.0",

--- a/tools/scripts/ci/after-success.sh
+++ b/tools/scripts/ci/after-success.sh
@@ -9,10 +9,8 @@ cd $(dirname $0)/../../..
 # Use @DevVersion npm plugin Travis-After-Modes to
 # confirm all Travis jobs completed successfully see .travis.yml
 
-npmBin=$(npm bin)
-ciResult=$($npmBin/travis-after-modes)
-
-if [ "$ciResult" = "PASSED" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+# If not running as a PR, wait for all other travis modes to finish.
+if [ "$TRAVIS_PULL_REQUEST" = "false" ] && $(npm bin)/travis-after-modes; then
   echo "All travis modes passed. Publishing the build artifacts..."
   ./tools/scripts/release/publish-build-artifacts.sh
 fi


### PR DESCRIPTION
* Updates the travis-after-modes script to the latest version (fixed potential travis timeouts)
* Fixed a wrong path to the `after-success.sh` script.

R: @ThomasBurleson 