### PR TITLE
fix(ObservableMedia): startup should propagate lastReplay value properly

### DIFF
--- a/src/demo-app/app/shared/media-query-status.ts
+++ b/src/demo-app/app/shared/media-query-status.ts
@@ -31,7 +31,9 @@ export class MediaQueryStatus implements OnDestroy {
   private _watcher : Subscription;
   activeMediaQuery : string;
 
-  constructor(media$ : ObservableMedia) { this.watchMediaQueries(media$); }
+  constructor(media$ : ObservableMedia) {
+    this.watchMediaQueries(media$);
+  }
 
   ngOnDestroy() {
     this._watcher.unsubscribe();

--- a/src/lib/media-query/breakpoints/break-point-registry.ts
+++ b/src/lib/media-query/breakpoints/break-point-registry.ts
@@ -30,6 +30,20 @@ export class BreakPointRegistry {
   }
 
   /**
+   * Accessor to sorted list used for registration with matchMedia API
+   *
+   * NOTE: During breakpoint registration, we want to register the overlaps FIRST
+   *       so the non-overlaps will trigger the MatchMedia:BehaviorSubject last!
+   *       And the largest, non-overlap, matching breakpoint should be the lastReplay value
+   */
+  get sortedItems(): BreakPoint[] {
+    let overlaps = this._registry.filter(it => it.overlapping === true);
+    let nonOverlaps = this._registry.filter(it => it.overlapping !== true);
+
+    return [...overlaps, ...nonOverlaps];
+  }
+
+  /**
    * Search breakpoints by alias (e.g. gt-xs)
    */
   findByAlias(alias: string): BreakPoint {

--- a/src/lib/media-query/match-media.spec.ts
+++ b/src/lib/media-query/match-media.spec.ts
@@ -86,13 +86,12 @@ describe('match-media', () => {
   });
 
 
-  it('can observe only a specific custom mediaQuery ranges', () => {
+  it('can observe an array of custom mediaQuery ranges', () => {
     let current: MediaChange, activated;
     let query1 = "screen and (min-width: 610px) and (max-width: 620px)";
     let query2 = "(min-width: 730px) and (max-width: 950px)";
 
-    matchMedia.registerQuery(query1);
-    matchMedia.registerQuery(query2);
+    matchMedia.registerQuery([query1, query2]);
 
     let subscription = matchMedia.observe(query1).subscribe((change: MediaChange) => {
       current = change;

--- a/src/lib/media-query/media-monitor.ts
+++ b/src/lib/media-query/media-monitor.ts
@@ -92,8 +92,7 @@ export class MediaMonitor {
    * and prepare for immediate subscription notifications
    */
   private _registerBreakpoints() {
-    this._breakpoints.items.forEach(bp => {
-      this._matchMedia.registerQuery(bp.mediaQuery);
-    });
+    let queries = this._breakpoints.sortedItems.map(bp => bp.mediaQuery);
+    this._matchMedia.registerQuery(queries);
   }
 }

--- a/src/lib/media-query/observable-media-provider.ts
+++ b/src/lib/media-query/observable-media-provider.ts
@@ -24,7 +24,7 @@ import {ObservableMedia, MediaService} from './observable-media';
 export function OBSERVABLE_MEDIA_PROVIDER_FACTORY(parentService: ObservableMedia,
                                                   matchMedia: MatchMedia,
                                                   breakpoints: BreakPointRegistry) {
-  return parentService || new MediaService(matchMedia, breakpoints);
+  return parentService || new MediaService(breakpoints, matchMedia);
 }
 /**
  *  Provider to return global service for observable service for all MediaQuery activations


### PR DESCRIPTION
ObservableMedia only dispatches notifications for activated, non-overlapping breakpoints.
If the MatchMedia lastReplay value is an *overlapping* breakpoint
(e.g. `lt-md`, `gt-lg`) then that value will be filtered by ObservableMedia
and not be emitted to subscribers.

* MatchMedia breakpoints registration was not correct
  *  overlapping breakpoints were registered in the wrong order
  * non-overlapping breakpoints should be registered last; so the BehaviorSubject's last replay value should be an non-overlapping breakpoint range.
* Optimize stylesheet injection to group `n` mediaQuerys in a single stylesheet
   > ![screen shot 2017-06-12 at 1 44 43 pm](https://user-images.githubusercontent.com/210413/27049606-70137f72-4f75-11e7-9ad7-c8d4bbcd5533.png)


Fixes #245, #275, #303.

> See working plunker:  https://plnkr.co/edit/yylQr2IdbGy2Yr00srrN?p=preview
