### PR TITLE
chore(demo): remove unnecessary attributes

### DIFF
--- a/src/demo-app/app/demo-app/demo-app.ts
+++ b/src/demo-app/app/demo-app/demo-app.ts
@@ -22,7 +22,7 @@ import {Component, ViewEncapsulation} from '@angular/core';
         </div>
     </md-toolbar>
     
-    <div #root="$implicit" dir="ltr" class="demo-content">
+    <div class="demo-content">
       <router-outlet></router-outlet>
     </div>
   `,


### PR DESCRIPTION
it is a very confusing mention of a directive that is not actually used in this demo.
Additionally, looks like setting this on router root is a practice likely to change (see https://github.com/angular/material2/issues/1719)