### PR TITLE
build: fix chrome headless not starting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: node_js
-sudo: false
 dist: trusty
 
+# Temporary set sudo to required, because in normal container-based Travis jobs, the Chrome
+# binaries seem to be owned by root, and therefore can't be accessed by Karma. To workaround
+# the issue we temporary grant the CI sudo permissions.
+# https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524.
+sudo: required
+
 node_js:
-  - '--lts'
+  - '8.9.4'
 
 addons:
   jwt:


### PR DESCRIPTION
* Applies a workaround for travis-ci/travis-ci#8836 that fixes the Chrome launch issues. (similar workaround applied on angular/angular)