### PR TITLE
chore: fix sigpipe error for commit message

### DIFF
--- a/tools/scripts/release/publish-build-artifacts.sh
+++ b/tools/scripts/release/publish-build-artifacts.sh
@@ -14,7 +14,7 @@ buildVersion=$(sed -nE 's/^\s*"version": "(.*?)",$/\1/p' package.json)
 commitSha=$(git rev-parse --short HEAD)
 commitAuthorName=$(git --no-pager show -s --format='%an' HEAD)
 commitAuthorEmail=$(git --no-pager show -s --format='%ae' HEAD)
-commitMessage=$(git log --oneline | head -n1)
+commitMessage=$(git log --oneline -n 1)
 
 repoName="flex-layout-builds"
 repoUrl="http://github.com/ThomasBurleson/$repoName.git"


### PR DESCRIPTION
When retrieving the last commit message, the script currently pipes it through the `head` command.
Since the `git log` command using the `less` command will exit immediately the pipe will fail with a `141` exit code (because it can't read from a closed stream)