### PR TITLE
chore: upgrade Material to 5.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       }
     },
     "@angular/cdk": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-5.0.4.tgz",
-      "integrity": "sha512-6IKDOhDrfKdywTZNTWZbM1O8Q3cTi7uIOAyFC9sXitg0JUy2SHms0UY9FdW32BABIsZp692ofMCMdMPjHDjwwA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-5.1.0.tgz",
+      "integrity": "sha512-xDCVx65SvxoGDMpQhaQvfP7bZhQDuX65Uk+JntPlLTiwFr7v82a+71RnzOCzNKyaNXGoIgUGcrLZpozlyqNgFg==",
       "dev": true,
       "requires": {
         "tslib": "1.8.1"
@@ -91,9 +91,9 @@
       }
     },
     "@angular/material": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-5.0.4.tgz",
-      "integrity": "sha512-xrGYPHOlNXpPkventLAvZyTjfCo2A8ZfdyJEHNR4LhFWIjw3ilwb1ihNv4dy/qG56g8L4AwQ2cONxQ0YyZfcWg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-5.1.0.tgz",
+      "integrity": "sha512-F+dM2xGbyWK3f+j5ZiWMOCBK1Jnv4RAlFRwezJVnzcWaAjwhO2YBHUQGZcnwsVJpwf5Vrihix8N+sWiPvVw+jw==",
       "dev": true,
       "requires": {
         "tslib": "1.8.1"
@@ -9892,6 +9892,14 @@
       "dev": true,
       "requires": {
         "temp": "0.4.0"
+      },
+      "dependencies": {
+        "temp": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz",
+          "integrity": "sha1-ZxrWPVe+D+nXKUZks/xABjZnimA=",
+          "dev": true
+        }
       }
     },
     "grpc": {
@@ -18341,10 +18349,22 @@
       }
     },
     "temp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz",
-      "integrity": "sha1-ZxrWPVe+D+nXKUZks/xABjZnimA=",
-      "dev": true
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2",
+        "rimraf": "2.2.8"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+          "dev": true
+        }
+      }
     },
     "ternary-stream": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
   },
   "devDependencies": {
     "@angular/animations": "~5.2.0",
-    "@angular/cdk": "^5.0.1",
+    "@angular/cdk": "^5.1.0",
     "@angular/compiler-cli": "~5.2.0",
     "@angular/forms": "~5.2.0",
     "@angular/http": "~5.2.0",
-    "@angular/material": "^5.0.1",
+    "@angular/material": "^5.1.0",
     "@angular/platform-browser-dynamic": "~5.2.0",
     "@angular/platform-server": "~5.2.0",
     "@angular/router": "~5.2.0",


### PR DESCRIPTION
Artifact of #560. - upgrading to ng 5.2.x . 

Getting a whole lot of following warnings. 
```console
npm WARN @angular/cdk@5.0.4 requires a peer of @angular/core@~5.1.1 but none is installed. You must install peer dependencies yourself.
npm WARN @angular/cdk@5.0.4 requires a peer of @angular/common@~5.1.1 but none is installed. You must install peer dependencies yourself.
npm WARN @angular/material@5.0.4 requires a peer of @angular/core@~5.1.1 but none is installed. You must install peer dependencies yourself.
npm WARN @angular/material@5.0.4 requires a peer of @angular/common@~5.1.1 but none is installed. You must install peer dependencies yourself.
```

ng material 5.1.x is compatible with ng 5.2 indeed and upgrading fixes those warnings. 