### PR TITLE
Apply margin-top in layout-gap for column layouts - Fixes #106

### DIFF
--- a/src/lib/flexbox/api/layout-gap.spec.ts
+++ b/src/lib/flexbox/api/layout-gap.spec.ts
@@ -7,7 +7,7 @@
  */
 import {Component, OnInit} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 
 import {MockMatchMedia} from '../../media-query/mock/mock-match-media';
 import {MatchMedia} from '../../media-query/match-media';
@@ -23,7 +23,6 @@ import {
 } from '../../utils/testing/helpers';
 
 describe('layout-gap directive', () => {
-  let fixture: ComponentFixture<any>;
   let createTestComponent = makeCreateTestComponent(() => TestLayoutGapComponent);
   let expectDomForQuery = makeExpectDOMForQuery(() => TestLayoutGapComponent);
 
@@ -39,12 +38,6 @@ describe('layout-gap directive', () => {
         {provide: MatchMedia, useClass: MockMatchMedia}
       ]
     });
-  });
-  afterEach(() => {
-    if (fixture) {
-      fixture.debugElement.injector.get(MatchMedia).clearAll();
-      fixture = null;
-    }
   });
 
   describe('with static features', () => {
@@ -78,7 +71,33 @@ describe('layout-gap directive', () => {
       expect(nodes[2].nativeElement).toHaveCssStyle({ 'margin-left': '13px'});
     });
 
+    it('should apply margin-top for column layouts', () => {
+      verifyCorrectMargin('column', 'margin-top');
+    });
+
+    it('should apply margin-right for row-reverse layouts', () => {
+      verifyCorrectMargin('row-reverse', 'margin-right');
+    });
+
+    it('should apply margin-bottom for column-reverse layouts', () => {
+      verifyCorrectMargin('column-reverse', 'margin-bottom');
+    });
   });
+
+  function verifyCorrectMargin(layout: string, expectedMarginType: string) {
+    const margin = '8px';
+    const template = `
+            <div fxLayout='${layout}' fxLayoutGap='${margin}'>
+                <span></span>
+                <span></span>
+            </div>
+        `;
+    const fixture = createTestComponent(template);
+    fixture.detectChanges();
+
+    const nodes = queryFor(fixture, 'span');
+    expect(nodes[1].nativeElement).toHaveCssStyle({ [expectedMarginType]: margin});
+  }
 
   describe('with responsive features', () => {
 
@@ -105,4 +124,5 @@ export class TestLayoutGapComponent implements OnInit {
   ngOnInit() {
   }
 }
+
 

--- a/src/lib/flexbox/api/layout-gap.ts
+++ b/src/lib/flexbox/api/layout-gap.ts
@@ -12,12 +12,17 @@ import {
   OnChanges,
   Renderer,
   SimpleChanges,
-  AfterContentInit
+  Self,
+  AfterContentInit,
+  Optional,
+  OnDestroy,
 } from '@angular/core';
+import {Subscription} from 'rxjs/Subscription';
 
 import {BaseFxDirective} from './base';
 import {MediaChange} from '../../media-query/media-change';
 import {MediaMonitor} from '../../media-query/media-monitor';
+import {LayoutDirective, LAYOUT_VALUES} from './layout';
 
 /**
  * 'layout-padding' styling directive
@@ -35,7 +40,11 @@ import {MediaMonitor} from '../../media-query/media-monitor';
   [fxLayoutGap.gt-lg],
   [fxLayoutGap.xl]
 `})
-export class LayoutGapDirective extends BaseFxDirective implements AfterContentInit, OnChanges {
+export class LayoutGapDirective extends BaseFxDirective implements AfterContentInit, OnChanges,
+                                                                   OnDestroy {
+  private _layout = 'row';  // default flex-direction
+  private _layoutWatcher: Subscription;
+
   @Input('fxLayoutGap')       set gap(val)     { this._cacheInput('gap', val); }
   @Input('fxLayoutGap.xs')    set gapXs(val)   { this._cacheInput('gapXs', val); }
   @Input('fxLayoutGap.gt-xs') set gapGtXs(val) { this._cacheInput('gapGtXs', val); };
@@ -47,8 +56,16 @@ export class LayoutGapDirective extends BaseFxDirective implements AfterContentI
   @Input('fxLayoutGap.gt-lg') set gapGtLg(val) { this._cacheInput('gapGtLg', val); };
   @Input('fxLayoutGap.xl')    set gapXl(val)   { this._cacheInput('gapXl', val); };
 
-  constructor(monitor: MediaMonitor, elRef: ElementRef, renderer: Renderer ) {
+  constructor(
+    monitor: MediaMonitor,
+    elRef: ElementRef,
+    renderer: Renderer,
+    @Optional() @Self() container: LayoutDirective) {
     super(monitor, elRef, renderer);
+
+    if (container) {  // Subscribe to layout direction changes
+      this._layoutWatcher = container.layout$.subscribe(this._onLayoutChange.bind(this));
+    }
   }
 
   // *********************************************
@@ -72,9 +89,28 @@ export class LayoutGapDirective extends BaseFxDirective implements AfterContentI
     this._updateWithValue();
   }
 
+  ngOnDestroy() {
+     super.ngOnDestroy();
+     if (this._layoutWatcher) {
+       this._layoutWatcher.unsubscribe();
+     }
+   }
+
   // *********************************************
   // Protected methods
   // *********************************************
+
+  /**
+   * Cache the parent container 'flex-direction' and update the 'margin' styles
+   */
+  private _onLayoutChange(direction) {
+    this._layout = (direction || '').toLowerCase();
+    if (!LAYOUT_VALUES.find(x => x === this._layout)) {
+      this._layout = 'row';
+    }
+
+    this._updateWithValue();
+  }
 
   /**
    *
@@ -93,7 +129,11 @@ export class LayoutGapDirective extends BaseFxDirective implements AfterContentI
   }
 
   private _buildCSS(value) {
-    return { 'margin-left' : value };
+    let margin = 'margin-left';
+    if (this._layout === 'row-reverse') { margin = 'margin-right'; }
+    if (this._layout === 'column') { margin = 'margin-top'; }
+    if (this._layout === 'column-reverse') { margin = 'margin-bottom'; }
+    return { [margin] : value };
   }
 
 }

--- a/src/lib/utils/testing/helpers.ts
+++ b/src/lib/utils/testing/helpers.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Type} from '@angular/core';
+import {Type, DebugElement} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import any = jasmine.any; // tslint:disable-line:no-unused-variable
@@ -88,7 +88,7 @@ export function makeExpectDOMForQuery(getClass: ComponentClazzFn) {
 }
 
 
-export function queryFor(fixture: ComponentFixture<any>, selector: string): any {
+export function queryFor(fixture: ComponentFixture<any>, selector: string): DebugElement[] {
   return fixture.debugElement.queryAll(By.css(selector));
 }
 


### PR DESCRIPTION
Use margin-top for column layouts instead of margin-left.
Also add small typing improvement to the queryFor helper function.