### PR TITLE
Fix RegExp Issue in older versions of Safari

### DIFF
--- a/src/lib/core/browser-provider.ts
+++ b/src/lib/core/browser-provider.ts
@@ -17,7 +17,12 @@ export function removeStyles(_document: Document, platformId: Object) {
   return () => {
     if (isPlatformBrowser(platformId)) {
       const elements = Array.from(_document.querySelectorAll(`[class*=${CLASS_NAME}]`));
-      const classRegex = new RegExp(/\bflex-layout-.+?\b/, 'g');
+
+      // RegExp constructor should only be used if passing a variable to the constructor.
+      // When using static regular expression it is more performant to use reg exp literal.
+      // This is also needed to provide Safari 9 compatibility, please see
+      // https://stackoverflow.com/questions/37919802 for more discussion.
+      const classRegex = /\bflex-layout-.+?\b/g;
       elements.forEach(el => {
         el.classList.contains(`${CLASS_NAME}ssr`) && el.parentNode ?
           el.parentNode.removeChild(el) : el.className.replace(classRegex, '');


### PR DESCRIPTION
Error is: TypeError: Cannot supply flags when constructing one RegExp from another.  

Discussion here: https://stackoverflow.com/questions/37919802/regex-created-with-constructor-not-working-with-safari