### PR TITLE
refactor(api): use Renderer2 instead of Renderer

### DIFF
--- a/src/demo-app/app/docs-layout-responsive/responsiveStyle.demo.ts
+++ b/src/demo-app/app/docs-layout-responsive/responsiveStyle.demo.ts
@@ -49,13 +49,14 @@ import {Component} from '@angular/core';
 
       <md-card-content>
         <div class="containerX">
-          <div fxLayout="row" fxFlex class="coloredContainerX box">
-            <div
-              fxFlex
+          <div fxLayout="row"
+               fxFlex
+               class="coloredContainerX box">
+            <div fxFlex
               style="font-style: italic"
-              [style.xs]="{'font-size.px': 10, color: 'blue'}"
-              [style.sm]="{'font-size.px': 20, color: 'lightblue'}"
-              [style.md]="{'font-size.px': 30, color: 'orange'}"
+              [style.xs]="{'font-size.px': 10, 'background-color': '#ddd', color: 'blue'}"
+              [style.sm]="{'font-size.px': 20, 'background-color': 'grey', color: '#482b00'}"
+              [style.md]="{'font-size.px': 30, 'background-color': 'black', color: 'orange'}"
               [style.lg]="styleLgExp">
                 Sample Text #2
             </div>

--- a/src/lib/flexbox/api/base-adapter.ts
+++ b/src/lib/flexbox/api/base-adapter.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ElementRef, Renderer} from '@angular/core';
+import {ElementRef, Renderer2} from '@angular/core';
 
 import {BaseFxDirective} from './base';
 import {ResponsiveActivation} from './../responsive/responsive-activation';
@@ -48,7 +48,7 @@ export class BaseFxDirectiveAdapter extends BaseFxDirective {
   constructor(protected _baseKey: string,   // non-responsive @Input property name
               protected _mediaMonitor: MediaMonitor,
               protected _elementRef: ElementRef,
-              protected _renderer: Renderer) {
+              protected _renderer: Renderer2) {
     super(_mediaMonitor, _elementRef, _renderer);
   }
 

--- a/src/lib/flexbox/api/base.ts
+++ b/src/lib/flexbox/api/base.ts
@@ -126,8 +126,8 @@ export abstract class BaseFxDirective implements OnDestroy, OnChanges {
     let element: HTMLElement = source || this._elementRef.nativeElement;
     let value = this._lookupStyle(element, 'display');
 
-    return value ? value.trim() :
-        ((element.nodeType === 1) ? 'block' : 'inline-block');
+    // Note: 'inline' is the default of all elements, unless UA stylesheet overrides
+    return value ? value.trim() : 'inline';
   }
 
   /**

--- a/src/lib/flexbox/api/base.ts
+++ b/src/lib/flexbox/api/base.ts
@@ -7,7 +7,7 @@
  */
 import {
   ElementRef, OnDestroy, SimpleChanges, OnChanges,
-  SimpleChange, Renderer
+  SimpleChange, Renderer2
 } from '@angular/core';
 import {ɵgetDOM as getDom} from '@angular/platform-browser';
 
@@ -65,7 +65,7 @@ export abstract class BaseFxDirective implements OnDestroy, OnChanges {
    */
   constructor(protected _mediaMonitor: MediaMonitor,
               protected _elementRef: ElementRef,
-              protected _renderer: Renderer) {
+              protected _renderer: Renderer2) {
     this._display = this._getDisplayStyle();
   }
 
@@ -175,7 +175,7 @@ export abstract class BaseFxDirective implements OnDestroy, OnChanges {
     Object.keys(styles).forEach(key => {
       const values = Array.isArray(styles[key]) ? styles[key] : [styles[key]];
       for (let value of values) {
-        this._renderer.setElementStyle(element, key, value);
+        this._renderer.setStyle(element, key, value);
       }
     });
   }

--- a/src/lib/flexbox/api/flex-align.ts
+++ b/src/lib/flexbox/api/flex-align.ts
@@ -12,7 +12,7 @@ import {
   OnInit,
   OnChanges,
   OnDestroy,
-  Renderer,
+  Renderer2,
   SimpleChanges,
 } from '@angular/core';
 
@@ -54,7 +54,7 @@ export class FlexAlignDirective extends BaseFxDirective implements OnInit, OnCha
   @Input('fxFlexAlign.gt-lg') set alignGtLg(val)  { this._cacheInput('alignGtLg', val); };
 
   /* tslint:enable */
-  constructor(monitor: MediaMonitor, elRef: ElementRef, renderer: Renderer) {
+  constructor(monitor: MediaMonitor, elRef: ElementRef, renderer: Renderer2) {
     super(monitor, elRef, renderer);
   }
 

--- a/src/lib/flexbox/api/flex-fill.ts
+++ b/src/lib/flexbox/api/flex-fill.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Directive, ElementRef, Renderer} from '@angular/core';
+import {Directive, ElementRef, Renderer2} from '@angular/core';
 
 import {MediaMonitor} from '../../media-query/media-monitor';
 import {BaseFxDirective} from './base';
@@ -29,7 +29,7 @@ const FLEX_FILL_CSS = {
   [fxFlexFill]
 `})
 export class FlexFillDirective extends BaseFxDirective {
-  constructor(monitor: MediaMonitor, public elRef: ElementRef, public renderer: Renderer) {
+  constructor(monitor: MediaMonitor, public elRef: ElementRef, public renderer: Renderer2) {
     super(monitor, elRef, renderer);
     this._applyStyleToElement(FLEX_FILL_CSS);
   }

--- a/src/lib/flexbox/api/flex-offset.ts
+++ b/src/lib/flexbox/api/flex-offset.ts
@@ -13,7 +13,7 @@ import {
   OnChanges,
   OnDestroy,
   Optional,
-  Renderer,
+  Renderer2,
   SimpleChanges,
   SkipSelf
 } from '@angular/core';
@@ -59,7 +59,7 @@ export class FlexOffsetDirective extends BaseFxDirective implements OnInit, OnCh
   /* tslint:enable */
   constructor(monitor: MediaMonitor,
               elRef: ElementRef,
-              renderer: Renderer,
+              renderer: Renderer2,
               @Optional() @SkipSelf() protected _container: LayoutDirective ) {
     super(monitor, elRef, renderer);
 

--- a/src/lib/flexbox/api/flex-order.ts
+++ b/src/lib/flexbox/api/flex-order.ts
@@ -12,7 +12,7 @@ import {
   OnInit,
   OnChanges,
   OnDestroy,
-  Renderer,
+  Renderer2,
   SimpleChanges,
 } from '@angular/core';
 
@@ -52,7 +52,7 @@ export class FlexOrderDirective extends BaseFxDirective implements OnInit, OnCha
   @Input('fxFlexOrder.lt-xl') set orderLtXl(val) { this._cacheInput('orderLtXl', val); };
 
   /* tslint:enable */
-  constructor(monitor: MediaMonitor, elRef: ElementRef, renderer: Renderer) {
+  constructor(monitor: MediaMonitor, elRef: ElementRef, renderer: Renderer2) {
     super(monitor, elRef, renderer);
   }
 

--- a/src/lib/flexbox/api/flex.ts
+++ b/src/lib/flexbox/api/flex.ts
@@ -13,7 +13,7 @@
   OnDestroy,
   OnInit,
   Optional,
-  Renderer,
+  Renderer2,
   SimpleChanges,
   SkipSelf,
 } from '@angular/core';
@@ -84,7 +84,7 @@ export class FlexDirective extends BaseFxDirective implements OnInit, OnChanges,
   //       for the parent flex container for this flex item.
   constructor(monitor: MediaMonitor,
               elRef: ElementRef,
-              renderer: Renderer,
+              renderer: Renderer2,
               @Optional() @SkipSelf() protected _container: LayoutDirective,
               @Optional() @SkipSelf() protected _wrap: LayoutWrapDirective) {
 

--- a/src/lib/flexbox/api/layout-align.ts
+++ b/src/lib/flexbox/api/layout-align.ts
@@ -13,7 +13,7 @@ import {
   OnDestroy,
   OnInit,
   Optional,
-  Renderer,
+  Renderer2,
   SimpleChanges, Self,
 } from '@angular/core';
 import {Subscription} from 'rxjs/Subscription';
@@ -67,7 +67,7 @@ export class LayoutAlignDirective extends BaseFxDirective implements OnInit, OnC
   /* tslint:enable */
   constructor(
       monitor: MediaMonitor,
-      elRef: ElementRef, renderer: Renderer,
+      elRef: ElementRef, renderer: Renderer2,
       @Optional() @Self() container: LayoutDirective) {
     super(monitor, elRef, renderer);
 

--- a/src/lib/flexbox/api/layout-gap.ts
+++ b/src/lib/flexbox/api/layout-gap.ts
@@ -10,7 +10,7 @@ import {
   ElementRef,
   Input,
   OnChanges,
-  Renderer,
+  Renderer2,
   SimpleChanges,
   Self,
   AfterContentInit,
@@ -65,7 +65,7 @@ export class LayoutGapDirective extends BaseFxDirective implements AfterContentI
   /* tslint:enable */
   constructor(monitor: MediaMonitor,
               elRef: ElementRef,
-              renderer: Renderer,
+              renderer: Renderer2,
               @Optional() @Self() container: LayoutDirective,
               private _zone: NgZone) {
     super(monitor, elRef, renderer);

--- a/src/lib/flexbox/api/layout-wrap.ts
+++ b/src/lib/flexbox/api/layout-wrap.ts
@@ -12,7 +12,7 @@ import {
   OnChanges,
   OnDestroy,
   OnInit,
-  Renderer,
+  Renderer2,
   SimpleChanges, Self, Optional,
 } from '@angular/core';
 import {Subscription} from 'rxjs/Subscription';
@@ -64,7 +64,7 @@ export class LayoutWrapDirective extends BaseFxDirective implements OnInit, OnCh
   constructor(
     monitor: MediaMonitor,
     elRef: ElementRef,
-    renderer: Renderer,
+    renderer: Renderer2,
     @Optional() @Self() container: LayoutDirective) {
 
     super(monitor, elRef, renderer);

--- a/src/lib/flexbox/api/layout.ts
+++ b/src/lib/flexbox/api/layout.ts
@@ -12,7 +12,7 @@ import {
   OnInit,
   OnChanges,
   OnDestroy,
-  Renderer,
+  Renderer2,
   SimpleChanges,
 } from '@angular/core';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
@@ -71,7 +71,7 @@ export class LayoutDirective extends BaseFxDirective implements OnInit, OnChange
   /**
    *
    */
-  constructor(monitor: MediaMonitor, elRef: ElementRef, renderer: Renderer) {
+  constructor(monitor: MediaMonitor, elRef: ElementRef, renderer: Renderer2) {
     super(monitor, elRef, renderer);
     this._announcer = new BehaviorSubject<string>('row');
     this.layout$ = this._announcer.asObservable();

--- a/src/lib/flexbox/api/show-hide.ts
+++ b/src/lib/flexbox/api/show-hide.ts
@@ -125,7 +125,7 @@ export class ShowHideDirective extends BaseFxDirective implements OnInit, OnChan
   /**
    * Override accessor to the current HTMLElement's `display` style
    * Note: Show/Hide will not change the display to 'flex' but will set it to 'block'
-   * unless it was already explicitly defined.
+   * unless it was already explicitly specified inline or in a CSS stylesheet.
    */
   protected _getDisplayStyle(): string {
     return this._layout ? 'flex' : super._getDisplayStyle();

--- a/src/lib/flexbox/api/show-hide.ts
+++ b/src/lib/flexbox/api/show-hide.ts
@@ -12,7 +12,7 @@ import {
   OnInit,
   OnChanges,
   OnDestroy,
-  Renderer,
+  Renderer2,
   SimpleChanges,
   Self,
   Optional
@@ -104,7 +104,7 @@ export class ShowHideDirective extends BaseFxDirective implements OnInit, OnChan
   constructor(monitor: MediaMonitor,
               @Optional() @Self() protected _layout: LayoutDirective,
               protected elRef: ElementRef,
-              protected renderer: Renderer) {
+              protected renderer: Renderer2) {
 
     super(monitor, elRef, renderer);
 


### PR DESCRIPTION
* Use Renderer2 instead of Renderer
* Do not extend the Angular base directives, but instead inject them into the constructor.
* improve support for future releases of Angular 5

Fixes #326.