### PR TITLE
fix(FlexLayoutModule): remove console.warn() calls that conflict with ngc+aot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 ### BREAKING CHANGES
 
 * ObservableMedia: Deprecated use of `ObservableMediaService` opaque token. Developers now simply use the ObservableMedia class to inject the service.
-* FlexLayoutModule: Previously releases used FlexLayoutModule.forRoot(). This has been deprecated; and a console warning will be issued if used.
+* FlexLayoutModule: Previously releases used FlexLayoutModule.forRoot(); This has been deprecated.
 
 *before*
 

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "node": ">= 5.4.1 < 7"
   },
   "dependencies": {
-    "@angular/common": "^2.2.3",
-    "@angular/compiler": "^2.2.3",
-    "@angular/core": "^2.2.3",
-    "@angular/platform-browser": "^2.2.3",
-    "@angular/platform-browser-dynamic": "^2.2.3",
+    "@angular/common": "^2.3.1",
+    "@angular/compiler": "^2.3.1",
+    "@angular/core": "^2.3.1",
+    "@angular/platform-browser": "^2.3.1",
+    "@angular/platform-browser-dynamic": "^2.3.1",
     "@types/gulp-util": "^3.0.30",
     "core-js": "^2.4.1",
     "reflect-metadata": "^0.1.8",
@@ -49,11 +49,11 @@
     "zone.js": "^0.7.2"
   },
   "devDependencies": {
-    "@angular/compiler-cli": "^2.2.3",
-    "@angular/forms": "^2.2.3",
-    "@angular/http": "^2.2.3",
+    "@angular/compiler-cli": "^2.3.1",
+    "@angular/forms": "^2.3.1",
+    "@angular/http": "^2.3.1",
     "@angular/material": "2.0.0-beta.0",
-    "@angular/platform-server": "^2.2.3",
+    "@angular/platform-server": "^2.3.1",
     "@angular/router": "~3.1.1",
     "@angular/tsc-wrapped": "~0.4.0",
     "@angularclass/conventions-loader": "^1.0.2",

--- a/src/demo-app/app/docs-layout/DemosLayoutAPI.ts
+++ b/src/demo-app/app/docs-layout/DemosLayoutAPI.ts
@@ -1,8 +1,8 @@
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
-    selector: 'demos-docs-layout',
-    template: `
+  selector: 'demos-docs-layout',
+  template: `
       <demo-layout-alignment      class="small-demo">  </demo-layout-alignment>          
       <demo-layout-fill           class="small-demo">  </demo-layout-fill>
       <demo-flex-row-fill         class="small-demo">  </demo-flex-row-fill>
@@ -12,14 +12,14 @@ import { Component } from '@angular/core';
       <demo-flex-offset-values    class="small-demo">  </demo-flex-offset-values>
     `
 })
-export class DemosLayoutAPI { }
+export class DemosLayoutAPI {
+}
 
 import {NgModule}            from '@angular/core';
 import {CommonModule}        from "@angular/common";
 import {FormsModule}         from "@angular/forms";
 import {MaterialModule}      from "@angular/material";
 import {FlexLayoutModule}    from "../../../lib";     // `gulp build:components` to deploy to node_modules manually
-
 
 import {DemoLayoutAlignment} from "./layoutAlignment.demo";
 import {DemoFlexRowFill}     from "./flexRowFill.demo";
@@ -29,9 +29,8 @@ import {DemoFlexOffsetValues}    from "./flexOffetValues.demo";
 import {DemoLayoutFill}      from "./layoutFill.demo";
 import {DemoFlexAlignSelf}   from "./FlexAlignSelf.demo";
 
-
 @NgModule({
-  declarations : [
+  declarations: [
     DemosLayoutAPI,       // used by the Router with the root app component
 
     DemoFlexRowFill,
@@ -42,12 +41,12 @@ import {DemoFlexAlignSelf}   from "./FlexAlignSelf.demo";
     DemoLayoutFill,
     DemoFlexAlignSelf
   ],
-  imports : [
+  imports: [
     CommonModule,
     FormsModule,
     MaterialModule,
     FlexLayoutModule
   ]
-
 })
-export class DemosLayoutAPIModule { }
+export class DemosLayoutAPIModule {
+}

--- a/src/lib/flexbox/_module.ts
+++ b/src/lib/flexbox/_module.ts
@@ -57,12 +57,11 @@ const ALL_DIRECTIVES = [
   declarations: ALL_DIRECTIVES,
   imports: [MediaQueriesModule],
   exports: [MediaQueriesModule, ...ALL_DIRECTIVES],
-  providers: [ MediaMonitor ]
+  providers: [MediaMonitor]
 })
 export class FlexLayoutModule {
   /** @deprecated */
   static forRoot(): ModuleWithProviders {
-    console.warn('FlexLayoutModule.forRoot() has been deprecated and is no longer needed.');
     return {
       ngModule: FlexLayoutModule
     };

--- a/tools/scripts/release/npm_assets/README.md
+++ b/tools/scripts/release/npm_assets/README.md
@@ -5,7 +5,7 @@
 [![Gitter](https://badges.gitter.im/angular/flex-layout.svg)](https://gitter.im/angular/flex-layout))
 
 Angular Flex Layout provides a sophisticated layout API using FlexBox CSS + mediaQuery. 
-This module provides Angular (v2.x and higher) developers with component layout features using a 
+This module provides Angular (v2.3.1 and higher) developers with component layout features using a 
 custom Layout API, mediaQuery observables,and injected DOM flexbox-2016 css stylings.  
 
 The Layout engine intelligently automates the process of applying appropriate FlexBox CSS to 
@@ -26,10 +26,10 @@ While other Flexbox CSS libraries are implementations of:
 Angular Flex Layout - in contrast - is a pure-Typescript UI Layout engine with an implementation that: 
 
 *  uses HTML attributes (aka Layout API) to specify the layout configurations
-*  is currently only available for Angular (v2.x or higher) Applications.
+*  is currently only available for Angular (v2.4.3 or higher) Applications.
 *  is independent of Angular Material (v1 or v2).
 *  requires no external stylesheets.
-*  requires Angular v2.x or higher.
+*  requires Angular v2.4.3 or higher.
 
 <br/>
 


### PR DESCRIPTION
* 'forRoot()' fn is never evaluated in AoT, ngc only analyzes the content of the fn to get the module and ngc does not know what to do with the first statetement (console.warn)
* clarify changes to FlexLayoutModule.forRoot()

Refs http://github.com/angular/angular#14410
Fixes #174, Fixes #175, Fixes #176, Fixes #178.