### PR TITLE
fix(fxLayoutAlign): add space-between and space-around options

### DIFF
--- a/src/lib/flex/layout-align/layout-align.spec.ts
+++ b/src/lib/flex/layout-align/layout-align.spec.ts
@@ -5,16 +5,22 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { Platform } from '@angular/cdk/platform';
-import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
-import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
-import { MatchMedia, MockMatchMedia, MockMatchMediaProvider, SERVER_TOKEN, StyleUtils } from '@angular/flex-layout/core';
-import { FlexLayoutModule } from '../../module';
-import { extendObject } from '../../utils/object-extend';
-import { customMatchers } from '../../utils/testing/custom-matchers';
-import { expectNativeEl, makeCreateTestComponent } from '../../utils/testing/helpers';
+import {Component, OnInit} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
+import {Platform} from '@angular/cdk/platform';
+import {
+  MatchMedia,
+  MockMatchMedia,
+  MockMatchMediaProvider,
+  SERVER_TOKEN,
+  StyleUtils,
+} from '@angular/flex-layout/core';
 
+import {FlexLayoutModule} from '../../module';
+import {extendObject} from '../../utils/object-extend';
+import {customMatchers} from '../../utils/testing/custom-matchers';
+import {makeCreateTestComponent, expectNativeEl} from '../../utils/testing/helpers';
 
 describe('layout-align directive', () => {
   let fixture: ComponentFixture<any>;

--- a/src/lib/flex/layout-align/layout-align.spec.ts
+++ b/src/lib/flex/layout-align/layout-align.spec.ts
@@ -5,22 +5,16 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Component, OnInit} from '@angular/core';
-import {CommonModule} from '@angular/common';
-import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
-import {Platform} from '@angular/cdk/platform';
-import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
-  SERVER_TOKEN,
-  StyleUtils,
-} from '@angular/flex-layout/core';
+import { Platform } from '@angular/cdk/platform';
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { MatchMedia, MockMatchMedia, MockMatchMediaProvider, SERVER_TOKEN, StyleUtils } from '@angular/flex-layout/core';
+import { FlexLayoutModule } from '../../module';
+import { extendObject } from '../../utils/object-extend';
+import { customMatchers } from '../../utils/testing/custom-matchers';
+import { expectNativeEl, makeCreateTestComponent } from '../../utils/testing/helpers';
 
-import {FlexLayoutModule} from '../../module';
-import {extendObject} from '../../utils/object-extend';
-import {customMatchers} from '../../utils/testing/custom-matchers';
-import {makeCreateTestComponent, expectNativeEl} from '../../utils/testing/helpers';
 
 describe('layout-align directive', () => {
   let fixture: ComponentFixture<any>;

--- a/src/lib/flex/layout-align/layout-align.spec.ts
+++ b/src/lib/flex/layout-align/layout-align.spec.ts
@@ -154,14 +154,6 @@ describe('layout-align directive', () => {
           styler
         );
       });
-      it('should add correct styles for `fxLayoutAlign="start baseline"` usage', () => {
-        createTestComponent(`<div fxLayoutAlign='start baseline'></div>`);
-        expectNativeEl(fixture)
-            .toHaveStyle({
-              'justify-content': 'flex-start',
-              'align-items': 'baseline'
-            }, styler);
-      });
       it('should add correct styles for `fxLayoutAlign="start center"` usage', () => {
         createTestComponent(`<div fxLayoutAlign='start center'></div>`);
         expectNativeEl(fixture).toHaveStyle(
@@ -179,6 +171,33 @@ describe('layout-align directive', () => {
               'align-content': 'flex-end'
             }), styler
         );
+      });
+      it('should add correct styles for `fxLayoutAlign="start space-between"` usage', () => {
+        createTestComponent(`<div fxLayoutAlign='start space-between'></div>`);
+        expectNativeEl(fixture).toHaveStyle(
+            extendObject(MAINAXIS_DEFAULTS, {
+              'align-items': 'stretch',
+              'align-content': 'space-between'
+            }), styler
+        );
+      });
+      it('should add correct styles for `fxLayoutAlign="start space-around"` usage', () => {
+        createTestComponent(`<div fxLayoutAlign='start space-around'></div>`);
+        expectNativeEl(fixture).toHaveStyle(
+            extendObject(MAINAXIS_DEFAULTS, {
+              'align-items': 'stretch',
+              'align-content': 'space-around'
+            }), styler
+        );
+      });
+      it('should add correct styles for `fxLayoutAlign="start baseline"` usage', () => {
+        createTestComponent(`<div fxLayoutAlign='start baseline'></div>`);
+        expectNativeEl(fixture)
+            .toHaveStyle({
+              'justify-content': 'flex-start',
+              'align-items': 'baseline',
+              'align-content': 'stretch'
+            }, styler);
       });
       it('should add ignore invalid cross-axis values', () => {
         createTestComponent(`<div fxLayoutAlign='start invalid'></div>`);

--- a/src/lib/flex/layout-align/layout-align.ts
+++ b/src/lib/flex/layout-align/layout-align.ts
@@ -5,23 +5,14 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {
-  Directive,
-  ElementRef,
-  Input,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Optional,
-  SimpleChanges,
-  Self,
-} from '@angular/core';
-import {BaseDirective, MediaChange, MediaMonitor, StyleUtils} from '@angular/flex-layout/core';
-import {Subscription} from 'rxjs';
+import { Directive, ElementRef, Input, OnChanges, OnDestroy, OnInit, Optional, Self, SimpleChanges } from '@angular/core';
+import { BaseDirective, MediaChange, MediaMonitor, StyleUtils } from '@angular/flex-layout/core';
+import { Subscription } from 'rxjs';
+import { isFlowHorizontal, LAYOUT_VALUES } from '../../utils/layout-validator';
+import { extendObject } from '../../utils/object-extend';
+import { Layout, LayoutDirective } from '../layout/layout';
 
-import {extendObject} from '../../utils/object-extend';
-import {Layout, LayoutDirective} from '../layout/layout';
-import {LAYOUT_VALUES, isFlowHorizontal} from '../../utils/layout-validator';
+
 
 /**
  * 'layout-align' flexbox styling directive

--- a/src/lib/flex/layout-align/layout-align.ts
+++ b/src/lib/flex/layout-align/layout-align.ts
@@ -5,14 +5,23 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { Directive, ElementRef, Input, OnChanges, OnDestroy, OnInit, Optional, Self, SimpleChanges } from '@angular/core';
-import { BaseDirective, MediaChange, MediaMonitor, StyleUtils } from '@angular/flex-layout/core';
-import { Subscription } from 'rxjs';
-import { isFlowHorizontal, LAYOUT_VALUES } from '../../utils/layout-validator';
-import { extendObject } from '../../utils/object-extend';
-import { Layout, LayoutDirective } from '../layout/layout';
+import {
+  Directive,
+  ElementRef,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Optional,
+  SimpleChanges,
+  Self,
+} from '@angular/core';
+import {BaseDirective, MediaChange, MediaMonitor, StyleUtils} from '@angular/flex-layout/core';
+import {Subscription} from 'rxjs';
 
-
+import {extendObject} from '../../utils/object-extend';
+import {Layout, LayoutDirective} from '../layout/layout';
+import {LAYOUT_VALUES, isFlowHorizontal} from '../../utils/layout-validator';
 
 /**
  * 'layout-align' flexbox styling directive

--- a/src/lib/flex/layout-align/layout-align.ts
+++ b/src/lib/flex/layout-align/layout-align.ts
@@ -170,15 +170,24 @@ export class LayoutAlignDirective extends BaseDirective implements OnInit, OnCha
       case 'flex-start':
         css['align-items'] = css['align-content'] = 'flex-start';
         break;
-      case 'baseline':
-        css['align-items'] = 'baseline';
-        break;
       case 'center':
         css['align-items'] = css['align-content'] = 'center';
         break;
       case 'end':
       case 'flex-end':
         css['align-items'] = css['align-content'] = 'flex-end';
+        break;
+      case 'space-between':
+        css['align-content'] = 'space-between';
+        css['align-items'] = 'stretch';
+        break;
+      case 'space-around':
+        css['align-content'] = 'space-around';
+        css['align-items'] = 'stretch';
+        break;
+      case 'baseline':
+        css['align-content'] = 'stretch';
+        css['align-items'] = 'baseline';
         break;
       case 'stretch':
       default : // 'stretch'


### PR DESCRIPTION
The actual implementation doesn't allow the 'space-between' and 'space-around' flex
align-content options (cross-axis). fxLayoutAlign should cover all of them.

Closes #841