### PR TITLE
chore(versions): upgrade madge to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3955,18 +3955,6 @@
       "integrity": "sha1-MC5YIY2FxRqXY4cw2/m32FKhlpM=",
       "dev": true
     },
-    "dependency-tree": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-5.11.0.tgz",
-      "integrity": "sha1-koRk1vknNgfT9muaV+JZ5jVmd1U=",
-      "dev": true,
-      "requires": {
-        "commander": "2.13.0",
-        "debug": "2.6.9",
-        "filing-cabinet": "1.12.0",
-        "precinct": "3.8.0"
-      }
-    },
     "deprecated": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
@@ -4108,43 +4096,6 @@
       "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-1.0.0.tgz",
       "integrity": "sha1-UK7n24uruZA4HwEMY/q7pbWOVM0=",
       "dev": true
-    },
-    "detective-typescript": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-1.0.1.tgz",
-      "integrity": "sha512-4DZpsap+dVzQblcL/ffVXtaXtA7byrP14XQnvyAvwo8+z7/C0OrwLNQhyiC6cLZlzy2T8QuPc+mDsYsa4lAxHw==",
-      "dev": true,
-      "requires": {
-        "node-source-walk": "3.2.0",
-        "typescript": "2.0.10",
-        "typescript-eslint-parser": "1.0.2"
-      },
-      "dependencies": {
-        "babylon": {
-          "version": "6.8.4",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz",
-          "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
-        },
-        "node-source-walk": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-3.2.0.tgz",
-          "integrity": "sha1-PGBcxTq97ktFq2XpR9+x23yQ8OM=",
-          "dev": true,
-          "requires": {
-            "babylon": "6.8.4"
-          }
-        },
-        "typescript": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.10.tgz",
-          "integrity": "sha1-zN1O2G/VVQpAcQGggUAS4bP6w90=",
-          "dev": true
-        }
-      }
     },
     "dgeni": {
       "version": "0.4.9",
@@ -4595,18 +4546,6 @@
         "blob": "0.0.4",
         "has-binary": "0.1.7",
         "wtf-8": "1.0.0"
-      }
-    },
-    "enhanced-resolve": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.0.3.tgz",
-      "integrity": "sha1-3xTAa1/F7sreEJTJxaErSz7cC2I=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
       }
     },
     "ent": {
@@ -5187,27 +5126,6 @@
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
       "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==",
       "dev": true
-    },
-    "filing-cabinet": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.12.0.tgz",
-      "integrity": "sha1-b7k/2WjoO+3xtCmPKCNqiq/ffXg=",
-      "dev": true,
-      "requires": {
-        "app-module-path": "1.1.0",
-        "commander": "2.13.0",
-        "debug": "2.6.9",
-        "enhanced-resolve": "3.0.3",
-        "is-relative-path": "1.0.2",
-        "module-definition": "2.2.4",
-        "module-lookup-amd": "4.0.5",
-        "object-assign": "4.1.1",
-        "resolve": "1.5.0",
-        "resolve-dependency-path": "1.0.2",
-        "sass-lookup": "1.1.0",
-        "stylus-lookup": "1.0.2",
-        "typescript": "2.6.2"
-      }
     },
     "fill-range": {
       "version": "2.2.3",
@@ -13676,21 +13594,6 @@
         "lodash.escape": "3.2.0"
       }
     },
-    "lodash.tostring": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz",
-      "integrity": "sha1-Vgwn0fjq3eA8LM4Zj+9cAx2CmPs=",
-      "dev": true
-    },
-    "lodash.unescape": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.0.tgz",
-      "integrity": "sha1-Nt6/xJK4FHhHHvl0zTeD4gLrbO8=",
-      "dev": true,
-      "requires": {
-        "lodash.tostring": "4.1.4"
-      }
-    },
     "lodash.values": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
@@ -13820,25 +13723,54 @@
       }
     },
     "madge": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/madge/-/madge-2.2.0.tgz",
-      "integrity": "sha512-5UoX9n8od0UmKPcZo4KydgQch+oKvlywsee+60ochES6Uo1UDaHnt6yx+SOIZMt007R0F/ZNq03vhxlaJPep+g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/madge/-/madge-3.0.0.tgz",
+      "integrity": "sha512-fqMlHRGo3CHJ+e1+cHuoMC6YtpPEKhCC0JZnr+7tdXhRgXEObP7V1VLhggDJy3LUKAy0Yv+azP9dnNxAnfwHqw==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "commander": "2.9.0",
+        "chalk": "2.3.0",
+        "commander": "2.13.0",
         "commondir": "1.0.1",
-        "debug": "2.2.0",
-        "dependency-tree": "5.11.0",
+        "debug": "3.1.0",
+        "dependency-tree": "6.0.0",
         "graphviz": "0.0.8",
-        "mz": "2.4.0",
-        "ora": "1.2.0",
-        "pluralize": "4.0.0",
-        "pretty-ms": "2.1.0",
-        "rc": "1.1.6",
-        "walkdir": "0.0.11"
+        "mz": "2.7.0",
+        "ora": "1.3.0",
+        "pluralize": "7.0.0",
+        "pretty-ms": "3.1.0",
+        "rc": "1.2.3",
+        "walkdir": "0.0.12"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "babylon": {
+          "version": "6.8.4",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz",
+          "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
         "cli-cursor": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -13854,28 +13786,97 @@
           "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
           "dev": true
         },
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "ms": "2.0.0"
           }
         },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+        "dependency-tree": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-6.0.0.tgz",
+          "integrity": "sha512-/F1jMkrwkdQ69GVOni5a/4YK8OItKr1TeWAk9ctN38K70ciI9JJF5Y92oO6sScEkAwAF4m/lv98kbtf7tFV7Mw==",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "commander": "2.13.0",
+            "debug": "3.1.0",
+            "filing-cabinet": "1.13.1",
+            "precinct": "4.0.0"
           }
+        },
+        "detective-typescript": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-2.0.0.tgz",
+          "integrity": "sha512-0VcvklZWrEAqsGHs1Hp5Px3MfKfHTny7zCVVHQwesrib9XanuV3fsMYQ9iJIfd9bJ196KpBQUPgFHdrp34UB+w==",
+          "dev": true,
+          "requires": {
+            "node-source-walk": "3.2.0",
+            "typescript": "2.6.2",
+            "typescript-eslint-parser": "9.0.1"
+          },
+          "dependencies": {
+            "node-source-walk": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-3.2.0.tgz",
+              "integrity": "sha1-PGBcxTq97ktFq2XpR9+x23yQ8OM=",
+              "dev": true,
+              "requires": {
+                "babylon": "6.8.4"
+              }
+            }
+          }
+        },
+        "enhanced-resolve": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+          "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "memory-fs": "0.4.1",
+            "object-assign": "4.1.1",
+            "tapable": "0.2.8"
+          }
+        },
+        "filing-cabinet": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.13.1.tgz",
+          "integrity": "sha512-uK8bwNArVOuC38LqajIJEs1lpGMtShfGwdM+GuMZVWSaEgO/I9NSh1v8uFTaJL0gTHVT9HJASyTwj8LZONogiA==",
+          "dev": true,
+          "requires": {
+            "app-module-path": "1.1.0",
+            "commander": "2.13.0",
+            "debug": "3.1.0",
+            "enhanced-resolve": "3.4.1",
+            "is-relative-path": "1.0.2",
+            "module-definition": "2.2.4",
+            "module-lookup-amd": "4.0.5",
+            "resolve": "1.5.0",
+            "resolve-dependency-path": "1.0.2",
+            "sass-lookup": "1.1.0",
+            "stylus-lookup": "1.0.2",
+            "typescript": "2.6.2"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "lodash.unescape": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+          "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+          "dev": true
         },
         "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "onetime": {
@@ -13888,27 +13889,62 @@
           }
         },
         "ora": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/ora/-/ora-1.2.0.tgz",
-          "integrity": "sha1-Mvsxg1AO/oP16okQF4Xw7mBg/sk=",
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-1.3.0.tgz",
+          "integrity": "sha1-gAeN0rkqk0r2ajrXKluRBpTt5Ro=",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
             "cli-cursor": "2.1.0",
             "cli-spinners": "1.1.0",
             "log-symbols": "1.0.2"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
           }
         },
-        "rc": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-          "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
+        "precinct": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/precinct/-/precinct-4.0.0.tgz",
+          "integrity": "sha512-nMnVxEajGPtM6qBmotQeS7pC4kD+FOvvaDV+N0DwI4hUtAe02KSca4LwL5t+BH7fLfzVd3N270fT+ZMHeFhLCg==",
           "dev": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "1.0.4"
+            "commander": "2.13.0",
+            "debug": "3.1.0",
+            "detective-amd": "2.4.0",
+            "detective-cjs": "2.0.0",
+            "detective-es6": "1.2.0",
+            "detective-less": "1.0.0",
+            "detective-sass": "2.0.1",
+            "detective-scss": "1.0.1",
+            "detective-stylus": "1.0.0",
+            "detective-typescript": "2.0.0",
+            "module-definition": "2.2.4",
+            "node-source-walk": "3.3.0"
           }
         },
         "restore-cursor": {
@@ -13921,10 +13957,29 @@
             "signal-exit": "3.0.2"
           }
         },
-        "strip-json-comments": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "typescript-eslint-parser": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-9.0.1.tgz",
+          "integrity": "sha512-w1jqotvnhLtLukD9H3gQPAlbD0kLf7ZkoQGwiwSIshKIlzRL7i0OY9Y7VIdE1xtytZXThg678eomxMZ1rZXGVQ==",
+          "dev": true,
+          "requires": {
+            "lodash.unescape": "4.0.1",
+            "semver": "5.4.1"
+          }
+        },
+        "walkdir": {
+          "version": "0.0.12",
+          "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.12.tgz",
+          "integrity": "sha512-HFhaD4mMWPzFSqhpyDG48KDdrjfn409YQuVW7ckZYhW4sE87mYtWifdB/+73RA7+p4s4K18n5Jfx1kHthE1gBw==",
           "dev": true
         }
       }
@@ -14474,9 +14529,9 @@
       "optional": true
     },
     "mz": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.4.0.tgz",
-      "integrity": "sha1-mHupYk2JOVOIw3y0dB4sr03ROxo=",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "requires": {
         "any-promise": "1.3.0",
@@ -15604,15 +15659,18 @@
       }
     },
     "plur": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
-      "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
-      "dev": true
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+      "dev": true,
+      "requires": {
+        "irregular-plurals": "1.4.0"
+      }
     },
     "pluralize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
-      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "portfinder": {
@@ -15715,43 +15773,6 @@
       "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
       "dev": true
     },
-    "precinct": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/precinct/-/precinct-3.8.0.tgz",
-      "integrity": "sha1-JZqUkKhUd6HyaYn73y+ybETyR1o=",
-      "dev": true,
-      "requires": {
-        "commander": "2.13.0",
-        "debug": "3.1.0",
-        "detective-amd": "2.4.0",
-        "detective-cjs": "2.0.0",
-        "detective-es6": "1.2.0",
-        "detective-less": "1.0.0",
-        "detective-sass": "2.0.1",
-        "detective-scss": "1.0.1",
-        "detective-stylus": "1.0.0",
-        "detective-typescript": "1.0.1",
-        "module-definition": "2.2.4",
-        "node-source-walk": "3.3.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -15783,14 +15804,13 @@
       "dev": true
     },
     "pretty-ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
-      "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
+      "integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2",
         "parse-ms": "1.0.1",
-        "plur": "1.0.0"
+        "plur": "2.1.2"
       }
     },
     "process-nextick-args": {
@@ -18938,16 +18958,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
       "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
       "dev": true
-    },
-    "typescript-eslint-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-1.0.2.tgz",
-      "integrity": "sha1-/Sq6zy7j2Tgqs+RJyHYra+rk0Nc=",
-      "dev": true,
-      "requires": {
-        "lodash.unescape": "4.0.0",
-        "object-assign": "4.1.1"
-      }
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "karma-jasmine": "^1.1.1",
     "karma-sauce-launcher": "^1.2.0",
     "karma-sourcemap-loader": "^0.3.7",
-    "madge": "^2.2.0",
+    "madge": "^3.0.0",
     "magic-string": "^0.22.4",
     "merge2": "^1.2.0",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
Revisiting #584 again.
Address the following warning. 

```console
npm WARN typescript-eslint-parser@1.0.2 requires a peer of typescript@~2.0.3 but none is installed. You must install peer dependencies yourself.
```
by upgrading madge to 3.0.0 .  