### PR TITLE
chore(versions): update tsickle to 0.26.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18805,9 +18805,9 @@
       }
     },
     "tsickle": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.24.1.tgz",
-      "integrity": "sha512-XloFQZhVhgjpQsi3u2ORNRJvuID5sflOg6HfP093IqAbhE1+fIUXznULpdDwHgG4p+v8w78KdHruQtkWUKx5AQ==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.26.0.tgz",
+      "integrity": "sha512-eWJ2CUfttGK0LqF9iJ/Avnxbj4M+fCyJ50Zag3wm73Fut1hsasPRHKxKdrMWVj4BMHnQNx7TO+DdNmLmJTSuNw==",
       "requires": {
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "core-js": "^2.4.1",
     "rxjs": "^5.5.5",
     "systemjs": "0.19.43",
-    "tsickle": "^0.24.x",
+    "tsickle": "^0.26.0",
     "tslib": "^1.8.0",
     "zone.js": "^0.8.18"
   },
@@ -77,7 +77,7 @@
     "gulp-clean-css": "^3.9.0",
     "gulp-cli": "^1.3.0",
     "gulp-connect": "^5.0.0",
-    "gulp-conventional-changelog": "^1.1.6",
+    "gulp-conventional-changelog": "^1.1.7",
     "gulp-dom": "^0.9.17",
     "gulp-flatten": "^0.3.1",
     "gulp-highlight-files": "^0.0.5",


### PR DESCRIPTION
Address the following warning. 

```console
npm WARN tsickle@0.24.1 requires a peer of typescript@2.4.2 but none is installed. You must install peer dependencies yourself.
```

by upgrading to tsickle 0.26.0 
