### PR TITLE
chore: remove Angular v6 instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,6 @@ different layouts, sizing, visibilities for different viewport sizes and display
 
 ---
 
-### Angular 6
-
-When upgrading your application to use Angular 6 and RxJS 6, you must install release 6.x of Flex Layout:
-
-```shell
-npm i --save @angular/flex-layout@6.0.0-beta.15
-```
-
----
-
 ### Quick Links
 
 *  [ChangeLog](https://github.com/angular/flex-layout/blob/master/CHANGELOG.md)


### PR DESCRIPTION
* The latest release on NPM points to the 6.x release, so these instructions are no longer necessary