### PR TITLE
chore: only publish artifacts once

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "style-loader": "^0.13.1",
     "stylelint": "^7.5.0",
     "symlink-or-copy": "^1.0.1",
-    "travis-after-modes": "0.0.6-2",
+    "travis-after-modes": "0.0.7",
     "ts-helpers": "1.1.2",
     "ts-node": "^0.7.3",
     "tslint": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7287,9 +7287,9 @@ traverse-chain@~0.1.0:
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
 
-travis-after-modes@0.0.6-2:
-  version "0.0.6-2"
-  resolved "https://registry.yarnpkg.com/travis-after-modes/-/travis-after-modes-0.0.6-2.tgz#1c7bd73f1fd3e9c646bb1eb7600d63e01433e23b"
+travis-after-modes@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/travis-after-modes/-/travis-after-modes-0.0.7.tgz#a3f3c058d3e86aaa7bf41bb087c75db9145a718c"
   dependencies:
     request "^2.79.0"
     request-promise "^4.1.1"


### PR DESCRIPTION
Right now Travis tries to publish the build artifacts to the `flex-layout-builds` repository for each mode.
Fortunately it still only published once, because Git doesn't allow re-publishing of the same git tags.

The issue has been fixed with version `0.0.7` of `travis-after-modes` (DevVersion/travis-after-modes@387328e)

This is similar to angular/material2@8470534