### PR TITLE
fix(fxFlex): fix non-wrapping behavior and default fxFlex value

### DIFF
--- a/src/lib/flex/flex-offset/flex-offset.spec.ts
+++ b/src/lib/flex/flex-offset/flex-offset.spec.ts
@@ -8,7 +8,6 @@
 import {Component, PLATFORM_ID} from '@angular/core';
 import {CommonModule, isPlatformServer} from '@angular/common';
 import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
-import {Platform, PlatformModule} from '@angular/cdk/platform';
 import {DIR_DOCUMENT} from '@angular/cdk/bidi';
 import {SERVER_TOKEN, StyleUtils} from '@angular/flex-layout/core';
 
@@ -25,15 +24,13 @@ describe('flex-offset directive', () => {
   let fixture: ComponentFixture<any>;
   let fakeDocument: {body: {dir?: string}, documentElement: {dir?: string}};
   let styler: StyleUtils;
-  let platform: Platform;
   let platformId: Object;
   let componentWithTemplate = (template: string) => {
     fixture = makeCreateTestComponent(() => TestFlexComponent)(template);
 
-    inject([StyleUtils, Platform, PLATFORM_ID],
-      (_styler: StyleUtils, _platform: Platform, _platformId: Object) => {
+    inject([StyleUtils, PLATFORM_ID],
+      (_styler: StyleUtils, _platformId: Object) => {
       styler = _styler;
-      platform = _platform;
       platformId = _platformId;
     })();
   };
@@ -44,7 +41,7 @@ describe('flex-offset directive', () => {
 
     // Configure testbed to prepare services
     TestBed.configureTestingModule({
-      imports: [CommonModule, FlexLayoutModule, PlatformModule],
+      imports: [CommonModule, FlexLayoutModule],
       declarations: [TestFlexComponent],
       providers: [
         {provide: DIR_DOCUMENT, useValue: fakeDocument},
@@ -61,22 +58,14 @@ describe('flex-offset directive', () => {
 
       let dom = fixture.debugElement.children[0];
       expectEl(dom).toHaveStyle({'margin-left': '32px'}, styler);
-      if (platform.BLINK) {
-        expectEl(dom).toHaveStyle({'flex': '1 1 1e-09px'}, styler);
-      } else if (platform.FIREFOX) {
-        expectEl(dom).toHaveStyle({'flex': '1 1 1e-9px'}, styler);
-      } else if (platform.EDGE || platform.TRIDENT) {
-        expectEl(dom).toHaveStyle({'flex': '1 1 0px'}, styler);
-      } else {
-        expectEl(dom).toHaveStyle({'flex': '1 1 0.000000001px'}, styler);
-      }
+      expectEl(dom).toHaveStyle({'flex': '1 1 0%'}, styler);
     });
 
 
     it('should work with percentage values', () => {
       componentWithTemplate(`<div fxFlexOffset='17' fxFlex='37'></div>`);
       expectNativeEl(fixture).toHaveStyle({
-        'flex': '1 1 37%',
+        'flex': '1 1 100%',
         'box-sizing': 'border-box',
         'margin-left': '17%'
       }, styler);

--- a/src/lib/flex/flex-offset/flex-offset.ts
+++ b/src/lib/flex/flex-offset/flex-offset.ts
@@ -26,7 +26,7 @@ import {
 } from '@angular/flex-layout/core';
 import {Subscription} from 'rxjs/Subscription';
 
-import {LayoutDirective} from '../layout/layout';
+import {Layout, LayoutDirective} from '../layout/layout';
 import {isFlowHorizontal} from '../../utils/layout-validator';
 
 /**
@@ -117,7 +117,7 @@ export class FlexOffsetDirective extends BaseFxDirective implements OnInit, OnCh
   // *********************************************
 
   /** The flex-direction of this element's host container. Defaults to 'row'. */
-  protected _layout = 'row';
+  protected _layout = {direction: 'row', wrap: false};
 
   /**
    * Subscription to the parent flex container's layout changes.
@@ -132,9 +132,9 @@ export class FlexOffsetDirective extends BaseFxDirective implements OnInit, OnCh
   protected watchParentFlow() {
     if (this._container) {
       // Subscribe to layout immediate parent direction changes (if any)
-      this._layoutWatcher = this._container.layout$.subscribe((direction) => {
+      this._layoutWatcher = this._container.layout$.subscribe((layout) => {
         // `direction` === null if parent container does not have a `fxLayout`
-        this._onLayoutChange(direction);
+        this._onLayoutChange(layout);
       });
     }
   }
@@ -143,8 +143,8 @@ export class FlexOffsetDirective extends BaseFxDirective implements OnInit, OnCh
    * Caches the parent container's 'flex-direction' and updates the element's style.
    * Used as a handler for layout change events from the parent flex container.
    */
-  protected _onLayoutChange(direction?: string) {
-    this._layout = direction || this._layout || 'row';
+  protected _onLayoutChange(layout?: Layout) {
+    this._layout = layout || this._layout || {direction: 'row', wrap: false};
     this._updateWithValue();
   }
 

--- a/src/lib/flex/flex/flex.spec.ts
+++ b/src/lib/flex/flex/flex.spec.ts
@@ -72,16 +72,7 @@ describe('flex directive', () => {
 
       let dom = fixture.debugElement.children[0];
       expectEl(dom).toHaveStyle({'box-sizing': 'border-box'}, styler);
-
-      if (platform.BLINK) {
-        expectEl(dom).toHaveStyle({'flex': '1 1 1e-09px'}, styler);
-      } else if (platform.FIREFOX) {
-        expectEl(dom).toHaveStyle({'flex': '1 1 1e-9px'}, styler);
-      } else if (platform.EDGE || platform.TRIDENT) {
-        expectEl(dom).toHaveStyle({'flex': '1 1 0px'}, styler);
-      } else {
-        expectEl(dom).toHaveStyle({'flex': '1 1 0.000000001px'}, styler);
-      }
+      expectEl(dom).toHaveStyle({'flex': '1 1 0%'}, styler);
     });
 
     it('should apply `fxGrow` value to flex-grow when used default `fxFlex`', () => {
@@ -91,16 +82,7 @@ describe('flex directive', () => {
       let dom = fixture.debugElement.children[0];
 
       expectEl(dom).toHaveStyle({'box-sizing': 'border-box'}, styler);
-
-      if (platform.BLINK) {
-        expectEl(dom).toHaveStyle({'flex': '10 1 1e-09px'}, styler);
-      } else if (platform.FIREFOX) {
-        expectEl(dom).toHaveStyle({'flex': '10 1 1e-9px'}, styler);
-      } else if (platform.EDGE || platform.TRIDENT) {
-        expectEl(dom).toHaveStyle({'flex': '10 1 0px'}, styler);
-      } else {
-        expectEl(dom).toHaveStyle({'flex': '10 1 0.000000001px'}, styler);
-      }
+      expectEl(dom).toHaveStyle({'flex': '10 1 0%'}, styler);
     });
 
     it('should apply `fxShrink` value to flex-shrink when used default `fxFlex`', () => {
@@ -110,16 +92,7 @@ describe('flex directive', () => {
       let dom = fixture.debugElement.children[0];
 
       expectEl(dom).toHaveStyle({'box-sizing': 'border-box'}, styler);
-
-      if (platform.BLINK) {
-        expectEl(dom).toHaveStyle({'flex': '1 10 1e-09px'}, styler);
-      } else if (platform.FIREFOX) {
-        expectEl(dom).toHaveStyle({'flex': '1 10 1e-9px'}, styler);
-      } else if (platform.EDGE || platform.TRIDENT) {
-        expectEl(dom).toHaveStyle({'flex': '1 10 0px'}, styler);
-      } else {
-        expectEl(dom).toHaveStyle({'flex': '1 10 0.000000001px'}, styler);
-      }
+      expectEl(dom).toHaveStyle({'flex': '1 10 0%'}, styler);
     });
 
     it('should apply both `fxGrow` and `fxShrink` when used with default fxFlex', () => {
@@ -128,16 +101,7 @@ describe('flex directive', () => {
 
       let dom = fixture.debugElement.children[0];
       expectEl(dom).toHaveStyle({'box-sizing': 'border-box'}, styler);
-
-      if (platform.BLINK) {
-        expectEl(dom).toHaveStyle({'flex': '4 5 1e-09px'}, styler);
-      } else if (platform.FIREFOX) {
-        expectEl(dom).toHaveStyle({'flex': '4 5 1e-9px'}, styler);
-      } else if (platform.EDGE || platform.TRIDENT) {
-        expectEl(dom).toHaveStyle({'flex': '4 5 0px'}, styler);
-      } else {
-        expectEl(dom).toHaveStyle({'flex': '4 5 0.000000001px'}, styler);
-      }
+      expectEl(dom).toHaveStyle({'flex': '4 5 0%'}, styler);
     });
 
     it('should add correct styles for flex-basis unitless 0 input', () => {
@@ -188,7 +152,7 @@ describe('flex directive', () => {
       fixture.detectChanges();
       expectNativeEl(fixture).toHaveStyle({
         'max-width': '2%',
-        'flex': '1 1 2%',
+        'flex': '1 1 100%',
         'box-sizing': 'border-box',
       }, styler);
     });
@@ -196,7 +160,7 @@ describe('flex directive', () => {
     it('should work with percentage values', () => {
       componentWithTemplate(`<div fxFlex='37%'></div>`);
       expectNativeEl(fixture).toHaveStyle({
-        'flex': '1 1 37%',
+        'flex': '1 1 100%',
         'max-width': '37%',
         'box-sizing': 'border-box',
       }, styler);
@@ -470,7 +434,7 @@ describe('flex directive', () => {
         fixture.detectChanges();
         expectEl(queryFor(fixture, '[fxFlex]')[0])
           .toHaveStyle({
-            'flex': '1 1 37%',
+            'flex': '1 1 100%',
             'max-height': '37%',
           }, styler);
       });
@@ -478,7 +442,7 @@ describe('flex directive', () => {
       it('should set max-width for `fxFlex="<%val>"`', () => {
         componentWithTemplate(`<div fxFlex='37%'></div>`);
         expectNativeEl(fixture).toHaveStyle({
-          'flex': '1 1 37%',
+          'flex': '1 1 100%',
           'max-width': '37%',
         }, styler);
       });
@@ -486,7 +450,7 @@ describe('flex directive', () => {
       it('should set max-width for `fxFlex="2%"` usage', () => {
         componentWithTemplate(`<div fxFlex='2%'></div>`);
         expectNativeEl(fixture).toHaveStyle({
-          'flex': '1 1 2%',
+          'flex': '1 1 100%',
           'max-width': '2%',
         }, styler);
       });
@@ -508,7 +472,7 @@ describe('flex directive', () => {
       fixture.detectChanges();
 
       expectNativeEl(fixture).toHaveStyle({
-        'flex': '1 1 50%',
+        'flex': '1 1 100%',
         'max-width': '50%'
       }, styler);
 
@@ -516,7 +480,7 @@ describe('flex directive', () => {
       fixture.detectChanges();
 
       expectNativeEl(fixture).toHaveStyle({
-        'flex': '1 1 33%',
+        'flex': '1 1 100%',
         'max-width': '33%'
       }, styler);
     });
@@ -544,9 +508,9 @@ describe('flex directive', () => {
       fixture.detectChanges();
 
       nodes = queryFor(fixture, '[fxFlex]');
-      expectEl(nodes[0]).toHaveStyle({'flex': '1 1 50%', 'max-height': '50%'}, styler);
-      expectEl(nodes[1]).toHaveStyle({'flex': '1 1 24.4%', 'max-height': '24.4%'}, styler);
-      expectEl(nodes[2]).toHaveStyle({'flex': '1 1 25.6%', 'max-height': '25.6%'}, styler);
+      expectEl(nodes[0]).toHaveStyle({'flex': '1 1 100%', 'max-height': '50%'}, styler);
+      expectEl(nodes[1]).toHaveStyle({'flex': '1 1 100%', 'max-height': '24.4%'}, styler);
+      expectEl(nodes[2]).toHaveStyle({'flex': '1 1 100%', 'max-height': '25.6%'}, styler);
 
       matchMedia.activate('sm');
       fixture.detectChanges();
@@ -595,9 +559,9 @@ describe('flex directive', () => {
       fixture.detectChanges();
       nodes = queryFor(fixture, '[fxFlex]');
 
-      expectEl(nodes[0]).toHaveStyle({'flex': '1 1 50%', 'max-height': '50%'}, styler);
-      expectEl(nodes[1]).toHaveStyle({'flex': '1 1 24.4%', 'max-height': '24.4%'}, styler);
-      expectEl(nodes[2]).toHaveStyle({'flex': '1 1 25.6%', 'max-height': '25.6%'}, styler);
+      expectEl(nodes[0]).toHaveStyle({'flex': '1 1 100%', 'max-height': '50%'}, styler);
+      expectEl(nodes[1]).toHaveStyle({'flex': '1 1 100%', 'max-height': '24.4%'}, styler);
+      expectEl(nodes[2]).toHaveStyle({'flex': '1 1 100%', 'max-height': '25.6%'}, styler);
     });
 
     it('should fallback to the default layout from lt-md selectors', () => {
@@ -619,7 +583,7 @@ describe('flex directive', () => {
       nodes = queryFor(fixture, '[fxFlex]');
 
       expectEl(nodes[0]).toHaveStyle({
-        'flex': '1 1 50%',
+        'flex': '1 1 100%',
         'max-height': '50%'
       }, styler);
 

--- a/src/lib/flex/layout-align/layout-align.ts
+++ b/src/lib/flex/layout-align/layout-align.ts
@@ -20,7 +20,7 @@ import {BaseFxDirective, MediaChange, MediaMonitor, StyleUtils} from '@angular/f
 import {Subscription} from 'rxjs/Subscription';
 
 import {extendObject} from '../../utils/object-extend';
-import {LayoutDirective} from '../layout/layout';
+import {Layout, LayoutDirective} from '../layout/layout';
 import {LAYOUT_VALUES, isFlowHorizontal} from '../../utils/layout-validator';
 
 /**
@@ -124,8 +124,8 @@ export class LayoutAlignDirective extends BaseFxDirective implements OnInit, OnC
   /**
    * Cache the parent container 'flex-direction' and update the 'flex' styles
    */
-  protected _onLayoutChange(direction) {
-    this._layout = (direction || '').toLowerCase();
+  protected _onLayoutChange(layout: Layout) {
+    this._layout = (layout.direction || '').toLowerCase();
     if (!LAYOUT_VALUES.find(x => x === this._layout)) {
       this._layout = 'row';
     }

--- a/src/lib/flex/layout-gap/layout-gap.ts
+++ b/src/lib/flex/layout-gap/layout-gap.ts
@@ -21,7 +21,7 @@ import {Directionality} from '@angular/cdk/bidi';
 import {BaseFxDirective, MediaChange, MediaMonitor, StyleUtils} from '@angular/flex-layout/core';
 import {Subscription} from 'rxjs/Subscription';
 
-import {LayoutDirective} from '../layout/layout';
+import {Layout, LayoutDirective} from '../layout/layout';
 import {LAYOUT_VALUES} from '../../utils/layout-validator';
 
 /**
@@ -143,8 +143,8 @@ export class LayoutGapDirective extends BaseFxDirective
   /**
    * Cache the parent container 'flex-direction' and update the 'margin' styles
    */
-  protected _onLayoutChange(direction) {
-    this._layout = (direction || '').toLowerCase();
+  protected _onLayoutChange(layout: Layout) {
+    this._layout = (layout.direction || '').toLowerCase();
     if (!LAYOUT_VALUES.find(x => x === this._layout)) {
       this._layout = 'row';
     }

--- a/src/lib/flex/layout/layout.ts
+++ b/src/lib/flex/layout/layout.ts
@@ -20,6 +20,11 @@ import {ReplaySubject} from 'rxjs/ReplaySubject';
 
 import {buildLayoutCSS} from '../../utils/layout-validator';
 
+export type Layout = {
+  direction: string;
+  wrap: boolean;
+};
+
 /**
  * 'layout' flexbox styling directive
  * Defines the positioning flow direction for the child elements: row or column
@@ -39,13 +44,13 @@ export class LayoutDirective extends BaseFxDirective implements OnInit, OnChange
    * Create Observable for nested/child 'flex' directives. This allows
    * child flex directives to subscribe/listen for flexbox direction changes.
    */
-  protected _announcer: ReplaySubject<string>;
+  protected _announcer: ReplaySubject<Layout>;
 
   /**
    * Publish observer to enabled nested, dependent directives to listen
    * to parent 'layout' direction changes
    */
-  layout$: Observable<string>;
+  layout$: Observable<Layout>;
 
   /* tslint:disable */
   @Input('fxLayout')       set layout(val)     { this._cacheInput('layout', val); };
@@ -73,7 +78,7 @@ export class LayoutDirective extends BaseFxDirective implements OnInit, OnChange
               elRef: ElementRef,
               styleUtils: StyleUtils) {
     super(monitor, elRef, styleUtils);
-    this._announcer = new ReplaySubject<string>(1);
+    this._announcer = new ReplaySubject<Layout>(1);
     this.layout$ = this._announcer.asObservable();
   }
 
@@ -122,7 +127,10 @@ export class LayoutDirective extends BaseFxDirective implements OnInit, OnChange
     let css = buildLayoutCSS(!!value ? value : '');
 
     this._applyStyleToElement(css);
-    this._announcer.next(css['flex-direction']);
+    this._announcer.next({
+      direction: css['flex-direction'],
+      wrap: !!css['flex-wrap'] && css['flex-wrap'] !== 'nowrap'
+    });
   }
 
 }


### PR DESCRIPTION
* Set the non-wrapping behavior for fxFlex to be 100% instead of
  the width/height value
* Set the default value for fxFlex to auto for column and 0% for
  row instead of 1e-9px

Fixes #666 
Fixes #481 
Fixes #544 
Fixes #338 
Fixes #314