### PR TITLE
fix(closure-compiler): use Number to cast

### DIFF
--- a/src/lib/utils/auto-prefixer.ts
+++ b/src/lib/utils/auto-prefixer.ts
@@ -143,6 +143,6 @@ export function toBoxDirection(flexDirection = 'row') {
 
 /** Convert flex order to Box ordinal group */
 export function toBoxOrdinal(order = '0') {
-  let value = order ? parseInt(order) + 1 : 1;
+  let value = order ? Number(order) + 1 : 1;
   return isNaN(value) ? "0" : value.toString();
 }


### PR DESCRIPTION
parseInt requires two arguments within Google (the second is the radix)
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt:
"Always specify this parameter"

Casting with Number('1') is better.