### PR TITLE
chore: use a for loop instead Array.map() when the return value is discarded.

### DIFF
--- a/src/lib/media-query/mock/mock-match-media.ts
+++ b/src/lib/media-query/mock/mock-match-media.ts
@@ -153,7 +153,7 @@ export class MockMatchMedia extends MatchMedia {
   private _deactivateAll() {
     if (this._actives.length) {
       // Deactivate all current MQLs and reset the buffer
-      this._actives.map(it => it.deactivate());
+      this._actives.forEach(it => it.deactivate());
       this._actives = [];
     }
     return this;

--- a/src/lib/media-query/mock/mock-match-media.ts
+++ b/src/lib/media-query/mock/mock-match-media.ts
@@ -153,7 +153,9 @@ export class MockMatchMedia extends MatchMedia {
   private _deactivateAll() {
     if (this._actives.length) {
       // Deactivate all current MQLs and reset the buffer
-      this._actives.forEach(it => it.deactivate());
+      for (const it of this._actives) {
+        it.deactivate();
+      }
       this._actives = [];
     }
     return this;


### PR DESCRIPTION
We're enabling a check in google's internal TypeScript compiler that detects calls to well-known functions and methods that return a value that is discarded. So this pattern will become a compilation error soon.