### PR TITLE
fix(api, class): remove ‘[class]’ selector

### DIFF
--- a/src/lib/api/core/base-adapter.ts
+++ b/src/lib/api/core/base-adapter.ts
@@ -73,7 +73,9 @@ export class BaseFxDirectiveAdapter extends BaseFxDirective {
     } else if (typeof source === 'string') {
       this._cacheInputString(key, source);
     } else {
-      throw new Error('Invalid class value provided. Did you want to cache the raw value?');
+      throw new Error(
+        `Invalid class value '${key}' provided. Did you want to cache the raw value?`
+      );
     }
   }
 
@@ -123,5 +125,15 @@ export class BaseFxDirectiveAdapter extends BaseFxDirective {
    */
   protected _cacheInputString(key = '', source?: string) {
     this._inputMap[key] = source;
+  }
+
+  /**
+   * Does this directive have 1 or more responsive keys defined
+   * Note: we exclude the 'baseKey' key (which is NOT considered responsive)
+   */
+  public get usesResponsiveAPI() {
+    const totalKeys = Object.keys(this._inputMap).length;
+    const baseValue = this._inputMap[this._baseKey];
+    return  (totalKeys - (!!baseValue ? 1 : 0)) > 0;
   }
 }

--- a/src/lib/api/ext/class.spec.ts
+++ b/src/lib/api/ext/class.spec.ts
@@ -65,21 +65,44 @@ describe('class directive', () => {
   });
 
   it('should override base `class` values with responsive values', () => {
-      createTestComponent(`<div class="class0" class.xs="class1 class2" ngClass.xs="what"></div>`);
+      createTestComponent(`<div class="class0" ngClass.xs="what class2"></div>`);
 
       expectNativeEl(fixture).toHaveCssClass('class0');
-      expectNativeEl(fixture).not.toHaveCssClass('class1');
+      expectNativeEl(fixture).not.toHaveCssClass('what');
       expectNativeEl(fixture).not.toHaveCssClass('class2');
 
+      // the CSS classes listed in the string (space delimited) are added,
       matchMedia.activate('xs');
-      expectNativeEl(fixture).not.toHaveCssClass('class0');
-      expectNativeEl(fixture).toHaveCssClass('class1');
+      expectNativeEl(fixture).toHaveCssClass('class0');
+      expectNativeEl(fixture).toHaveCssClass('what');
       expectNativeEl(fixture).toHaveCssClass('class2');
 
-      // matchMedia.activate('lg');
-      //       expectNativeEl(fixture).toHaveCssClass('class0');
-      //       expectNativeEl(fixture).not.toHaveCssClass('class1');
-      //       expectNativeEl(fixture).not.toHaveCssClass('class2');
+      matchMedia.activate('lg');
+      expectNativeEl(fixture).toHaveCssClass('class0');
+      expectNativeEl(fixture).not.toHaveCssClass('what');
+      expectNativeEl(fixture).not.toHaveCssClass('class2');
+    });
+
+  it('should override base `class` values with responsive values', () => {
+      createTestComponent(`
+        <div class="class0" [ngClass.xs]="{'what':true, 'class2':true, 'class0':false}"></div>
+      `);
+
+      expectNativeEl(fixture).toHaveCssClass('class0');
+      expectNativeEl(fixture).not.toHaveCssClass('what');
+      expectNativeEl(fixture).not.toHaveCssClass('class2');
+
+      // Object keys are CSS classes that get added when the expression given in
+      // the value evaluates to a truthy value, otherwise they are removed.
+      matchMedia.activate('xs');
+      expectNativeEl(fixture).not.toHaveCssClass('class0');
+      expectNativeEl(fixture).toHaveCssClass('what');
+      expectNativeEl(fixture).toHaveCssClass('class2');
+
+      matchMedia.activate('lg');
+      expectNativeEl(fixture).toHaveCssClass('class0');
+      expectNativeEl(fixture).not.toHaveCssClass('what');
+      expectNativeEl(fixture).not.toHaveCssClass('class2');
     });
 
   it('should keep the raw existing `class` with responsive updates', () => {


### PR DESCRIPTION
The host `class` attribute should be considered static and should not be used as a ClassDirective selector. This means that without associated responsive APIs, the ClassDirective will not be instantiated for elements using only the `class` attribute.

* Use the `class` attribute as a responsive fallback value only.
* Improve support of the ngClass directive for string and object assignments.

Fixes #393.
