### PR TITLE
fix(module): do not require breakpoints in withConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules
 # IDEs
 /.idea
 /.vscode
+/*.iml
 
 # misc
 .DS_Store

--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -41,28 +41,18 @@ export class FlexLayoutModule {
    * which sets the corresponding tokens accordingly
    */
   static withConfig(configOptions: LayoutConfigOptions,
-                    breakpoints?: BreakPoint|BreakPoint[]): ModuleWithProviders {
+                    breakpoints: BreakPoint|BreakPoint[] = []): ModuleWithProviders {
     return {
       ngModule: FlexLayoutModule,
-      providers: Array.isArray(breakpoints) ?
-        configOptions.serverLoaded ?
-          [
-            {provide: LAYOUT_CONFIG, useValue: configOptions},
-            {provide: BREAKPOINT, useValue: breakpoints, multi: true},
-            {provide: SERVER_TOKEN, useValue: true},
-          ] : [
-            {provide: LAYOUT_CONFIG, useValue: configOptions},
-            {provide: BREAKPOINT, useValue: breakpoints, multi: true},
-          ]
-        :
-        configOptions.serverLoaded ?
-          [
-            {provide: LAYOUT_CONFIG, useValue: configOptions},
-            {provide: SERVER_TOKEN, useValue: true},
-          ] :
-          [
-            {provide: LAYOUT_CONFIG, useValue: configOptions},
-          ]
+      providers: configOptions.serverLoaded ?
+        [
+          {provide: LAYOUT_CONFIG, useValue: configOptions},
+          {provide: BREAKPOINT, useValue: breakpoints, multi: true},
+          {provide: SERVER_TOKEN, useValue: true},
+        ] : [
+          {provide: LAYOUT_CONFIG, useValue: configOptions},
+          {provide: BREAKPOINT, useValue: breakpoints, multi: true},
+        ]
     };
   }
 


### PR DESCRIPTION
I have fixed issue #846 that causes runtime errors when using `withConfig` without providing `breakpoints` parameter.

There is probably a better way to fix this by locating the root cause but this solution should work for now since it is a workaround I use in my application.