### PR TITLE
chore: update to use material mat- prefix

### DIFF
--- a/src/demo-app/app/shared/demo-material-module.ts
+++ b/src/demo-app/app/shared/demo-material-module.ts
@@ -1,11 +1,11 @@
 import {NgModule} from '@angular/core';
 
 import {
-  MdButtonModule,
-  MdCardModule,
-  MdCheckboxModule,
-  MdRadioModule,
-  MdRippleModule,
+  MatButtonModule,
+  MatCardModule,
+  MatCheckboxModule,
+  MatRadioModule,
+  MatRippleModule,
   StyleModule
 } from '@angular/material';
 
@@ -17,11 +17,11 @@ import {ObserversModule} from '@angular/cdk/observers';
  */
 @NgModule({
   exports: [
-    MdButtonModule,
-    MdCardModule,
-    MdCheckboxModule,
-    MdRadioModule,
-    MdRippleModule,
+    MatButtonModule,
+    MatCardModule,
+    MatCheckboxModule,
+    MatRadioModule,
+    MatRippleModule,
     StyleModule,
 
     ObserversModule,


### PR DESCRIPTION
Angular Material modules no longer have the Md- prefix (now Mat-).