### PR TITLE
fix(api): restore element's display mode and more...

### DIFF
--- a/src/lib/flexbox/api/show.spec.ts
+++ b/src/lib/flexbox/api/show.spec.ts
@@ -199,6 +199,25 @@ describe('show directive', () => {
 
 
   });
+
+  describe('with fxHide features', () => {
+
+    it('should support hide and show', () => {
+      fixture = createTestComponent(`
+          <div fxHide fxShow.gt-sm>
+            This content to be shown ONLY when gt-sm
+          </div>
+       `);
+      expectNativeEl(fixture).toHaveCssStyle({'display': 'none'});
+
+      activateMediaQuery('md', true);
+      expectNativeEl(fixture).toHaveCssStyle({'display': 'block'});
+
+      activateMediaQuery('xs', true);
+      expectNativeEl(fixture).toHaveCssStyle({'display': 'none'});
+    });
+  });
+
 });
 
 

--- a/src/lib/flexbox/responsive/responsive-activation.ts
+++ b/src/lib/flexbox/responsive/responsive-activation.ts
@@ -7,6 +7,7 @@
  */
 import {Subscription} from 'rxjs/Subscription';
 import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/filter';
 import {extendObject} from '../../utils/object-extend';
 
 import {MediaChange, MediaQuerySubscriber} from '../../media-query/media-change';
@@ -23,7 +24,7 @@ export interface BreakPointX extends BreakPoint {
 export class KeyOptions {
   constructor(public baseKey: string,
               public defaultValue: string|number|boolean,
-              public inputKeys: {[key: string]: any}) {
+              public inputKeys: { [key: string]: any }) {
   }
 }
 
@@ -78,7 +79,7 @@ export class ResponsiveActivation {
    */
   get activatedInput(): any {
     let key = this.activatedInputKey;
-    return this._hasKeyValue(key) ? this._lookupKeyValue(key) : this._options.defaultValue;
+    return this.hasKeyValue(key) ? this._lookupKeyValue(key) : this._options.defaultValue;
   }
 
   /**
@@ -211,8 +212,4 @@ export class ResponsiveActivation {
     return this._options.inputKeys[key];
   }
 
-  private _hasKeyValue(key) {
-    let value = this._options.inputKeys[key];
-    return typeof value !== 'undefined';
-  }
 }

--- a/src/lib/media-query/mock/mock-match-media.ts
+++ b/src/lib/media-query/mock/mock-match-media.ts
@@ -217,7 +217,9 @@ export class MockMediaQueryList implements MediaQueryList {
     if (this._listeners.indexOf(listener) === -1) {
       this._listeners.push(listener);
     }
-    if (this._isActive) { listener(this); }
+    if (this._isActive) {
+      listener(this);
+    }
   }
 
   removeListener(listener: MediaQueryListListener) {

--- a/src/lib/utils/testing/custom-matchers.ts
+++ b/src/lib/utils/testing/custom-matchers.ts
@@ -148,7 +148,7 @@ export const customMatchers: jasmine.CustomMatcherFactories = {
  * (Safari, IE, etc) will use prefixed style instead of defaults.
  */
 function hasPrefixedStyles(actual, key, value) {
-  let hasStyle = getDOM().hasStyle(actual, key, value);
+  let hasStyle = getDOM().hasStyle(actual, key, value.trim());
   if (!hasStyle) {
     let prefixedStyles = applyCssPrefixes({[key]: value});
     Object.keys(prefixedStyles).forEach(prop => {


### PR DESCRIPTION
*  fxShow and fxHide should restore original display modes when deactivating
*  combination uses of fxHide + fxShow should work properly
*  static uses of `fxHide=""` should hide the hosting elmement

fixes #140, fixes #141.