### PR TITLE
chore(docs): use Markdown syntax instead of HTML

### DIFF
--- a/docs/documentation/Background.md
+++ b/docs/documentation/Background.md
@@ -13,11 +13,7 @@ expands items to fill available free space, or shrinks them to prevent overflow.
 Now let's add these complexities the requirements that developers often want combine the CSS Flexbox API with CSS media 
 queries in order to support responsive layouts. e.g.
 
-```html
-<a href="" target="_blank">
-  <img src="https://cloud.githubusercontent.com/assets/210413/20029960/fbbc0e62-a328-11e6-8045-c6532affc857.png">
-</a>
-```
+![](https://cloud.githubusercontent.com/assets/210413/20029960/fbbc0e62-a328-11e6-8045-c6532affc857.png)
 
 Unfortunately, developers manually implementing Flexbox CSS must become experts at both the syntax and the workarounds 
 to accommodate browser-specific differences in Flexbox runtime support.

--- a/docs/documentation/Browser-Support.md
+++ b/docs/documentation/Browser-Support.md
@@ -1,4 +1,2 @@
-<a href="http://caniuse.com/#feat=flexbox" target="_blank">
-<img src="https://cloud.githubusercontent.com/assets/210413/21288118/917e3faa-c440-11e6-9b08-28aff590c7ae.png">
-</a>
+[![caniuse](https://cloud.githubusercontent.com/assets/210413/21288118/917e3faa-c440-11e6-9b08-28aff590c7ae.png)](http://caniuse.com/#feat=flexbox)
 

--- a/docs/documentation/Home.md
+++ b/docs/documentation/Home.md
@@ -23,15 +23,8 @@ this is!
 
 Live Demo:
 
-<a href="https://tburleson-layouts-demos.firebaseapp.com/#/stackoverflow" target="_blank">
-<img alt="Featured" src="https://cloud.githubusercontent.com/assets/210413/24045163/216dae9c-0aec-11e7-8b22-616a4328eca3.jpg"></img>
-</a>
+[![Featured](https://cloud.githubusercontent.com/assets/210413/24045163/216dae9c-0aec-11e7-8b22-616a4328eca3.jpg)](https://tburleson-layouts-demos.firebaseapp.com/#/stackoverflow)
 
 Source Code:
 
-<a href="https://github.com/angular/flex-layout/blob/master/src/demo-app/app/stack-overflow/columnSpan.demo.ts#L28" target="_blank" >
-<img src="https://cloud.githubusercontent.com/assets/210413/24045169/247bad3c-0aec-11e7-827a-6ece0775ff39.jpg" alt="Feature Source" >
-</img>
-</a>
-
-
+[![Feature Source](https://cloud.githubusercontent.com/assets/210413/24045169/247bad3c-0aec-11e7-827a-6ece0775ff39.jpg)](https://github.com/angular/flex-layout/blob/master/src/demo-app/app/stack-overflow/columnSpan.demo.ts#L28)

--- a/docs/documentation/Responsive-API.md
+++ b/docs/documentation/Responsive-API.md
@@ -2,9 +2,7 @@ Responsive layouts in material design adapt to any possible screen size. Google'
 provide guidance that includes a flexible grid that ensures consistency across layouts, breakpoint details about how 
 content reflows on different screens, and a description of how an app can scale from small to extra-large screens.
 
-<a href="https://material.io/guidelines/layout/responsive-ui.html" target="_blank">
-<img src="http://material-design.storage.googleapis.com/publish/material_v_4/material_ext_publish/0B8olV15J7abPSGFxemFiQVRtb1k/layout_adaptive_breakpoints_01.png">
-</a>
+[![Feature Source](http://material-design.storage.googleapis.com/publish/material_v_4/material_ext_publish/0B8olV15J7abPSGFxemFiQVRtb1k/layout_adaptive_breakpoints_01.png)](https://material.io/guidelines/layout/responsive-ui.html)
 
 ## Enhancing the Static API
 

--- a/docs/documentation/fxFlex-API.md
+++ b/docs/documentation/fxFlex-API.md
@@ -14,7 +14,7 @@ available. The flex-grow value overrides the width.
 * **flex-shrink**: defines how much a flexbox item should **shrink** if there is **not enough** space available.
 * **flex-basis**: controls the default size of an element, before it is manipulated by other Flexbox properties
 
-<img width="459" alt="screen shot 2017-02-21 at 10 53 18 pm" src="https://cloud.githubusercontent.com/assets/210413/23197825/9742cf4c-f888-11e6-8812-b287f8aad15f.png">
+![screen shot 2017-02-21 at 10 53 18 pm](https://cloud.githubusercontent.com/assets/210413/23197825/9742cf4c-f888-11e6-8812-b287f8aad15f.png)
 
 Note that the resizing occurs along the main-axis of the layout and maybe affected by the **fxLayoutAlign** options. 
 


### PR DESCRIPTION
Use proper Markdown syntax instead of native HTML when possible
for consistency sake throughout the docs