### PR TITLE
fix(api): remove use of static ngModule.forRoot()

### DIFF
--- a/src/demo-app/app/demo-app-module.ts
+++ b/src/demo-app/app/demo-app-module.ts
@@ -16,7 +16,7 @@ import { DemosResponsiveLayoutsModule } from './docs-layout-responsive/DemosResp
   imports         : [
     BrowserModule,
     MaterialModule.forRoot(),
-    FlexLayoutModule.forRoot(),
+    FlexLayoutModule,
     DemoAppRoutingModule,
 
     /* Internal Demo App Modules */

--- a/src/demo-app/app/docs-layout-responsive/DemosResponsiveLayouts.ts
+++ b/src/demo-app/app/docs-layout-responsive/DemosResponsiveLayouts.ts
@@ -40,7 +40,7 @@ import {DemoResponsiveFlexOrder} from "./responsiveFlexOrder.demo";
     CommonModule,
     FormsModule,
     MaterialModule,
-    FlexLayoutModule.forRoot()
+    FlexLayoutModule
   ]
 
 })

--- a/src/lib/flexbox/_module.ts
+++ b/src/lib/flexbox/_module.ts
@@ -8,9 +8,11 @@
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/map';
 
-import {ModuleWithProviders, NgModule} from '@angular/core';
+import {NgModule} from '@angular/core';
+
 import {MediaMonitor} from '../media-query/media-monitor';
 import {MediaQueriesModule} from '../media-query/_module';
+
 import {FlexDirective} from './api/flex';
 import {LayoutDirective} from './api/layout';
 import {HideDirective} from './api/hide';
@@ -52,10 +54,6 @@ const ALL_DIRECTIVES = [
   declarations: ALL_DIRECTIVES,
   imports: [MediaQueriesModule],
   exports: [MediaQueriesModule, ...ALL_DIRECTIVES],
-  providers: []
+  providers: [ MediaMonitor ]
 })
-export class FlexLayoutModule {
-  static forRoot(): ModuleWithProviders {
-    return {ngModule: FlexLayoutModule, providers: [MediaMonitor]};
-  }
-}
+export class FlexLayoutModule { }

--- a/src/lib/flexbox/api/flex.spec.ts
+++ b/src/lib/flexbox/api/flex.spec.ts
@@ -37,7 +37,7 @@ describe('flex directive', () => {
 
     // Configure testbed to prepare services
     TestBed.configureTestingModule({
-      imports: [CommonModule, FlexLayoutModule.forRoot()],
+      imports: [CommonModule, FlexLayoutModule],
       declarations: [TestFlexComponent],
       providers: [
         BreakPointRegistry, BreakPointsProvider,

--- a/src/lib/flexbox/api/hide.spec.ts
+++ b/src/lib/flexbox/api/hide.spec.ts
@@ -51,7 +51,7 @@ describe('hide directive', () => {
 
     // Configure testbed to prepare services
     TestBed.configureTestingModule({
-      imports: [CommonModule, MediaQueriesModule.forRoot()],
+      imports: [CommonModule, MediaQueriesModule],
       declarations: [TestHideComponent, HideDirective],
       providers: [
         BreakPointRegistry, BreakPointsProvider,

--- a/src/lib/flexbox/api/layout-align.spec.ts
+++ b/src/lib/flexbox/api/layout-align.spec.ts
@@ -34,7 +34,7 @@ describe('layout-align directive', () => {
 
     // Configure testbed to prepare services
     TestBed.configureTestingModule({
-      imports: [CommonModule, FlexLayoutModule.forRoot()],
+      imports: [CommonModule, FlexLayoutModule],
       declarations: [TestLayoutAlignComponent],
       providers: [
         BreakPointRegistry, BreakPointsProvider,

--- a/src/lib/flexbox/api/layout-gap.spec.ts
+++ b/src/lib/flexbox/api/layout-gap.spec.ts
@@ -32,7 +32,7 @@ describe('layout-gap directive', () => {
 
     // Configure testbed to prepare services
     TestBed.configureTestingModule({
-      imports: [CommonModule, FlexLayoutModule.forRoot()],
+      imports: [CommonModule, FlexLayoutModule],
       declarations: [TestLayoutGapComponent],
       providers: [
         BreakPointRegistry, BreakPointsProvider,

--- a/src/lib/flexbox/api/layout.spec.ts
+++ b/src/lib/flexbox/api/layout.spec.ts
@@ -38,7 +38,7 @@ describe('layout directive', () => {
 
     // Configure testbed to prepare services
     TestBed.configureTestingModule({
-      imports: [CommonModule, FlexLayoutModule.forRoot()],
+      imports: [CommonModule, FlexLayoutModule],
       declarations: [TestLayoutComponent],
       providers: [
         BreakPointRegistry, BreakPointsProvider,

--- a/src/lib/flexbox/api/show.spec.ts
+++ b/src/lib/flexbox/api/show.spec.ts
@@ -32,7 +32,7 @@ describe('show directive', () => {
 
     // Configure testbed to prepare services
     TestBed.configureTestingModule({
-      imports: [CommonModule, FlexLayoutModule.forRoot()],
+      imports: [CommonModule, FlexLayoutModule],
       declarations: [TestShowComponent],
       providers: [
         BreakPointRegistry, BreakPointsProvider,

--- a/src/lib/media-query/_module.ts
+++ b/src/lib/media-query/_module.ts
@@ -5,15 +5,13 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 
 import {MatchMedia} from './match-media';
 import {MediaMonitor} from './media-monitor';
 import {ObservableMediaProvider} from './observable-media-service';
 import {BreakPointsProvider} from './breakpoints/break-points';
 import {BreakPointRegistry} from './breakpoints/break-point-registry';
-
-
 
 /**
  * *****************************************************************
@@ -24,18 +22,13 @@ import {BreakPointRegistry} from './breakpoints/break-point-registry';
 @NgModule({
   providers: [
     MatchMedia,              // Low-level service to publish observables w/ window.matchMedia()
-    MediaMonitor,            // MediaQuery monitor service observes all known breakpoints
-    BreakPointRegistry,      // Registry of known/used BreakPoint(s)
     BreakPointsProvider,     // Supports developer overrides of list of known breakpoints
+    BreakPointRegistry,      // Registry of known/used BreakPoint(s)
+    MediaMonitor,            // MediaQuery monitor service observes all known breakpoints
     ObservableMediaProvider  // easy subscription injectable `media$` matchMedia observable
   ]
 })
 export class MediaQueriesModule {
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: MediaQueriesModule
-    };
-  }
 }
 
 


### PR DESCRIPTION
BREAKING CHANGE:

Previously releases used FlexLayoutModule.forRoot(). This has been deprecated and removed.

-*before*-

```js
@NgModule({
  declarations : [...],
  imports : [
    CommonModule,
    FlexLayoutModule.forRoot()
  ]
})
export class DemosResponsiveLayoutsModule { }
```

-*after*-

```js
@NgModule({
  declarations : [...],
  imports : [ CommonModule, FlexLayoutModule ]
})
export class DemosResponsiveLayoutsModule { }
```