### PR TITLE
fix(flexbox): Add default display property to `getDisplayStyle()`

### DIFF
--- a/src/lib/flexbox/api/base.ts
+++ b/src/lib/flexbox/api/base.ts
@@ -118,7 +118,7 @@ export abstract class BaseFxDirective implements OnDestroy, OnChanges {
   protected _getDisplayStyle(source?: HTMLElement): string {
     let element: HTMLElement = source || this._elementRef.nativeElement;
     let value = (element.style as any)['display'] || getComputedStyle(element)['display'];
-    return value.trim();
+    return value ? value.trim() : 'block';
   }
 
   protected _getFlowDirection(target: any, addIfMissing = false): string {


### PR DESCRIPTION
 - Prevents a possible TypeError being thrown at `value.trim()` if display is undefined.
 - Defaults to `block`, the default display property for css container elements.

Closes #300 