### PR TITLE
fix(breakpoints): resolve 1px hole between lg -> xl breakpoints

### DIFF
--- a/src/lib/media-query/breakpoints/break-points.ts
+++ b/src/lib/media-query/breakpoints/break-points.ts
@@ -65,7 +65,7 @@ export const RAW_DEFAULTS: BreakPoint[ ] = [
     alias: 'xl',
     suffix: 'Xl',
     overlapping: false,
-    mediaQuery: 'screen and (min-width: 1921px)'  // should be distinct from 'gt-lg' range
+    mediaQuery: 'screen and (min-width: 1920px) and (max-width: 5000px)'
   }
 ];
 


### PR DESCRIPTION
* alias `xl` now has mediaQuery == `screen and (min-width: 1920px) and (max-width: 5000px)`

fixes #149.