### PR TITLE
fix(build): add observable-media-service to index.ts

### DIFF
--- a/src/lib/media-query/index.ts
+++ b/src/lib/media-query/index.ts
@@ -11,4 +11,5 @@ export * from './providers/observable-media-service-provider';
 export * from './match-media';
 export * from './media-change';
 export * from './media-monitor';
+export * from './observable-media-service';
 export * from './_module';


### PR DESCRIPTION
After upgrade to beta 4,  I can't import `ObservableMediaService` from the barrel.

fixes #144.