### PR TITLE
chore: es5 modules as entry point

### DIFF
--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-alpha.12",
   "description": "Angular 2 Flexbox Layout",
   "main": "./flex-layout.umd.js",
+  "module": "./index.js",
   "types": "./index.d.ts",
   "repository": {
     "type": "git",

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -2,9 +2,8 @@
   "name": "@angular/flex-layout",
   "version": "1.0.0-alpha.12",
   "description": "Angular 2 Flexbox Layout",
-  "main": "./index.js",
+  "main": "./flex-layout.umd.js",
   "types": "./index.d.ts",
-  "typings": "./index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/flex-layout.git"


### PR DESCRIPTION
* Fixes inconsistent release packaging between `@angular/{core,material}`