### PR TITLE
fix(lib): read correct styles during SSR and add test for layout-wrap

### DIFF
--- a/src/lib/api/flexbox/layout.spec.ts
+++ b/src/lib/api/flexbox/layout.spec.ts
@@ -167,6 +167,13 @@ describe('layout directive', () => {
        });
     });
 
+    it('should have valid wrap with flex children', () => {
+      createTestComponent(`<div fxLayout='row wrap'><div fxFlex></div></div>`);
+      expectNativeEl(fixture).toHaveStyle({
+        'flex-wrap': 'wrap'
+      });
+    });
+
   });
 
   describe('with inline options', () => {

--- a/src/lib/utils/style-utils.ts
+++ b/src/lib/utils/style-utils.ts
@@ -72,7 +72,7 @@ export function lookupAttributeValue(element: HTMLElement, attribute: string): s
  * Find the DOM element's inline style value (if any)
  */
 export function lookupInlineStyle(element: HTMLElement, styleName: string): string {
-  return element.style[styleName];
+  return element.style[styleName] || element.style.getPropertyValue(styleName);
 }
 
 /**


### PR DESCRIPTION
* Domino can be stupid about parsing styles on the server, so
  add an additional inline style read for the property value
* Add a test case for nested flex children when parent uses layout
  wrap. This will be useful when adding SSR testing mode to ensure
  this case is accounted for in the future

Fixes #430