### PR TITLE
test(grid-gap): fix chrome 66 naming issue

### DIFF
--- a/src/lib/grid/gap/gap.spec.ts
+++ b/src/lib/grid/gap/gap.spec.ts
@@ -104,6 +104,11 @@ describe('grid gap directive', () => {
           'grid-row-gap': '10px',
           'grid-column-gap': '15px',
         }, styler);
+      } else if (platform.BLINK) {
+        expectNativeEl(fixture).toHaveStyle({
+          'display': 'grid',
+          'gap': '10px 15px',
+        }, styler);
       } else {
         expectNativeEl(fixture).toHaveStyle({
           'display': 'grid',


### PR DESCRIPTION
In the Chrome, [grid-gap becomes gap since v66](https://www.chromestatus.com/feature/4986266210795520), so need to fix the gap's unit test issue to pass the unit tests