### PR TITLE
test: use karma spec reporter to show karma results instead of dots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11614,6 +11614,23 @@
         "graceful-fs": "4.1.11"
       }
     },
+    "karma-spec-reporter": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/karma-spec-reporter/-/karma-spec-reporter-0.0.32.tgz",
+      "integrity": "sha1-LpxyB+pyZ3EmAln4K+y1QyCeRAo=",
+      "dev": true,
+      "requires": {
+        "colors": "1.2.1"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
+          "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
+          "dev": true
+        }
+      }
+    },
     "keyv": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "karma-firefox-launcher": "^1.0.1",
     "karma-jasmine": "^1.1.1",
     "karma-sauce-launcher": "^1.2.0",
+    "karma-spec-reporter": "^0.0.32",
     "karma-sourcemap-loader": "^0.3.7",
     "madge": "^3.0.0",
     "magic-string": "^0.22.4",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -13,7 +13,8 @@ module.exports = (config) => {
       require('karma-chrome-launcher'),
       require('karma-firefox-launcher'),
       require('karma-sourcemap-loader'),
-      require('karma-coverage')
+      require('karma-coverage'),
+      require('karma-spec-reporter')
     ],
     files: [
       {pattern: 'node_modules/core-js/client/core.js', included: true, watched: false},
@@ -49,13 +50,17 @@ module.exports = (config) => {
       'dist/packages/**/*.js': ['sourcemap']
     },
 
-    reporters: ['dots'],
+    reporters: ['spec'],
     autoWatch: false,
 
     coverageReporter: {
       type : 'json-summary',
       dir : 'dist/coverage/',
       subdir: '.'
+    },
+
+    specReporter: {
+      maxLogLines: 1,
     },
 
     sauceLabs: {
@@ -78,14 +83,15 @@ module.exports = (config) => {
       project: 'flex-layout',
       startTunnel: false,
       retryLimit: 1,
-      timeout: 600,
+      timeout: 1800,
       pollingTimeout: 20000,
       video: false
     },
 
-    browserDisconnectTimeout: 20000,
-    browserNoActivityTimeout: 240000,
-    captureTimeout: 120000,
+    browserDisconnectTimeout: 180000,
+    browserDisconnectTolerance: 3,
+    browserNoActivityTimeout: 300000,
+    captureTimeout: 180000,
     browsers: ['ChromeHeadlessCISandbox'],
 
     singleRun: false,

--- a/tools/gulp/tasks/unit-test.ts
+++ b/tools/gulp/tasks/unit-test.ts
@@ -44,7 +44,7 @@ task('test:single-run', [':test:build'], (done: () => void) => {
  * This task should be used when running unit tests locally.
  */
 task('test', [':test:build'], () => {
-  let patternRoot = join(packagesDir, '**/*');
+  let patternRoot = join(packagesDir, 'lib', '**/*');
   // Load karma not outside. Karma pollutes Promise with a different implementation.
   let karma = require('karma');
 


### PR DESCRIPTION
* Fix RangeError in Gulp caused by watching the apps directory in
  addition to the library source