### PR TITLE
revert: revert typescript to 2.5.x as ng 5.2 not compatible with ts 2.6.x yet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5206,7 +5206,7 @@
         "resolve-dependency-path": "1.0.2",
         "sass-lookup": "1.1.0",
         "stylus-lookup": "1.0.2",
-        "typescript": "2.6.2"
+        "typescript": "2.5.3"
       }
     },
     "fill-range": {
@@ -9892,6 +9892,14 @@
       "dev": true,
       "requires": {
         "temp": "0.4.0"
+      },
+      "dependencies": {
+        "temp": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz",
+          "integrity": "sha1-ZxrWPVe+D+nXKUZks/xABjZnimA=",
+          "dev": true
+        }
       }
     },
     "grpc": {
@@ -18341,10 +18349,22 @@
       }
     },
     "temp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz",
-      "integrity": "sha1-ZxrWPVe+D+nXKUZks/xABjZnimA=",
-      "dev": true
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2",
+        "rimraf": "2.2.8"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+          "dev": true
+        }
+      }
     },
     "ternary-stream": {
       "version": "2.0.1",
@@ -18914,9 +18934,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
+      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
       "dev": true
     },
     "typescript-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "tsconfig-paths": "^2.3.0",
     "tslint": "^5.8.0",
     "tsutils": "^2.13.0",
-    "typescript": "^2.6.2",
+    "typescript": "~2.5.3",
     "uglify-js": "^2.8.14"
   }
 }


### PR DESCRIPTION
Artifact of #560.

ng 5.2.x is not compatible with typescript 2.6.x (yet) . 

It is blocked on angular/angular#21591 . 

More details here at: https://github.com/angular/devkit/pull/394 . 

Given that - may be we should let the typescript version to be 2.5.x as before. 

Cc @ThomasBurleson @CaerusKaru 