### PR TITLE
chore(versions): upgrade dependency-tree to 6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3956,15 +3956,32 @@
       "dev": true
     },
     "dependency-tree": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-5.11.0.tgz",
-      "integrity": "sha1-koRk1vknNgfT9muaV+JZ5jVmd1U=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-6.0.0.tgz",
+      "integrity": "sha512-/F1jMkrwkdQ69GVOni5a/4YK8OItKr1TeWAk9ctN38K70ciI9JJF5Y92oO6sScEkAwAF4m/lv98kbtf7tFV7Mw==",
       "dev": true,
       "requires": {
         "commander": "2.13.0",
-        "debug": "2.6.9",
-        "filing-cabinet": "1.12.0",
-        "precinct": "3.8.0"
+        "debug": "3.1.0",
+        "filing-cabinet": "1.13.1",
+        "precinct": "4.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "deprecated": {
@@ -4110,14 +4127,14 @@
       "dev": true
     },
     "detective-typescript": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-1.0.1.tgz",
-      "integrity": "sha512-4DZpsap+dVzQblcL/ffVXtaXtA7byrP14XQnvyAvwo8+z7/C0OrwLNQhyiC6cLZlzy2T8QuPc+mDsYsa4lAxHw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-2.0.0.tgz",
+      "integrity": "sha512-0VcvklZWrEAqsGHs1Hp5Px3MfKfHTny7zCVVHQwesrib9XanuV3fsMYQ9iJIfd9bJ196KpBQUPgFHdrp34UB+w==",
       "dev": true,
       "requires": {
         "node-source-walk": "3.2.0",
-        "typescript": "2.0.10",
-        "typescript-eslint-parser": "1.0.2"
+        "typescript": "2.6.2",
+        "typescript-eslint-parser": "9.0.1"
       },
       "dependencies": {
         "babylon": {
@@ -4137,12 +4154,6 @@
           "requires": {
             "babylon": "6.8.4"
           }
-        },
-        "typescript": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.10.tgz",
-          "integrity": "sha1-zN1O2G/VVQpAcQGggUAS4bP6w90=",
-          "dev": true
         }
       }
     },
@@ -4598,9 +4609,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.0.3.tgz",
-      "integrity": "sha1-3xTAa1/F7sreEJTJxaErSz7cC2I=",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+      "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
@@ -5189,24 +5200,40 @@
       "dev": true
     },
     "filing-cabinet": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.12.0.tgz",
-      "integrity": "sha1-b7k/2WjoO+3xtCmPKCNqiq/ffXg=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.13.1.tgz",
+      "integrity": "sha512-uK8bwNArVOuC38LqajIJEs1lpGMtShfGwdM+GuMZVWSaEgO/I9NSh1v8uFTaJL0gTHVT9HJASyTwj8LZONogiA==",
       "dev": true,
       "requires": {
         "app-module-path": "1.1.0",
         "commander": "2.13.0",
-        "debug": "2.6.9",
-        "enhanced-resolve": "3.0.3",
+        "debug": "3.1.0",
+        "enhanced-resolve": "3.4.1",
         "is-relative-path": "1.0.2",
         "module-definition": "2.2.4",
         "module-lookup-amd": "4.0.5",
-        "object-assign": "4.1.1",
         "resolve": "1.5.0",
         "resolve-dependency-path": "1.0.2",
         "sass-lookup": "1.1.0",
         "stylus-lookup": "1.0.2",
         "typescript": "2.6.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "fill-range": {
@@ -13683,13 +13710,10 @@
       "dev": true
     },
     "lodash.unescape": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.0.tgz",
-      "integrity": "sha1-Nt6/xJK4FHhHHvl0zTeD4gLrbO8=",
-      "dev": true,
-      "requires": {
-        "lodash.tostring": "4.1.4"
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+      "dev": true
     },
     "lodash.values": {
       "version": "2.4.1",
@@ -13839,6 +13863,15 @@
         "walkdir": "0.0.11"
       },
       "dependencies": {
+        "babylon": {
+          "version": "6.8.4",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz",
+          "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
         "cli-cursor": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -13872,6 +13905,49 @@
             "ms": "0.7.1"
           }
         },
+        "dependency-tree": {
+          "version": "5.11.0",
+          "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-5.11.0.tgz",
+          "integrity": "sha1-koRk1vknNgfT9muaV+JZ5jVmd1U=",
+          "dev": true,
+          "requires": {
+            "commander": "2.9.0",
+            "debug": "2.2.0",
+            "filing-cabinet": "1.13.1",
+            "precinct": "3.8.0"
+          }
+        },
+        "detective-typescript": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-1.0.1.tgz",
+          "integrity": "sha512-4DZpsap+dVzQblcL/ffVXtaXtA7byrP14XQnvyAvwo8+z7/C0OrwLNQhyiC6cLZlzy2T8QuPc+mDsYsa4lAxHw==",
+          "dev": true,
+          "requires": {
+            "node-source-walk": "3.2.0",
+            "typescript": "2.0.10",
+            "typescript-eslint-parser": "1.0.2"
+          },
+          "dependencies": {
+            "node-source-walk": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-3.2.0.tgz",
+              "integrity": "sha1-PGBcxTq97ktFq2XpR9+x23yQ8OM=",
+              "dev": true,
+              "requires": {
+                "babylon": "6.8.4"
+              }
+            }
+          }
+        },
+        "lodash.unescape": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.0.tgz",
+          "integrity": "sha1-Nt6/xJK4FHhHHvl0zTeD4gLrbO8=",
+          "dev": true,
+          "requires": {
+            "lodash.tostring": "4.1.4"
+          }
+        },
         "ms": {
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -13897,6 +13973,49 @@
             "cli-cursor": "2.1.0",
             "cli-spinners": "1.1.0",
             "log-symbols": "1.0.2"
+          }
+        },
+        "precinct": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/precinct/-/precinct-3.8.0.tgz",
+          "integrity": "sha1-JZqUkKhUd6HyaYn73y+ybETyR1o=",
+          "dev": true,
+          "requires": {
+            "commander": "2.13.0",
+            "debug": "3.1.0",
+            "detective-amd": "2.4.0",
+            "detective-cjs": "2.0.0",
+            "detective-es6": "1.2.0",
+            "detective-less": "1.0.0",
+            "detective-sass": "2.0.1",
+            "detective-scss": "1.0.1",
+            "detective-stylus": "1.0.0",
+            "detective-typescript": "1.0.1",
+            "module-definition": "2.2.4",
+            "node-source-walk": "3.3.0"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.13.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+              "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+              "dev": true
+            },
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
         },
         "rc": {
@@ -13926,6 +14045,22 @@
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
           "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
           "dev": true
+        },
+        "typescript": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.10.tgz",
+          "integrity": "sha1-zN1O2G/VVQpAcQGggUAS4bP6w90=",
+          "dev": true
+        },
+        "typescript-eslint-parser": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-1.0.2.tgz",
+          "integrity": "sha1-/Sq6zy7j2Tgqs+RJyHYra+rk0Nc=",
+          "dev": true,
+          "requires": {
+            "lodash.unescape": "4.0.0",
+            "object-assign": "4.1.1"
+          }
         }
       }
     },
@@ -15716,9 +15851,9 @@
       "dev": true
     },
     "precinct": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/precinct/-/precinct-3.8.0.tgz",
-      "integrity": "sha1-JZqUkKhUd6HyaYn73y+ybETyR1o=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/precinct/-/precinct-4.0.0.tgz",
+      "integrity": "sha512-nMnVxEajGPtM6qBmotQeS7pC4kD+FOvvaDV+N0DwI4hUtAe02KSca4LwL5t+BH7fLfzVd3N270fT+ZMHeFhLCg==",
       "dev": true,
       "requires": {
         "commander": "2.13.0",
@@ -15730,7 +15865,7 @@
         "detective-sass": "2.0.1",
         "detective-scss": "1.0.1",
         "detective-stylus": "1.0.0",
-        "detective-typescript": "1.0.1",
+        "detective-typescript": "2.0.0",
         "module-definition": "2.2.4",
         "node-source-walk": "3.3.0"
       },
@@ -18940,13 +19075,13 @@
       "dev": true
     },
     "typescript-eslint-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-1.0.2.tgz",
-      "integrity": "sha1-/Sq6zy7j2Tgqs+RJyHYra+rk0Nc=",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-9.0.1.tgz",
+      "integrity": "sha512-w1jqotvnhLtLukD9H3gQPAlbD0kLf7ZkoQGwiwSIshKIlzRL7i0OY9Y7VIdE1xtytZXThg678eomxMZ1rZXGVQ==",
       "dev": true,
       "requires": {
-        "lodash.unescape": "4.0.0",
-        "object-assign": "4.1.1"
+        "lodash.unescape": "4.0.1",
+        "semver": "5.4.1"
       }
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "karma-sauce-launcher": "^1.2.0",
     "karma-sourcemap-loader": "^0.3.7",
     "madge": "^2.2.0",
+    "dependency-tree": "^6.0.0",
     "magic-string": "^0.22.4",
     "merge2": "^1.2.0",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
Address the following warning. 

```console
npm WARN typescript-eslint-parser@1.0.2 requires a peer of typescript@~2.0.3 but none is installed. You must install peer dependencies yourself.
```
by upgrading dependency-tree to 6.0.0 (madge depends on the same. Independently, pr logged with madge as well to avoid explicitly upgrading dependency-tree - https://github.com/pahen/madge/pull/147 ). 