### PR TITLE
Fix demo page to display fxFlex in place of "flex"

### DIFF
--- a/src/demo-app/app/docs-layout/flexOffetValues.demo.ts
+++ b/src/demo-app/app/docs-layout/flexOffetValues.demo.ts
@@ -12,8 +12,8 @@ import {Component} from '@angular/core';
       <md-card-content>
         <div class="containerX">
           <div fxLayout="row" class="colored box nopad" >
-              <div fxFlex="66" fxFlexOffset="15">  [flex="66"] [flex-offset="15"]  </div>
-              <div fxFlex>                           [flex]                          </div>
+              <div fxFlex="66" fxFlexOffset="15">  [fxFlex="66"] [fxFlexOffset="15"]  </div>
+              <div fxFlex>                           [fxFlex]                          </div>
           </div>          
         </div>
       </md-card-content>

--- a/src/demo-app/app/docs-layout/flexOtherValues.demo.ts
+++ b/src/demo-app/app/docs-layout/flexOtherValues.demo.ts
@@ -12,14 +12,14 @@ import {Component} from '@angular/core';
       <md-card-content>
         <div class="containerX">
           <div fxLayout="row wrap" class="colored box nopad" >
-            <div fxFlex="none">     [flex="none"]       </div>
-            <div fxFlex>            [flex]              </div>
-            <div fxFlex="nogrow">   [flex="nogrow"]     </div>
-            <div fxFlex="grow">     [flex="grow"]       </div>
-            <div fxFlex="initial">  [flex="initial"]    </div>
-            <div fxFlex="auto">     [flex="auto"]       </div>
-            <div fxFlex="noshrink"> [flex="noshrink"]   </div>
-            <div fxFlex="0">        [flex="0"]          </div>
+            <div fxFlex="none">     [fxFlex="none"]       </div>
+            <div fxFlex>            [fxFlex]              </div>
+            <div fxFlex="nogrow">   [fxFlex="nogrow"]     </div>
+            <div fxFlex="grow">     [fxFlex="grow"]       </div>
+            <div fxFlex="initial">  [fxFlex="initial"]    </div>
+            <div fxFlex="auto">     [fxFlex="auto"]       </div>
+            <div fxFlex="noshrink"> [fxFlex="noshrink"]   </div>
+            <div fxFlex="0">        [fxFlex="0"]          </div>
           </div>          
         </div>
       </md-card-content>


### PR DESCRIPTION
I spotted a few inconsistencies between the html and the text being displayed.