### PR TITLE
feat(MediaObserver): add MediaObserver to replace ObservableMedia

### DIFF
--- a/src/lib/core/breakpoints/break-points-provider.ts
+++ b/src/lib/core/breakpoints/break-points-provider.ts
@@ -44,7 +44,7 @@ export function buildMergedBreakPoints(_custom?: BreakPoint[],
   }, options || {});
 
   return () => {
-    // Order so the defaults are loaded last; so ObservableMedia will report these last!
+    // Order so the defaults are loaded last; so MediaObserver will report these last!
     let defaults = (options && options.orientations) ?
       ORIENTATION_BREAKPOINTS.concat(DEFAULT_BREAKPOINTS) : DEFAULT_BREAKPOINTS;
 

--- a/src/lib/core/media-observer/media-observer.spec.ts
+++ b/src/lib/core/media-observer/media-observer.spec.ts
@@ -1,0 +1,226 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {async, inject, TestBed} from '@angular/core/testing';
+import {map} from 'rxjs/operators/map';
+import {filter} from 'rxjs/operators/filter';
+
+import {BreakPointRegistry} from '../breakpoints/break-point-registry';
+import {BreakPoint} from '../breakpoints/break-point';
+import {MediaChange} from '../media-change';
+import {BREAKPOINTS} from '../breakpoints/break-points-token';
+import {MediaObserver} from './media-observer';
+import {MatchMedia} from '../match-media/match-media';
+import {
+  CUSTOM_BREAKPOINTS_PROVIDER_FACTORY,
+  DEFAULT_BREAKPOINTS_PROVIDER
+} from '../breakpoints/break-points-provider';
+import {MockMatchMedia, MockMatchMediaProvider} from '../match-media/mock/mock-match-media';
+
+describe('media-observable', () => {
+
+  describe('with default BreakPoints', () => {
+    let knownBreakPoints: BreakPoint[] = [];
+    let findMediaQuery: (alias: string) => string = (alias) => {
+      const NOT_FOUND = `${alias} not found`;
+      return knownBreakPoints.reduce((mediaQuery, bp) => {
+        return mediaQuery || ((bp.alias === alias) ? bp.mediaQuery : null);
+      }, null) as string || NOT_FOUND;
+    };
+    beforeEach(() => {
+      // Configure testbed to prepare services
+      TestBed.configureTestingModule({
+        providers: [
+          DEFAULT_BREAKPOINTS_PROVIDER,
+          BreakPointRegistry,   // Registry of known/used BreakPoint(s)
+          MockMatchMediaProvider,
+          MediaObserver,
+        ]
+      });
+    });
+    beforeEach(inject([BREAKPOINTS], (breakpoints: BreakPoint[]) => {
+      // Cache reference to list for easy testing...
+      knownBreakPoints = breakpoints;
+    }));
+
+    it('can supports the `.isActive()` API', async(inject(
+      [MediaObserver, MatchMedia],
+      (media: MediaObserver, matchMedia: MockMatchMedia) => {
+        expect(media).toBeDefined();
+
+        // Activate mediaQuery associated with 'md' alias
+        matchMedia.activate('md');
+        expect(media.isActive('md')).toBeTruthy();
+
+        matchMedia.activate('lg');
+        expect(media.isActive('lg')).toBeTruthy();
+        expect(media.isActive('md')).toBeFalsy();
+
+      })));
+
+    it('can supports RxJS operators', inject(
+      [MediaObserver, MatchMedia],
+      (media$: MediaObserver, matchMedia: MockMatchMedia) => {
+        let count = 0,
+          subscription = media$.media$.pipe(
+            filter((change: MediaChange) => change.mqAlias == 'md'),
+            map((change: MediaChange) => change.mqAlias)
+          ).subscribe(() => {
+            count += 1;
+          });
+
+
+        // Activate mediaQuery associated with 'md' alias
+        matchMedia.activate('sm');
+        expect(count).toEqual(0);
+
+        matchMedia.activate('md');
+        expect(count).toEqual(1);
+
+        matchMedia.activate('lg');
+        expect(count).toEqual(1);
+
+        matchMedia.activate('md');
+        expect(count).toEqual(2);
+
+        matchMedia.activate('gt-md');
+        matchMedia.activate('gt-lg');
+        matchMedia.activate('invalid');
+        expect(count).toEqual(2);
+
+        subscription.unsubscribe();
+      }));
+
+    it('can subscribe to built-in mediaQueries', inject(
+      [MediaObserver, MatchMedia],
+      (media$: MediaObserver, matchMedia: MockMatchMedia) => {
+        let current: MediaChange;
+
+        expect(media$).toBeDefined();
+
+        let subscription = media$.media$.subscribe((change: MediaChange) => {
+          current = change;
+        });
+
+        async(() => {
+          // Confirm initial match is for 'all'
+          expect(current).toBeDefined();
+          expect(current.matches).toBeTruthy();
+          expect(current.mediaQuery).toEqual('all');
+
+          try {
+            matchMedia.autoRegisterQueries = false;
+
+            // Activate mediaQuery associated with 'md' alias
+            matchMedia.activate('md');
+            expect(current.mediaQuery).toEqual(findMediaQuery('md'));
+
+            // Allow overlapping activations to be announced to observers
+            media$.filterOverlaps = false;
+
+            matchMedia.activate('gt-lg');
+            expect(current.mediaQuery).toEqual(findMediaQuery('gt-lg'));
+
+            matchMedia.activate('unknown');
+            expect(current.mediaQuery).toEqual(findMediaQuery('gt-lg'));
+
+          } finally {
+            matchMedia.autoRegisterQueries = true;
+            subscription.unsubscribe();
+          }
+        });
+      }));
+
+    it('can `.unsubscribe()` properly', inject(
+      [MediaObserver, MatchMedia],
+      (media: MediaObserver, matchMedia: MockMatchMedia) => {
+        let current: MediaChange;
+        let subscription = media.media$.subscribe((change: MediaChange) => {
+          current = change;
+        });
+
+        async(() => {
+          // Activate mediaQuery associated with 'md' alias
+          matchMedia.activate('md');
+          expect(current.mediaQuery).toEqual(findMediaQuery('md'));
+
+          // Un-subscribe
+          subscription.unsubscribe();
+
+          matchMedia.activate('lg');
+          expect(current.mqAlias).toBe('md');
+
+          matchMedia.activate('xs');
+          expect(current.mqAlias).toBe('md');
+        });
+      }));
+
+    it('can observe a startup activation of XS', inject(
+      [MediaObserver, MatchMedia],
+      (media: MediaObserver, matchMedia: MockMatchMedia) => {
+        let current: MediaChange;
+        let subscription = media.media$.subscribe((change: MediaChange) => {
+          current = change;
+        });
+
+        async(() => {
+          // Activate mediaQuery associated with 'md' alias
+          matchMedia.activate('xs');
+          expect(current.mediaQuery).toEqual(findMediaQuery('xs'));
+
+          // Un-subscribe
+          subscription.unsubscribe();
+
+          matchMedia.activate('lg');
+          expect(current.mqAlias).toBe('xs');
+        });
+      }));
+  });
+
+  describe('with custom BreakPoints', () => {
+    const excludeDefaults = true;
+    const gtXsMediaQuery = 'screen and (max-width:20px) and (orientations: landscape)';
+    const mdMediaQuery = 'print and (min-width:10000px)';
+    const CUSTOM_BREAKPOINTS = [
+      {alias: 'print.md', mediaQuery: mdMediaQuery},
+      {alias: 'tablet-gt-xs', mediaQuery: gtXsMediaQuery},
+    ];
+
+    beforeEach(() => {
+      // Configure testbed to prepare services
+      TestBed.configureTestingModule({
+        providers: [
+          BreakPointRegistry,   // Registry of known/used BreakPoint(s)
+          MockMatchMediaProvider,
+          CUSTOM_BREAKPOINTS_PROVIDER_FACTORY(CUSTOM_BREAKPOINTS, {defaults: excludeDefaults}),
+          MediaObserver,
+        ]
+      });
+    });
+
+    it('can activate custom alias with custom mediaQueries', inject(
+      [MediaObserver, MatchMedia],
+      (media: MediaObserver, matchMedia: MockMatchMedia) => {
+        let current: MediaChange;
+        let subscription = media.media$.subscribe((change: MediaChange) => {
+          current = change;
+        });
+
+        async(() => {
+          // Activate mediaQuery associated with 'md' alias
+          matchMedia.activate('print.md');
+          expect(current.mediaQuery).toEqual(mdMediaQuery);
+
+          matchMedia.activate('tablet-gt-xs');
+          expect(current.mqAlias).toBe('tablet-gt-xs');
+          expect(current.mediaQuery).toBe(gtXsMediaQuery);
+
+          subscription.unsubscribe();
+        });
+      }));
+  });
+});

--- a/src/lib/core/media-observer/media-observer.ts
+++ b/src/lib/core/media-observer/media-observer.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Injectable} from '@angular/core';
+import {Observable} from 'rxjs/Observable';
+import {map} from 'rxjs/operators/map';
+import {filter} from 'rxjs/operators/filter';
+
+import {MediaChange} from '../media-change';
+import {BreakPointRegistry} from '../breakpoints/break-point-registry';
+import {MatchMedia} from '../match-media/match-media';
+import {BreakPoint} from '../breakpoints/break-point';
+import {mergeAlias} from '../add-alias';
+
+@Injectable()
+export class MediaObserver {
+
+  /**
+   * Whether we should announce gt-<xxx> breakpoint activations
+   */
+  filterOverlaps = true;
+
+  constructor(private breakpoints: BreakPointRegistry,
+              private matchMedia: MatchMedia) {
+    this._registerBreakPoints();
+  }
+
+  /**
+   * Whether a given query/alias is active
+   */
+  isActive(alias): boolean {
+    let query = this._toMediaQuery(alias);
+    return this.matchMedia.isActive(query);
+  }
+
+  /**
+   * Takes in an optional set of media queries and returns an
+   * Observable that emits when the given queries become active
+   */
+  observe(value?: string | string[]): Observable<MediaChange> {
+    let obs = this._getObservable();
+    let values: string[] = value ?
+      (Array.isArray(value) ? value : [value]).map(this._toMediaQuery) : [];
+
+    this.matchMedia.registerQuery(values);
+    if (values.length > 0) {
+      obs = obs.pipe(
+        filter(change => values.indexOf(change.mediaQuery) > -1)
+      );
+    }
+
+    return obs;
+  }
+
+  /**
+   * Returns an Observable that emits whenever a breakpoint
+   * becomes active
+   */
+  get media$(): Observable<MediaChange> {
+    return this._getObservable();
+  }
+
+  // ************************************************
+  // Internal Methods
+  // ************************************************
+
+  /**
+   * Construct an Observable based on the MatchMedia Observable
+   * that only emits on activations, adds breakpoint aliases to the
+   * MediaChange object, and excludes overlaps based on the current
+   * state of the service
+   */
+  private _getObservable(): Observable<MediaChange> {
+    const activationsOnly = (change: MediaChange) => {
+      return change.matches === true;
+    };
+    const addAliasInformation = (change: MediaChange) => {
+      return mergeAlias(change, this._findByQuery(change.mediaQuery));
+    };
+    const excludeOverlaps = (change: MediaChange) => {
+      let bp = this._findByQuery(change.mediaQuery);
+      return !bp || !(this.filterOverlaps && bp.overlapping);
+    };
+
+    return this.matchMedia.observe()
+      .pipe(
+        filter(activationsOnly),
+        filter(excludeOverlaps),
+        map(addAliasInformation)
+      );
+  }
+
+  /**
+   * Register all the mediaQueries registered in the BreakPointRegistry
+   * This is needed so subscribers can be auto-notified of all standard, registered
+   * mediaQuery activations
+   */
+  private _registerBreakPoints() {
+    let queries = this.breakpoints.sortedItems.map(bp => bp.mediaQuery);
+    this.matchMedia.registerQuery(queries);
+  }
+
+  /**
+   * Breakpoint locator by alias
+   */
+  private _findByAlias(alias: string) {
+    return this.breakpoints.findByAlias(alias);
+  }
+
+  /**
+   * Breakpoint locator by mediaQuery
+   */
+  private _findByQuery(query: string) {
+    return this.breakpoints.findByQuery(query);
+  }
+
+  /**
+   * Find associated breakpoint (if any)
+   */
+  private _toMediaQuery(query: string) {
+    let bp: BreakPoint | null = this._findByAlias(query) || this._findByQuery(query);
+    return bp ? bp.mediaQuery : query;
+  }
+}

--- a/src/lib/core/module.ts
+++ b/src/lib/core/module.ts
@@ -10,9 +10,9 @@ import {NgModule} from '@angular/core';
 import {MatchMedia} from './match-media/match-media';
 import {MediaMonitor} from './media-monitor/media-monitor';
 import {BreakPointRegistry} from './breakpoints/break-point-registry';
-
 import {OBSERVABLE_MEDIA_PROVIDER} from './observable-media/observable-media-provider';
 import {DEFAULT_BREAKPOINTS_PROVIDER} from './breakpoints/break-points-provider';
+import {MediaObserver} from './media-observer/media-observer';
 
 /**
  * *****************************************************************
@@ -26,7 +26,8 @@ import {DEFAULT_BREAKPOINTS_PROVIDER} from './breakpoints/break-points-provider'
     BreakPointRegistry,      // Registry of known/used BreakPoint(s)
     MatchMedia,              // Low-level service to publish observables w/ window.matchMedia()
     MediaMonitor,            // MediaQuery monitor service observes all known breakpoints
-    OBSERVABLE_MEDIA_PROVIDER  // easy subscription injectable `media$` matchMedia observable
+    OBSERVABLE_MEDIA_PROVIDER,  // easy subscription injectable `media$` matchMedia observable
+    MediaObserver,           // easy subscription injectable `media$` matchMedia observable
   ]
 })
 export class CoreModule {

--- a/src/lib/core/observable-media/observable-media-provider.ts
+++ b/src/lib/core/observable-media/observable-media-provider.ts
@@ -12,6 +12,8 @@ import {MatchMedia} from '../match-media/match-media';
 import {ObservableMedia, MediaService} from './observable-media';
 
 /**
+ * @deprecated use MediaObserver
+ * @deletion-target 5.0.0-beta.16
  * Ensure a single global ObservableMedia service provider
  */
 export function OBSERVABLE_MEDIA_PROVIDER_FACTORY(parentService: ObservableMedia,
@@ -20,6 +22,8 @@ export function OBSERVABLE_MEDIA_PROVIDER_FACTORY(parentService: ObservableMedia
   return parentService || new MediaService(breakpoints, matchMedia);
 }
 /**
+ *  @deprecated use MediaObserver
+ *  @deletion-target 5.0.0-beta.16
  *  Provider to return global service for observable service for all MediaQuery activations
  */
 export const OBSERVABLE_MEDIA_PROVIDER = { // tslint:disable-line:variable-name

--- a/src/lib/core/observable-media/observable-media.ts
+++ b/src/lib/core/observable-media/observable-media.ts
@@ -18,6 +18,8 @@ import {mergeAlias} from '../add-alias';
 import {BreakPoint} from '../breakpoints/break-point';
 
 /**
+ * @deprecated use MediaObserver
+ * @deletion-target 5.0.0-beta.16
  * Base class for MediaService and pseudo-token for
  */
 export abstract class ObservableMedia implements Subscribable<MediaChange> {
@@ -31,6 +33,8 @@ export abstract class ObservableMedia implements Subscribable<MediaChange> {
 }
 
 /**
+ * @deprecated use MediaObserver
+ * @deletion-target 5.0.0-beta.16
  * Class internalizes a MatchMedia service and exposes an Subscribable and Observable interface.
 
  * This an Observable with that exposes a feature to subscribe to mediaQuery

--- a/src/lib/core/public-api.ts
+++ b/src/lib/core/public-api.ts
@@ -18,6 +18,7 @@ export * from './breakpoints/index';
 export * from './match-media/index';
 export * from './media-monitor/index';
 export * from './observable-media/index';
+export * from './media-observer/media-observer';
 
 export * from './responsive-activation/responsive-activation';
 export * from './style-utils/style-utils';

--- a/src/lib/extended/show-hide/hide.spec.ts
+++ b/src/lib/extended/show-hide/hide.spec.ts
@@ -14,7 +14,7 @@ import {
   MatchMedia,
   CoreModule,
   MockMatchMedia,
-  ObservableMedia,
+  MediaObserver,
   StylesheetMap,
   SERVER_TOKEN,
   StyleUtils,
@@ -271,7 +271,7 @@ class TestHideComponent implements OnInit {
   isHidden = true;
   menuHidden = true;
 
-  constructor(public media: ObservableMedia) {
+  constructor(public media: MediaObserver) {
   }
 
   toggleMenu() {

--- a/src/lib/extended/show-hide/show.spec.ts
+++ b/src/lib/extended/show-hide/show.spec.ts
@@ -13,7 +13,7 @@ import {
   DEFAULT_BREAKPOINTS_PROVIDER,
   MatchMedia,
   MockMatchMedia,
-  ObservableMedia,
+  MediaObserver,
   StylesheetMap,
   SERVER_TOKEN,
   StyleUtils,
@@ -215,7 +215,7 @@ class TestShowComponent implements OnInit {
   isHidden = false;
   menuOpen = true;
 
-  constructor(public media: ObservableMedia) {
+  constructor(public media: MediaObserver) {
   }
 
   toggleMenu() {


### PR DESCRIPTION
* Add MediaObservable class that returns an Observable instead of creating a Subscribable
* Deprecate ObservableMedia and MediaService since they are no longer needed

BREAKING CHANGE:
* `ObservableMedia` is deprecated. Please use `MediaObserver`, which has compatible APIs

Fixes #297 