### PR TITLE
feat(img-srcset): add ImgSrcsetDirective for progressive images

### DIFF
--- a/src/lib/api/ext/img-srcset.spec.ts
+++ b/src/lib/api/ext/img-srcset.spec.ts
@@ -1,0 +1,353 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Component, OnInit} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
+
+import {DEFAULT_BREAKPOINTS_PROVIDER} from '../../media-query/breakpoints/break-points-provider';
+import {BreakPointRegistry} from '../../media-query/breakpoints/break-point-registry';
+import {MockMatchMedia} from '../../media-query/mock/mock-match-media';
+import {MatchMedia} from '../../media-query/match-media';
+import {FlexLayoutModule} from '../../module';
+
+import {customMatchers} from '../../utils/testing/custom-matchers';
+import {makeCreateTestComponent, queryFor} from '../../utils/testing/helpers';
+import {expect} from '../../utils/testing/custom-matchers';
+import {_dom as _} from '../../utils/testing/dom-tools';
+
+const SRCSET_URLS_MAP = {
+  'xs': [
+    'https://dummyimage.com/300x200/c7751e/fff.png',
+    'https://dummyimage.com/300x200/c7751e/000.png'
+  ],
+  'gt-xs': [
+    'https://dummyimage.com/400x250/c7c224/fff.png',
+    'https://dummyimage.com/400x250/c7c224/000.png'
+  ],
+  'md': [
+    'https://dummyimage.com/500x300/76c720/fff.png',
+    'https://dummyimage.com/500x300/76c720/000.png'
+  ],
+  'lt-lg': [
+    'https://dummyimage.com/600x350/25c794/fff.png',
+    'https://dummyimage.com/600x350/25c794/000.png'
+  ],
+  'lg': [
+    'https://dummyimage.com/700x400/258cc7/fff.png',
+    'https://dummyimage.com/700x400/258cc7/000.png'
+  ],
+  'lt-xl': [
+    'https://dummyimage.com/800x500/b925c7/ffffff.png',
+    'https://dummyimage.com/800x500/b925c7/000.png'
+  ]
+};
+const DEFAULT_SRC = 'https://dummyimage.com/300x300/c72538/ffffff.png';
+
+describe('img-srcset directive', () => {
+  let fixture: ComponentFixture<any>;
+  let matchMedia: MockMatchMedia;
+  let breakpoints: BreakPointRegistry;
+
+  let componentWithTemplate = (template: string) => {
+    fixture = makeCreateTestComponent(() => TestSrcsetComponent)(template);
+
+    inject([MatchMedia, BreakPointRegistry],
+        (_matchMedia: MockMatchMedia, _breakpoints: BreakPointRegistry) => {
+          matchMedia = _matchMedia;
+          breakpoints = _breakpoints;
+        })();
+  };
+
+  beforeEach(() => {
+    jasmine.addMatchers(customMatchers);
+
+    // Configure testbed to prepare services
+    TestBed.configureTestingModule({
+      imports: [CommonModule, FlexLayoutModule],
+      declarations: [TestSrcsetComponent],
+      providers: [
+        BreakPointRegistry, DEFAULT_BREAKPOINTS_PROVIDER,
+        {provide: MatchMedia, useClass: MockMatchMedia}
+      ]
+    });
+  });
+
+  it('should work without a <picture> wrapper element', () => {
+    const template = `
+      <img src="${DEFAULT_SRC}" srcset="${SRCSET_URLS_MAP['gt-xs'][0]}">
+    `;
+    componentWithTemplate(template);
+    fixture.detectChanges();
+
+    let sources = queryFor(fixture, 'source');
+    let pictures = queryFor(fixture, 'picture');
+
+    expect(sources.length).toBe(0);
+    expect(pictures.length).toBe(0);
+  });
+
+  it('should preserve the static img.srcset attribute', () => {
+    const template = `
+      <img srcset="https://dummyimage.com/300x300/c72538/ffffff.png">
+    `;
+    componentWithTemplate(template);
+    fixture.detectChanges();
+
+    const img = queryFor(fixture, 'img')[0].nativeElement;
+    expect(img).toHaveAttributes({
+      srcset: 'https://dummyimage.com/300x300/c72538/ffffff.png'
+    });
+
+  });
+
+  it('should preserve bindable img.srcset attribute', () => {
+    const template = `
+       <img src="${DEFAULT_SRC}" [srcset]="lgSrcSet">
+    `;
+    componentWithTemplate(template);
+    fixture.detectChanges();
+
+    let sources = queryFor(fixture, 'source');
+    let pictures = queryFor(fixture, 'picture');
+    let img = queryFor(fixture, 'img')[0].nativeElement;
+
+    expect(sources.length).toBe(0);
+    expect(pictures.length).toBe(0);
+    expect(img).toBeDefined();
+    expect(img).toHaveAttributes({
+      src: 'https://dummyimage.com/300x300/c72538/ffffff.png',
+      srcset: fixture.componentInstance.lgSrcSet
+    });
+  });
+
+  it('should work when no "srcset" directive is used', () => {
+    const template = `
+        <picture>
+          <img style="width:auto;" src="${DEFAULT_SRC}" >
+        </picture>
+    `;
+    componentWithTemplate(template);
+    fixture.detectChanges();
+
+    const nodes = queryFor(fixture, 'source');
+    const pictureElt = queryFor(fixture, 'picture')[0].nativeElement;
+
+    expect(nodes.length).toBe(0);
+    expect(pictureElt.children.length).toEqual(1);
+    expect(_.tagName(_.lastElementChild(pictureElt))).toEqual('IMG');
+  });
+
+  it('should keep img as the last child tag of <picture>', () => {
+    const template = `
+      <div>
+        <picture>
+          <img  style="width:auto;"
+                src="${DEFAULT_SRC}"
+                srcset.gt-xs="${SRCSET_URLS_MAP['gt-xs'][0]}"
+                srcset.lt-lg="${SRCSET_URLS_MAP['lt-lg'][0]}" >
+        </picture>
+      </div>
+    `;
+    componentWithTemplate(template);
+    fixture.detectChanges();
+
+    const pictureElt = queryFor(fixture, 'picture')[0].nativeElement;
+
+    expect(_.tagName(_.lastElementChild(pictureElt))).toEqual('IMG');
+  });
+
+  it('should inject source elements from largest to smallest corresponding media queries', () => {
+    const template = `
+      <picture>
+          <img  style="width:auto;"
+                src="${DEFAULT_SRC}"
+                srcset.xs="${SRCSET_URLS_MAP['xs'][0]}"
+                srcset.lg="${SRCSET_URLS_MAP['lg'][0]}"
+                srcset.md="${SRCSET_URLS_MAP['md'][0]}" >
+      </picture>
+    `;
+    componentWithTemplate(template);
+    fixture.detectChanges();
+
+    const nodes = queryFor(fixture, 'source');
+
+    expect(nodes.length).toBe(3);
+    expect(nodes[0].nativeElement).toHaveAttributes({
+      srcset: `${SRCSET_URLS_MAP['lg'][0]}`,
+      media: breakpoints.findByAlias('lg').mediaQuery
+    });
+    expect(nodes[1].nativeElement).toHaveAttributes({
+      srcset: `${SRCSET_URLS_MAP['md'][0]}`,
+      media: breakpoints.findByAlias('md').mediaQuery
+    });
+    expect(nodes[2].nativeElement).toHaveAttributes({
+      srcset: `${SRCSET_URLS_MAP['xs'][0]}`,
+      media: breakpoints.findByAlias('xs').mediaQuery
+    });
+  });
+
+  it('should update source elements srcset values when srcset input properties change', () => {
+    const template = `
+      <picture>
+          <img  style="width:auto;"
+                src="${DEFAULT_SRC}"
+                [srcset.xs]="xsSrcSet"
+                [srcset.lg]="lgSrcSet"
+                [srcset.md]="mdSrcSet" >
+      </picture>
+    `;
+    componentWithTemplate(template);
+    fixture.detectChanges();
+
+    fixture.componentInstance.xsSrcSet = SRCSET_URLS_MAP['xs'][1];
+    fixture.componentInstance.mdSrcSet = SRCSET_URLS_MAP['md'][1];
+    fixture.componentInstance.lgSrcSet = SRCSET_URLS_MAP['lg'][1];
+    fixture.detectChanges();
+
+    let nodes = queryFor(fixture, 'source');
+
+    expect(nodes.length).toBe(3);
+    expect(nodes[0].nativeElement).toHaveAttributes({
+      srcset: `${SRCSET_URLS_MAP['lg'][1]}`,
+      media: breakpoints.findByAlias('lg').mediaQuery
+    });
+    expect(nodes[1].nativeElement).toHaveAttributes({
+      srcset: `${SRCSET_URLS_MAP['md'][1]}`,
+      media: breakpoints.findByAlias('md').mediaQuery
+    });
+    expect(nodes[2].nativeElement).toHaveAttributes({
+      srcset: `${SRCSET_URLS_MAP['xs'][1]}`,
+      media: breakpoints.findByAlias('xs').mediaQuery
+    });
+  });
+
+  it('should work with overlapping breakpoints', () => {
+    const template = `
+      <picture>
+          <img  style="width:auto;"
+                src="${DEFAULT_SRC}"
+                srcset.lt-xl="${SRCSET_URLS_MAP['lt-xl'][0]}"
+                srcset.xs="${SRCSET_URLS_MAP['xs'][0]}"
+                srcset.lt-lg="${SRCSET_URLS_MAP['lt-lg'][0]}" >
+      </picture>
+    `;
+    componentWithTemplate(template);
+    fixture.detectChanges();
+
+    let nodes = queryFor(fixture, 'source');
+    expect(nodes[0].nativeElement).toHaveAttributes({
+      srcset: `${SRCSET_URLS_MAP['lt-xl'][0]}`,
+      media: breakpoints.findByAlias('lt-xl').mediaQuery
+    });
+    expect(nodes[1].nativeElement).toHaveAttributes({
+      srcset: `${SRCSET_URLS_MAP['lt-lg'][0]}`,
+      media: breakpoints.findByAlias('lt-lg').mediaQuery
+    });
+    expect(nodes[2].nativeElement).toHaveAttributes({
+      srcset: `${SRCSET_URLS_MAP['xs'][0]}`,
+      media: breakpoints.findByAlias('xs').mediaQuery
+    });
+  });
+
+  describe('with responsive api', () => {
+
+    it('should work with a isolated image element and responsive srcset(s)', () => {
+      componentWithTemplate(`
+        <img [srcset]="xsSrcSet"
+             [srcset.md]="mdSrcSet">
+      `);
+
+      let img = queryFor(fixture, 'img')[0].nativeElement;
+
+      matchMedia.activate('md');
+      fixture.detectChanges();
+      expect(img).toBeDefined();
+      expect(img).toHaveAttributes({
+        src: fixture.componentInstance.mdSrcSet
+      });
+
+      // When activating an unused breakpoint, fallback to default [srcset] value
+      matchMedia.activate('xl');
+      fixture.detectChanges();
+      expect(img).toHaveAttributes({
+        src: fixture.componentInstance.xsSrcSet
+      });
+    });
+
+    it('should work use [src] if default [srcset] is not defined', () => {
+      componentWithTemplate(`
+         <img src="${DEFAULT_SRC}"
+              [srcset.md]="mdSrcSet">
+       `);
+      fixture.detectChanges();
+      let img = queryFor(fixture, 'img')[0].nativeElement;
+
+      matchMedia.activate('md');
+      fixture.detectChanges();
+
+      expect(img).toBeDefined();
+      expect(img).toHaveAttributes({
+        src: fixture.componentInstance.mdSrcSet
+      });
+
+      // When activating an unused breakpoint, fallback to default [srcset] value
+      matchMedia.activate('xl');
+      fixture.detectChanges();
+      expect(img).toHaveAttributes({
+        src: DEFAULT_SRC
+      });
+    });
+
+    it('should work with lookup from `src` when the default `srcset` is not defined', () => {
+      componentWithTemplate(`
+        <picture>
+            <img  src="https://dummyimage.com/400x200/c7c224/000.png&text=default"
+                  srcset.md="https://dummyimage.com/500x200/76c720/fff.png&text=md">
+        </picture>
+      `);
+      matchMedia.activate('md');
+      fixture.detectChanges();
+
+      let sources = queryFor(fixture, 'source');
+      let defaultSourceEl = sources[sources.length - 1].nativeElement;
+      expect(defaultSourceEl).toHaveAttributes({
+        srcset: 'https://dummyimage.com/500x200/76c720/fff.png&text=md'
+      });
+
+      // When activating an unused breakpoint, fallback to default [srcset] value
+      matchMedia.activate('xs');
+      fixture.detectChanges();
+      expect(defaultSourceEl).toHaveAttributes({
+        srcset: 'https://dummyimage.com/400x200/c7c224/000.png&text=default'
+      });
+    });
+  });
+});
+
+// *****************************************************************
+// Template Component
+// *****************************************************************
+
+@Component({
+  selector: 'test-srcset-api',
+  template: ''
+})
+export class TestSrcsetComponent implements OnInit {
+  xsSrcSet: string;
+  mdSrcSet: string;
+  lgSrcSet: string;
+
+  constructor() {
+    this.xsSrcSet = SRCSET_URLS_MAP['xs'][0];
+    this.mdSrcSet = SRCSET_URLS_MAP['md'][0];
+    this.lgSrcSet = SRCSET_URLS_MAP['lg'][0];
+  }
+
+  ngOnInit() {
+  }
+}

--- a/src/lib/api/ext/img-srcset.ts
+++ b/src/lib/api/ext/img-srcset.ts
@@ -1,0 +1,256 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {
+  Directive,
+  ElementRef,
+  Input,
+  OnInit,
+  OnChanges,
+  OnDestroy,
+  Renderer2,
+} from '@angular/core';
+import {ɵgetDOM as getDom} from '@angular/platform-browser';
+
+import {BaseFxDirective} from '../core/base';
+import {MediaMonitor} from '../../media-query/media-monitor';
+import {BreakPointX} from '../core/responsive-activation';
+import {extendObject} from '../../utils/object-extend';
+
+const DEFAULT_SRCSET = 'srcset';
+
+/**
+ * This directive provides a responsive API for the HTML 'srcset' attribute; and
+ * supports two (2) uses:
+ *    1) standalone <img>, or
+ *    2) nested <picture><img></picture>.
+ *
+ * In both cases the expression/value assigned is simply the appropriate image url.
+ * e.g.
+ *      <img srcset="defaultScene.jpg" srcset.xs="mobileScene.jpg"></img>
+ *      <picture>
+ *        <img srcset="defaultScene.jpg" srcset.xs="mobileScene.jpg"></img>
+ *      </picture>
+ *
+ * For standalone (1) usages, this directive will update the img.src property with the responsive
+ * activated input value. For picture (2) usages, this directive will inject
+ * [into the parent <picture> element] <source> elements with media and srcset attributes.
+ * Note that <source> elements are sorted according to the related media query :
+ *      from largest to smallest
+ *
+ * > For browsers not supporting the <picture> element, the Picturefill polyfill is still needed.
+ *
+ * @see https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture
+ * @see https://www.html5rocks.com/en/tutorials/responsive/picture-element/
+ * @see https://caniuse.com/#search=picture
+ * @see http://scottjehl.github.io/picturefill/
+ */
+@Directive({
+  selector: `
+  img[srcset],
+  img[srcset.xs], img[srcset.sm], img[srcset.md], img[srcset.lg], img[srcset.xl],
+  img[srcset.lt-sm], img[srcset.lt-md], img[srcset.lt-lg], img[srcset.lt-xl],
+  img[srcset.gt-xs], img[srcset.gt-sm], img[srcset.gt-md], img[srcset.gt-lg]
+`
+})
+export class ImgSrcsetDirective extends BaseFxDirective implements OnInit, OnChanges, OnDestroy {
+
+  /* tslint:disable */
+  /**
+   * Intercept srcset assignment so we cache the default static value.
+   * When the responsive breakpoint deactivates,it is possible that fallback static
+   * value (which is used to clear the deactivated value) will be used
+   * (if no other breakpoints activate)
+   */
+  @Input('srcset')        set srcsetBase(val) { this._cacheInput('srcset', val);    }
+
+  @Input('srcset.xs')     set srcsetXs(val)   { this._cacheInput('srcsetXs', val);  }
+  @Input('srcset.sm')     set srcsetSm(val)   { this._cacheInput('srcsetSm', val);  }
+  @Input('srcset.md')     set srcsetMd(val)   { this._cacheInput('srcsetMd', val);  }
+  @Input('srcset.lg')     set srcsetLg(val)   { this._cacheInput('srcsetLg', val);  }
+  @Input('srcset.xl')     set srcsetXl(val)   { this._cacheInput('srcsetXl', val);  }
+
+  @Input('srcset.lt-sm')  set srcsetLtSm(val) { this._cacheInput('srcsetLtSm', val);  }
+  @Input('srcset.lt-md')  set srcsetLtMd(val) { this._cacheInput('srcsetLtMd', val);  }
+  @Input('srcset.lt-lg')  set srcsetLtLg(val) { this._cacheInput('srcsetLtLg', val);  }
+  @Input('srcset.lt-xl')  set srcsetLtXl(val) { this._cacheInput('srcsetLtXl', val);  }
+
+  @Input('srcset.gt-xs')  set srcsetGtXs(val) { this._cacheInput('srcsetGtXs', val);  }
+  @Input('srcset.gt-sm')  set srcsetGtSm(val) { this._cacheInput('srcsetGtSm', val);  }
+  @Input('srcset.gt-md')  set srcsetGtMd(val) { this._cacheInput('srcsetGtMd', val);  }
+  @Input('srcset.gt-lg')  set srcsetGtLg(val) { this._cacheInput('srcsetGtLg', val);  }
+  /* tslint:enable */
+
+  constructor(elRef: ElementRef, renderer: Renderer2, monitor: MediaMonitor) {
+    super(monitor, elRef, renderer);
+  }
+
+  /**
+   * Configure the Picture element with injected <source> elements or support responsive
+   * activation of the standalone- Img element.
+   */
+  ngOnInit() {
+    super.ngOnInit();
+
+    this._configureIsolatedImg();
+    this._configureDefaultSrcset();
+    this._injectSourceElements();
+
+    // Only responsively update srcset values for stand-alone image elements
+    // Fallback to [srcset] value for responsive deactivation
+    this._listenForMediaQueryChanges('src', '', () => {
+      this._updateSrcset();
+    });
+
+    this._updateSrcset();
+  }
+
+  /**
+   * Update the srcset of the relevant injected <source> elements with the new data-bound input
+   * properties. <source> elements are injected once through ngOnInit
+   */
+  ngOnChanges() {
+    if (this.hasInitialized) {
+      this._updateSrcset();
+    }
+  }
+
+  ngOnDestroy() {
+    super.ngOnDestroy();
+    // remove reference to dom elements to avoid memory leaks
+    this._injectedSourceElements = null;
+  }
+
+  /**
+   * Responsive activation is used ONLY for standalone images
+   *
+   * Image tags nested in Picture containers, however, ignore responsive activations
+   * as injected <sources> are used. Changes to srcset values for nested images
+   * directly update the injected source elements.
+   *
+   * For stand-alone img elements with responsive srcset attributes, the
+   * img.src property will be responsively updated.
+   */
+  protected _updateSrcset() {
+    const activatedKey = this._mqActivation ? this._mqActivation.activatedInputKey : 'src';
+    const findSource = () => {
+      return !this._mqActivation ? this.nativeElement : this._findInjectSourceBy(activatedKey);
+    };
+    const attrKey = !this.hasPictureParent ? 'src' : activatedKey;
+    const attrVal = this._mqActivation ? this._mqActivation.activatedInput : this._queryInput(attrKey); // tslint:disable-line:max-line-length
+    const target = !this.hasPictureParent ? this.nativeElement : findSource();
+
+    if (target) {
+      this._renderer.setAttribute(target, attrKey, attrVal);
+    }
+  }
+
+  /**
+   * Identify the correct source instance in order to update its `srcset`
+   * attribute with the new value
+   */
+  protected _findInjectSourceBy(activatedKey: string) {
+    return this._injectedSourceElements[activatedKey];
+  }
+
+  /**
+   * Inject source elements based on their related media queries from largest to smallest.
+   * Keep the <img> element as the last child of the <picture> element: this necessary as the
+   * browser process the children of <picture> and uses the first one with the acceptable media
+   * query. <img> is defaulted to when no <source> element matches (and providing in the same time
+   * backward compatibility)
+   */
+  protected _injectSourceElements() {
+    let isBrowser = getDom().supportsDOMEvents();
+    if (isBrowser && this.hasPictureParent) {
+
+      // If <picture><img></picture>, create a <source> elements inside the <picture> container;
+      // @see https://www.html5rocks.com/en/tutorials/responsive/picture-element/
+
+      this._breakpointsInUse().forEach((bpX: BreakPointX) => {
+        const sourceElt = this._renderer.createElement('source');
+        this._injectedSourceElements[bpX.key] = sourceElt;
+
+        this._renderer.setAttribute(sourceElt, 'media', bpX.mediaQuery);
+        this._renderer.setAttribute(sourceElt, DEFAULT_SRCSET, this._queryInput(bpX.key));
+        this._renderer.insertBefore(this.parentElement, sourceElt, this.nativeElement);
+      });
+    }
+  }
+
+  /**
+   * Get a list of breakpoints that will be used (defined via @Input assignments);
+   * sorted from largest media range to smallest.
+   */
+  protected _breakpointsInUse(): BreakPointX[] {
+    return this._mediaMonitor
+        .breakpoints
+        .map(bp => {
+          return <BreakPointX> extendObject({}, bp, {
+            key: 'srcset' + bp.suffix  // e.g.  layoutGtSm, layoutMd, layoutGtLg
+          });
+        })
+        .filter(bp => {
+          return this._queryInput(bp.key) !== undefined;
+        })
+        .reverse();
+  }
+
+  /**
+   *  If only the <img> is defined with srcsets then use that as the target entry
+   *  add responsively update the property srcset based on activated input value
+   */
+  protected _configureIsolatedImg() {
+    if (!this.hasPictureParent) {
+      this._configureDefaultSrcset();
+
+      // If databinding is used, then the attribute is removed and
+      // `ng-reflect-srcset-base` is used; so let's manually restore the attribute.
+
+      let target = this.nativeElement;
+      this._renderer.setAttribute(target, DEFAULT_SRCSET, this._queryInput(DEFAULT_SRCSET));
+      this._renderer.setProperty(target, DEFAULT_SRCSET, this._queryInput(DEFAULT_SRCSET));
+    }
+  }
+
+  /**
+   * If [srcset] is not defined AND responsive API is in use
+   * then set [srcset] from the [src] property
+   */
+  protected _configureDefaultSrcset() {
+    const numInputsUsed = Object.keys(this._inputMap).length;
+    const defaultSrcsetVal = this._queryInput(DEFAULT_SRCSET);
+
+    if (typeof defaultSrcsetVal == 'undefined' && numInputsUsed) {
+      this._cacheInput(DEFAULT_SRCSET, this.defaultSrc);
+    }
+  }
+
+  /**
+   * Does the image (with srcset usages) have a <picture> parent;
+   * which is used as container for <source> element ?
+   * @see https://www.html5rocks.com/en/tutorials/responsive/picture-element/
+   *
+   */
+  protected get hasPictureParent() {
+    return this.parentElement.nodeName == 'PICTURE';
+  }
+
+  /**
+   * Empty values are maintained; undefined values are exposed as ''
+   */
+  protected get defaultSrc(): string {
+    let attrVal = getDom().getAttribute(this.nativeElement, 'src');
+    return this._queryInput('src') || attrVal || '';
+  }
+
+
+  /** Reference to injected source elements to be used when there is a need to update their
+   * attributes. */
+  private _injectedSourceElements: { [input: string]: any } = {};
+}

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -24,4 +24,5 @@ export * from './ext/class';
 export * from './ext/style';
 export * from './ext/show-hide';
 export * from './ext/img-src';
+export * from './ext/img-srcset';
 

--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -32,6 +32,7 @@ import {ShowHideDirective} from './api/ext/show-hide';
 import {ClassDirective} from './api/ext/class';
 import {StyleDirective} from './api/ext/style';
 import {ImgSrcDirective} from './api/ext/img-src';
+import {ImgSrcsetDirective} from './api/ext/img-srcset';
 
 /**
  * Since the equivalent results are easily achieved with a css class attached to each
@@ -54,7 +55,8 @@ const ALL_DIRECTIVES = [
   ShowHideDirective,
   ClassDirective,
   StyleDirective,
-  ImgSrcDirective
+  ImgSrcDirective,
+  ImgSrcsetDirective
 ];
 
 /**


### PR DESCRIPTION
Support responsive image by introducing srcset.<breakpoint alias> directive. When used as `<img>` attributes where

*  where the `<img>` is a child of a `<picture>` container, this directive will injects a `<source>` element for every srcset.<breakpoint alias>.
```html
<picture>
   <img  [src]="defaultSrc"
         [srcset.md]="mdSrcset"
         [srcset.xs]="xsSrcset" >
</picture>
```

*  where the `<img>` is NOT nested in a `<picture>` element, then the `img.src` property will be responsively updated.
```html
<img  [src]="defaultSrc"
      [srcset.md]="mdSrcset"
      [srcset.xs]="xsSrcset" >
```


> Thanks to @benbraou for his initial PR submission (@see #366)

Closes #81.