### PR TITLE
chore: fix incorrect path to umd bundles

### DIFF
--- a/tools/scripts/release/npm_assets/package.json
+++ b/tools/scripts/release/npm_assets/package.json
@@ -2,7 +2,7 @@
   "name": "@angular/flex-layout",
   "version": "1.0.0-alpha.12",
   "description": "Angular 2 Flexbox Layout",
-  "main": "./flex-layout.umd.js",
+  "main": "./bundles/flex-layout.umd.js",
   "module": "./index.js",
   "types": "./index.d.ts",
   "repository": {


### PR DESCRIPTION
* Fixes the incorrect path for the UMD bundles, which is essential for all module loaders and bundlers like Webpack.