### PR TITLE
fix(api): defer getComputedStyle() calls until ngOnInit phase

### DIFF
--- a/src/lib/flexbox/api/class.ts
+++ b/src/lib/flexbox/api/class.ts
@@ -139,11 +139,13 @@ export class ClassDirective extends BaseFxDirective
    * For @Input changes on the current mq activation property
    */
   ngOnChanges(changes: SimpleChanges) {
-    if (this._classAdapter.activeKey in changes) {
-      this._updateKlass();
-    }
-    if (this._ngClassAdapter.activeKey in changes) {
-      this._updateNgClass();
+    if (this.hasInitialized) {
+      if (this._classAdapter.activeKey in changes) {
+        this._updateKlass();
+      }
+      if (this._ngClassAdapter.activeKey in changes) {
+        this._updateNgClass();
+      }
     }
   }
 

--- a/src/lib/flexbox/api/flex-align.ts
+++ b/src/lib/flexbox/api/flex-align.ts
@@ -77,6 +77,8 @@ export class FlexAlignDirective extends BaseFxDirective implements OnInit, OnCha
    * mql change events to onMediaQueryChange handlers
    */
   ngOnInit() {
+    super.ngOnInit();
+
     this._listenForMediaQueryChanges('align', 'stretch', (changes: MediaChange) => {
       this._updateWithValue(changes.value);
     });

--- a/src/lib/flexbox/api/flex-offset.ts
+++ b/src/lib/flexbox/api/flex-offset.ts
@@ -95,6 +95,8 @@ export class FlexOffsetDirective extends BaseFxDirective implements OnInit, OnCh
    * mql change events to onMediaQueryChange handlers
    */
   ngOnInit() {
+    super.ngOnInit();
+
     this._listenForMediaQueryChanges('offset', 0 , (changes: MediaChange) => {
       this._updateWithValue(changes.value);
     });

--- a/src/lib/flexbox/api/flex-order.ts
+++ b/src/lib/flexbox/api/flex-order.ts
@@ -74,6 +74,8 @@ export class FlexOrderDirective extends BaseFxDirective implements OnInit, OnCha
    * mql change events to onMediaQueryChange handlers
    */
   ngOnInit() {
+    super.ngOnInit();
+
     this._listenForMediaQueryChanges('order', '0', (changes: MediaChange) => {
       this._updateWithValue(changes.value);
     });

--- a/src/lib/flexbox/api/flex.ts
+++ b/src/lib/flexbox/api/flex.ts
@@ -118,6 +118,8 @@ export class FlexDirective extends BaseFxDirective implements OnInit, OnChanges,
    * mql change events to onMediaQueryChange handlers
    */
   ngOnInit() {
+    super.ngOnInit();
+
     this._listenForMediaQueryChanges('flex', '', (changes: MediaChange) => {
       this._updateStyle(changes.value);
     });

--- a/src/lib/flexbox/api/layout-align.ts
+++ b/src/lib/flexbox/api/layout-align.ts
@@ -91,6 +91,8 @@ export class LayoutAlignDirective extends BaseFxDirective implements OnInit, OnC
    * mql change events to onMediaQueryChange handlers
    */
   ngOnInit() {
+    super.ngOnInit();
+
     this._listenForMediaQueryChanges('align', 'start stretch', (changes: MediaChange) => {
       this._updateWithValue(changes.value);
     });

--- a/src/lib/flexbox/api/layout-wrap.ts
+++ b/src/lib/flexbox/api/layout-wrap.ts
@@ -89,6 +89,8 @@ export class LayoutWrapDirective extends BaseFxDirective implements OnInit, OnCh
    * mql change events to onMediaQueryChange handlers
    */
   ngOnInit() {
+    super.ngOnInit();
+
     this._listenForMediaQueryChanges('wrap', 'wrap', (changes: MediaChange) => {
       this._updateWithValue(changes.value);
     });

--- a/src/lib/flexbox/api/layout.ts
+++ b/src/lib/flexbox/api/layout.ts
@@ -97,6 +97,8 @@ export class LayoutDirective extends BaseFxDirective implements OnInit, OnChange
    * mql change events to onMediaQueryChange handlers
    */
   ngOnInit() {
+    super.ngOnInit();
+
     this._listenForMediaQueryChanges('layout', 'row', (changes: MediaChange) => {
       this._updateWithDirection(changes.value);
     });

--- a/src/lib/flexbox/api/show-hide.ts
+++ b/src/lib/flexbox/api/show-hide.ts
@@ -108,7 +108,6 @@ export class ShowHideDirective extends BaseFxDirective implements OnInit, OnChan
 
     super(monitor, elRef, renderer);
 
-    this._display = this._getDisplayStyle();  // re-invoke override to use `this._layout`
     if (_layout) {
       /**
        * The Layout can set the display:flex (and incorrectly affect the Hide/Show directives.
@@ -138,7 +137,7 @@ export class ShowHideDirective extends BaseFxDirective implements OnInit, OnChan
    * Then conditionally override with the mq-activated Input's current value
    */
   ngOnChanges(changes: SimpleChanges) {
-    if (changes['show'] != null || this._mqActivation) {
+    if (this.hasInitialized && (changes['show'] != null || this._mqActivation)) {
       this._updateWithValue();
     }
   }
@@ -148,8 +147,9 @@ export class ShowHideDirective extends BaseFxDirective implements OnInit, OnChan
    * mql change events to onMediaQueryChange handlers
    */
   ngOnInit() {
-    let value = this._getDefaultVal('show', true);
+    super.ngOnInit();
 
+    let value = this._getDefaultVal('show', true);
     // Build _mqActivation controller
     this._listenForMediaQueryChanges('show', value, (changes: MediaChange) => {
       this._updateWithValue(changes.value);

--- a/src/lib/utils/style-utils.spec.ts
+++ b/src/lib/utils/style-utils.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Component} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {TestBed} from '@angular/core/testing';
+
+import {customMatchers} from './testing/custom-matchers';
+import {makeExpectDOMFrom} from './testing/helpers';
+
+describe('style-utils directive', () => {
+  let expectDOMFrom = makeExpectDOMFrom(() => TestLayoutComponent);
+
+  beforeEach(() => {
+    jasmine.addMatchers(customMatchers);
+
+    // Configure testbed to prepare services
+    TestBed.configureTestingModule({
+      imports: [CommonModule],
+      declarations: [TestLayoutComponent]
+    });
+  });
+
+  describe('testing display styles', () => {
+
+    it('should default to "display:block" for <div></div>', () => {
+      expectDOMFrom(`
+        <div></div>
+      `).toHaveStyle({'display': 'block'});
+    });
+
+    it('should find to "display" for inline style <div></div>', () => {
+      expectDOMFrom(`
+        <div style="display: flex;"></div>
+      `).toHaveStyle({'display': 'flex'});
+    });
+
+    it('should find `display` from html style element', () => {
+      expectDOMFrom(`
+        <style>
+          div.special { display: inline-block; }
+        </style>
+        <div class="special"></div>
+      `).toHaveStyle({'display': 'inline-block'});
+    });
+
+    it('should find `display` from component styles', () => {
+      let expectStyledDOM = makeExpectDOMFrom(() => TestLayoutComponent, [
+          'div.extra { display:table; }'
+      ]);
+      expectStyledDOM(`
+        <div class="extra"></div>
+      `).toHaveStyle({'display': 'table'});
+    });
+
+  });
+
+
+});
+
+
+// *****************************************************************
+// Template Component
+// *****************************************************************
+
+@Component({
+  selector: 'test-style-utils',
+  template: `<span>PlaceHolder Template HTML</span>`
+})
+export class TestLayoutComponent {
+}

--- a/src/lib/utils/style-utils.ts
+++ b/src/lib/utils/style-utils.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Renderer2} from '@angular/core';
+import {ɵgetDOM as getDom} from '@angular/platform-browser';
+import {applyCssPrefixes} from './auto-prefixer';
+
+/**
+ * Definition of a css style. Either a property name (e.g. "flex-basis") or an object
+ * map of property name and value (e.g. {display: 'none', flex-order: 5}).
+ */
+export type StyleDefinition = string | { [property: string]: string | number };
+
+
+/**
+ * Applies styles given via string pair or object map to the directive element.
+ */
+export function applyStyleToElement(renderer: Renderer2,
+                                    element: any,
+                                    style: StyleDefinition,
+                                    value?: string | number) {
+  let styles = {};
+  if (typeof style === 'string') {
+    styles[style] = value;
+    style = styles;
+  }
+
+  styles = applyCssPrefixes(style);
+  applyMultiValueStyleToElement(styles, element, renderer);
+}
+
+
+/**
+ * Applies styles given via string pair or object map to the directive's element.
+ */
+export function applyStyleToElements(renderer: Renderer2,
+                              style: StyleDefinition,
+                              elements: HTMLElement[ ]) {
+  let styles = applyCssPrefixes(style);
+
+  elements.forEach(el => {
+    applyMultiValueStyleToElement(styles, el, renderer);
+  });
+}
+
+/**
+ * Applies the styles to the element. The styles object map may contain an array of values.
+ * Each value will be added as element style.
+ */
+export function applyMultiValueStyleToElement(styles: {}, element: any, renderer: Renderer2) {
+  Object.keys(styles).forEach(key => {
+    const values = Array.isArray(styles[key]) ? styles[key] : [styles[key]];
+    for (let value of values) {
+      renderer.setStyle(element, key, value);
+    }
+  });
+}
+
+/**
+ * Find the DOM element's inline style value (if any)
+ */
+export function lookupInlineStyle(element: HTMLElement, styleName: string): string {
+  return getDom().getStyle(element, styleName);
+}
+
+/**
+ * Determine the inline or inherited CSS style
+ */
+export function lookupStyle(element: HTMLElement, styleName: string, inlineOnly = false): string {
+  let value = '';
+  if (element) {
+    try {
+      let immediateValue = value = lookupInlineStyle(element, styleName);
+      if ( !inlineOnly ) {
+        value = immediateValue || getDom().getComputedStyle(element).getPropertyValue(styleName);
+      }
+    } catch (e) {
+      // TODO: platform-server throws an exception for getComputedStyle
+    }
+  }
+
+  // Note: 'inline' is the default of all elements, unless UA stylesheet overrides;
+  //       in which case getComputedStyle() should determine a valid value.
+  return value ? value.trim() : 'block';
+}

--- a/src/lib/utils/testing/dom-tools.ts
+++ b/src/lib/utils/testing/dom-tools.ts
@@ -36,8 +36,15 @@ function getStyle(element: any, stylename: string): string {
   return element.style[stylename];
 }
 
-function hasStyle(element: any, styleName: string, styleValue: string = null): boolean {
-  const value = this.getStyle(element, styleName) || '';
+function hasStyle(element: any,
+                  styleName: string,
+                  styleValue: string = null,
+                  inlineOnly = true): boolean {
+  let value = getStyle(element, styleName) || '';
+  if ( !value && !inlineOnly ) {
+    // Search stylesheets
+    value = getComputedStyle(element).getPropertyValue(styleName) || '';
+  }
   return styleValue ? value == styleValue : value.length > 0;
 }
 
@@ -89,6 +96,7 @@ function isShadowRoot(node: any): boolean {
 function isPresent(obj: any): boolean {
   return obj != null;
 }
+
 function tagName(element: any): string {
   return element.tagName;
 }

--- a/src/lib/utils/testing/helpers.ts
+++ b/src/lib/utils/testing/helpers.ts
@@ -19,7 +19,7 @@ export type ComponentClazzFn = () => Type<any>;
  *  NOTE: These Generators (aka Partial Functions) are used only in
  *        the Karma/Jasmine testing.
  */
-export function makeExpectDOMFrom(getClass: ComponentClazzFn) {
+export function makeExpectDOMFrom(getClass: ComponentClazzFn, styles?: any) {
   let createTestComponent;
 
   // Return actual `expectTemplate()` function
@@ -28,7 +28,7 @@ export function makeExpectDOMFrom(getClass: ComponentClazzFn) {
       createTestComponent = makeCreateTestComponent(getClass);
     }
 
-    let fixture = createTestComponent(template);
+    let fixture = createTestComponent(template, styles);
     if (key) {
       let instance = fixture.componentInstance;
       instance[key] = value;

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -36,6 +36,7 @@ module.exports = (config) => {
       // Includes all package tests and source files into karma. Those files will be watched.
       // This pattern also matches all all sourcemap files and TypeScript files for debugging.
       {pattern: 'dist/packages/**/*', included: false, watched: true},
+
     ],
 
     customLaunchers: customLaunchers,


### PR DESCRIPTION
Previously, the Show/Hide directives would query the `display` style during directive instantiation.

For elements instantiated during `*ngFor`, constructor calls to getComputedStyle() will incorrectly return “” due to failures in queries for styles in CSS stylesheets or inline styles. Deferring these types of queries to the ngOnInit() lifecycle event, enables valid response to queries for both inline styles and stylesheets.

Fixes #310.