### PR TITLE
fix(fxFlex): apply correct flex-basis stylings

### DIFF
--- a/src/lib/core/style-utils/style-utils.ts
+++ b/src/lib/core/style-utils/style-utils.ts
@@ -70,7 +70,7 @@ export class StyleUtils {
    * Find the DOM element's inline style value (if any)
    */
   lookupInlineStyle(element: HTMLElement, styleName: string): string {
-    return element.style[styleName] || element.style.getPropertyValue(styleName);
+    return element.style[styleName] || element.style.getPropertyValue(styleName) || '';
   }
 
   /**
@@ -88,7 +88,7 @@ export class StyleUtils {
           }
         } else {
           if (this._serverModuleLoaded) {
-            value = `${this._serverStylesheet.getStyleForElement(element, styleName)}`;
+            value = this._serverStylesheet.getStyleForElement(element, styleName);
           }
         }
       }

--- a/src/lib/core/stylesheet-map.ts
+++ b/src/lib/core/stylesheet-map.ts
@@ -40,8 +40,15 @@ export class StylesheetMap {
   /**
    * Retrieve a given style for an HTML element
    */
-  getStyleForElement(el: HTMLElement, styleName: string): string|number {
+  getStyleForElement(el: HTMLElement, styleName: string): string {
     const styles = this.stylesheet.get(el);
-    return (styles && styles.get(styleName)) || '';
+    let value = '';
+    if (styles) {
+      const style = styles.get(styleName);
+      if (typeof style === 'number' || typeof style === 'string') {
+        value = style + '';
+      }
+    }
+    return value;
   }
 }

--- a/src/lib/flex/flex/flex.spec.ts
+++ b/src/lib/flex/flex/flex.spec.ts
@@ -142,7 +142,49 @@ describe('flex directive', () => {
       }
     });
 
-    it('should add correct styles for `fxFlex="0%"` usage', () => {
+    it('should add correct styles for flex-basis unitless 0 input', () => {
+      componentWithTemplate(`<div fxFlex="1 1 0"></div>`);
+
+      fixture.detectChanges();
+      expectNativeEl(fixture).toHaveStyle({
+        'flex': '1 1 0%',
+        'box-sizing': 'border-box',
+      }, styler);
+
+      expectNativeEl(fixture).not.toHaveStyle({
+        'max-width': '*'
+      }, styler);
+    });
+
+    it('should add correct styles for flex-basis 0px input', () => {
+      componentWithTemplate(`<div fxFlex="1 1 0px"></div>`);
+
+      fixture.detectChanges();
+      expectNativeEl(fixture).toHaveStyle({
+        'flex': '1 1 0%',
+        'box-sizing': 'border-box',
+      }, styler);
+
+      expectNativeEl(fixture).not.toHaveStyle({
+        'max-width': '*'
+      }, styler);
+    });
+
+    it('should add correct styles for noshrink with basis', () => {
+      componentWithTemplate(`<div fxFlex="1 0 50%"></div>`);
+
+      fixture.detectChanges();
+      expectNativeEl(fixture).toHaveStyle({
+        'flex': '1 0 50%',
+        'box-sizing': 'border-box',
+      }, styler);
+
+      expectNativeEl(fixture).not.toHaveStyle({
+        'max-width': '*'
+      }, styler);
+    });
+
+    it('should add correct styles for `fxFlex="2%"` usage', () => {
       componentWithTemplate(`<div fxFlex='2%'></div>`);
 
       fixture.detectChanges();
@@ -282,7 +324,9 @@ describe('flex directive', () => {
       if (!(platform.FIREFOX || platform.TRIDENT)) {
         expectNativeEl(fixture).toHaveStyle({
           'box-sizing': 'border-box',
-          'flex': '1 1 calc(30vw - 10px)'
+          'flex-grow': '1',
+          'flex-shrink': '1',
+          'flex-basis': 'calc(30vw - 10px)'
         }, styler);
       }
     });
@@ -295,7 +339,9 @@ describe('flex directive', () => {
         setTimeout(() => {
           expectNativeEl(fixture).toHaveStyle({
             'box-sizing': 'border-box',
-            'flex': '1 1 calc(75% - 10px)' // correct version has whitespace
+            'flex-grow': '1',
+            'flex-shrink': '1',
+            'flex-basis': 'calc(75% - 10px)' // correct version has whitespace
           }, styler);
         });
       }


### PR DESCRIPTION
* Fix for when flex-basis is unitless and 0
* Fix for when no width/height is applied and flex-basis should be
  set
* Fix for IE flex-basis with calc values
* Fix for SSR properties set to 0

Fixes #277
Fixes #280
Fixes #323
Fixes #528
Fixes #534