### PR TITLE
refactor: migrate ObservableMedia to MediaObserver

### DIFF
--- a/src/lib/core/base/base.ts
+++ b/src/lib/core/base/base.ts
@@ -25,9 +25,6 @@ import {StyleBuilder} from '../style-builder/style-builder';
 
 /** Abstract base class for the Layout API styling directives. */
 export abstract class BaseDirective implements OnDestroy, OnChanges {
-  get hasMediaQueryListener() {
-    return !!this._mqActivation;
-  }
 
   /**
    * Imperatively determine the current activated [input] value;
@@ -52,7 +49,7 @@ export abstract class BaseDirective implements OnDestroy, OnChanges {
       previousVal = this._inputMap[key];
       this._inputMap[key] = value;
     }
-    let change = new SimpleChange(previousVal, value, false);
+    const change = new SimpleChange(previousVal, value, false);
 
     this.ngOnChanges({[key]: change} as SimpleChanges);
   }
@@ -136,8 +133,8 @@ export abstract class BaseDirective implements OnDestroy, OnChanges {
    * If not, use the fallback value!
    */
   protected _getDefaultVal(key: string, fallbackVal: any): string | boolean {
-    let val = this._queryInput(key);
-    let hasDefaultVal = (val !== undefined && val !== null);
+    const val = this._queryInput(key);
+    const hasDefaultVal = (val !== undefined && val !== null);
     return (hasDefaultVal && val !== '') ? val : fallbackVal;
   }
 
@@ -164,20 +161,19 @@ export abstract class BaseDirective implements OnDestroy, OnChanges {
    * And optionally add the flow value to element's inline style.
    */
   protected _getFlexFlowDirection(target: HTMLElement, addIfMissing = false): string {
-    let value = 'row';
-    let hasInlineValue = '';
-
     if (target) {
-      [value, hasInlineValue] = this._styler.getFlowDirection(target);
+      let [value, hasInlineValue] = this._styler.getFlowDirection(target);
 
       if (!hasInlineValue && addIfMissing) {
         const style = buildLayoutCSS(value);
         const elements = [target];
         this._styler.applyStyleToElements(style, elements);
       }
+
+      return value.trim();
     }
 
-    return value.trim() || 'row';
+    return 'row';
   }
 
   /** Applies styles given via string pair or object map to the directive element */
@@ -234,11 +230,6 @@ export abstract class BaseDirective implements OnDestroy, OnChanges {
       buffer[i] = obj[i];
     }
     return buffer;
-  }
-
-  /** Fast validator for presence of attribute on the host element */
-  protected hasKeyValue(key: string) {
-    return this._mqActivation!.hasKeyValue(key);
   }
 
   protected get hasInitialized() {

--- a/src/lib/core/match-media/match-media.ts
+++ b/src/lib/core/match-media/match-media.ts
@@ -21,23 +21,20 @@ import {MediaChange} from '../media-change';
  */
 @Injectable({providedIn: 'root'})
 export class MatchMedia {
-  protected _registry: Map<string, MediaQueryList>;
-  protected _source: BehaviorSubject<MediaChange>;
-  protected _observable$: Observable<MediaChange>;
+  protected _registry: Map<string, MediaQueryList> = new Map();
+  protected _source: BehaviorSubject<MediaChange> = new BehaviorSubject(new MediaChange(true));
+  protected _observable$: Observable<MediaChange> = this._source.asObservable();
 
   constructor(protected _zone: NgZone,
               @Inject(PLATFORM_ID) protected _platformId: Object,
               @Inject(DOCUMENT) protected _document: any) {
-    this._registry = new Map<string, MediaQueryList>();
-    this._source = new BehaviorSubject<MediaChange>(new MediaChange(true));
-    this._observable$ = this._source.asObservable();
   }
 
   /**
    * For the specified mediaQuery?
    */
   isActive(mediaQuery: string): boolean {
-    let mql = this._registry.get(mediaQuery);
+    const mql = this._registry.get(mediaQuery);
     return !!mql ? mql.matches : false;
   }
 
@@ -55,9 +52,7 @@ export class MatchMedia {
     }
 
     return this._observable$.pipe(
-      filter((change: MediaChange) => {
-        return mediaQuery ? (change.mediaQuery === mediaQuery) : true;
-      })
+      filter(change => (mediaQuery ? (change.mediaQuery === mediaQuery) : true))
     );
   }
 
@@ -66,31 +61,29 @@ export class MatchMedia {
    * mediaQuery. Each listener emits specific MediaChange data to observers
    */
   registerQuery(mediaQuery: string | string[]) {
-    let list = normalizeQuery(mediaQuery);
+    const list = Array.isArray(mediaQuery) ? Array.from(new Set(mediaQuery)) : [mediaQuery];
 
     if (list.length > 0) {
-      this._prepareQueryCSS(list, this._document);
-
-      list.forEach(query => {
-        let mql = this._registry.get(query);
-        let onMQLEvent = (e: MediaQueryListEvent) => {
-          this._zone.run(() => {
-            let change = new MediaChange(e.matches, query);
-            this._source.next(change);
-          });
-        };
-
-        if (!mql) {
-          mql = this._buildMQL(query);
-          mql.addListener(onMQLEvent);
-          this._registry.set(query, mql);
-        }
-
-        if (mql.matches) {
-          onMQLEvent(mql as unknown as MediaQueryListEvent);
-        }
-      });
+      buildQueryCss(list, this._document);
     }
+
+    list.forEach(query => {
+      const onMQLEvent = (e: MediaQueryListEvent) => {
+        this._zone.run(() => this._source.next(new MediaChange(e.matches, query)));
+      };
+
+      let mql = this._registry.get(query);
+
+      if (!mql) {
+        mql = this._buildMQL(query);
+        mql.addListener(onMQLEvent);
+        this._registry.set(query, mql);
+      }
+
+      if (mql.matches) {
+        onMQLEvent(mql as unknown as MediaQueryListEvent);
+      }
+    });
   }
 
   /**
@@ -98,55 +91,7 @@ export class MatchMedia {
    * supports 0..n listeners for activation/deactivation
    */
   protected _buildMQL(query: string): MediaQueryList {
-    let canListen = isPlatformBrowser(this._platformId) &&
-      !!(<any>window).matchMedia('all').addListener;
-
-    return canListen ? (<any>window).matchMedia(query) : {
-      matches: query === 'all' || query === '',
-      media: query,
-      addListener: () => {
-      },
-      removeListener: () => {
-      }
-    } as unknown as MediaQueryList;
-  }
-
-  /**
-   * For Webkit engines that only trigger the MediaQueryList Listener
-   * when there is at least one CSS selector for the respective media query.
-   *
-   * @param mediaQueries
-   * @param _document
-   */
-  protected _prepareQueryCSS(mediaQueries: string[], _document: Document) {
-    const list: string[] = mediaQueries.filter(it => !ALL_STYLES[it]);
-    if (list.length > 0) {
-      const query = list.join(', ');
-
-      try {
-        let styleEl = _document.createElement('style');
-
-        styleEl.setAttribute('type', 'text/css');
-        if (!(styleEl as any).styleSheet) {
-          let cssText = `
-/*
-  @angular/flex-layout - workaround for possible browser quirk with mediaQuery listeners
-  see http://bit.ly/2sd4HMP
-*/
-@media ${query} {.fx-query-test{ }}
-` ;
-          styleEl.appendChild(_document.createTextNode(cssText));
-        }
-
-        _document.head!.appendChild(styleEl);
-
-        // Store in private global registry
-        list.forEach(mq => ALL_STYLES[mq] = styleEl);
-
-      } catch (e) {
-        console.error(e);
-      }
-    }
+    return constructMql(query, isPlatformBrowser(this._platformId));
   }
 }
 
@@ -157,20 +102,52 @@ export class MatchMedia {
 const ALL_STYLES: {[key: string]: any} = {};
 
 /**
- * Always convert to unique list of queries; for iteration in ::registerQuery()
+ * For Webkit engines that only trigger the MediaQueryList Listener
+ * when there is at least one CSS selector for the respective media query.
+ *
+ * @param mediaQueries
+ * @param _document
  */
-function normalizeQuery(mediaQuery: string | string[]): string[] {
-  return (typeof mediaQuery === 'undefined') ? [] :
-      (typeof mediaQuery === 'string') ? [mediaQuery] : unique(mediaQuery as string[]);
+function buildQueryCss(mediaQueries: string[], _document: Document) {
+  const list = mediaQueries.filter(it => !ALL_STYLES[it]);
+  if (list.length > 0) {
+    const query = list.join(', ');
+
+    try {
+      const styleEl = _document.createElement('style');
+
+      styleEl.setAttribute('type', 'text/css');
+      if (!(styleEl as any).styleSheet) {
+        const cssText = `
+/*
+  @angular/flex-layout - workaround for possible browser quirk with mediaQuery listeners
+  see http://bit.ly/2sd4HMP
+*/
+@media ${query} {.fx-query-test{ }}
+` ;
+        styleEl.appendChild(_document.createTextNode(cssText));
+      }
+
+      _document.head!.appendChild(styleEl);
+
+      // Store in private global registry
+      list.forEach(mq => ALL_STYLES[mq] = styleEl);
+
+    } catch (e) {
+      console.error(e);
+    }
+  }
 }
 
-/**
- * Filter duplicate mediaQueries in the list
- */
-function unique(list: string[]): string[] {
-  let seen: {[key: string]: boolean} = {};
-  return list.filter(item => {
-    return seen.hasOwnProperty(item) ? false : (seen[item] = true);
-  });
-}
+function constructMql(query: string, isBrowser: boolean): MediaQueryList {
+  const canListen = isBrowser && !!(<any>window).matchMedia('all').addListener;
 
+  return canListen ? (<any>window).matchMedia(query) : {
+    matches: query === 'all' || query === '',
+    media: query,
+    addListener: () => {
+    },
+    removeListener: () => {
+    }
+  } as unknown as MediaQueryList;
+}

--- a/src/lib/core/match-media/mock/mock-match-media.ts
+++ b/src/lib/core/match-media/mock/mock-match-media.ts
@@ -35,7 +35,6 @@ export class MockMatchMedia extends MatchMedia {
               @Inject(DOCUMENT) _document: any,
               private _breakpoints: BreakPointRegistry) {
     super(_zone, _platformId, _document);
-    this._actives = [];
   }
 
   /** Easy method to clear all listeners for all mediaQueries */
@@ -64,11 +63,8 @@ export class MockMatchMedia extends MatchMedia {
 
   /** Converts an optional mediaQuery alias to a specific, valid mediaQuery */
   _validateQuery(queryOrAlias: string) {
-    let bp = this._breakpoints.findByAlias(queryOrAlias);
-    if (bp) {
-      queryOrAlias = bp.mediaQuery;
-    }
-    return queryOrAlias;
+    const bp = this._breakpoints.findByAlias(queryOrAlias);
+    return (bp && bp.mediaQuery) || queryOrAlias;
   }
 
   /**
@@ -77,8 +73,8 @@ export class MockMatchMedia extends MatchMedia {
    */
   private _activateWithOverlaps(mediaQuery: string, useOverlaps: boolean): boolean {
     if (useOverlaps) {
-      let bp = this._breakpoints.findByQuery(mediaQuery);
-      let alias = bp ? bp.alias : 'unknown';
+      const bp = this._breakpoints.findByQuery(mediaQuery);
+      const alias = bp ? bp.alias : 'unknown';
 
       // Simulate activation of overlapping lt-<XXX> ranges
       switch (alias) {
@@ -120,8 +116,8 @@ export class MockMatchMedia extends MatchMedia {
    *
    */
   private _activateByAlias(aliases: string) {
-    let activate = (alias: string) => {
-      let bp = this._breakpoints.findByAlias(alias);
+    const activate = (alias: string) => {
+      const bp = this._breakpoints.findByAlias(alias);
       this._activateByQuery(bp ? bp.mediaQuery : alias);
     };
     aliases.split(',').forEach(alias => activate(alias.trim()));
@@ -131,10 +127,9 @@ export class MockMatchMedia extends MatchMedia {
    *
    */
   private _activateByQuery(mediaQuery: string) {
-    let mql = <MockMediaQueryList> this._registry.get(mediaQuery);
-    let alreadyAdded = this._actives.reduce((found, it) => {
-      return found || (mql && (it.media === mql.media));
-    }, false);
+    const mql = this._registry.get(mediaQuery)!;
+    const alreadyAdded = this._actives
+      .reduce((found, it) => (found || (mql && (it.media === mql.media))), false);
 
     if (mql && !alreadyAdded) {
       this._actives.push(mql.activate());
@@ -170,7 +165,7 @@ export class MockMatchMedia extends MatchMedia {
   }
 
   protected get hasActivated() {
-    return (this._actives.length > 0);
+    return this._actives.length > 0;
   }
 
   private _actives: MockMediaQueryList[] = [];

--- a/src/lib/core/match-media/server-match-media.ts
+++ b/src/lib/core/match-media/server-match-media.ts
@@ -7,11 +7,9 @@
  */
 import {DOCUMENT} from '@angular/common';
 import {Inject, Injectable, NgZone, PLATFORM_ID} from '@angular/core';
-import {BehaviorSubject, Observable} from 'rxjs';
 
 import {BreakPoint} from '../breakpoints/break-point';
 import {MatchMedia} from './match-media';
-import {MediaChange} from '../media-change';
 
 /**
  * Special server-only class to simulate a MediaQueryList and
@@ -115,17 +113,12 @@ export class ServerMediaQueryList implements MediaQueryList {
  */
 @Injectable()
 export class ServerMatchMedia extends MatchMedia {
-  protected _registry: Map<string, ServerMediaQueryList>;
-  protected _source: BehaviorSubject<MediaChange>;
-  protected _observable$: Observable<MediaChange>;
+  protected _registry: Map<string, ServerMediaQueryList> = new Map();
 
   constructor(protected _zone: NgZone,
               @Inject(PLATFORM_ID) protected _platformId: Object,
               @Inject(DOCUMENT) protected _document: any) {
     super(_zone, _platformId, _document);
-    this._registry = new Map<string, ServerMediaQueryList>();
-    this._source = new BehaviorSubject<MediaChange>(new MediaChange(true));
-    this._observable$ = this._source.asObservable();
   }
 
   /** Activate the specified breakpoint if we're on the server, no-op otherwise */

--- a/src/lib/core/media-monitor/media-monitor.ts
+++ b/src/lib/core/media-monitor/media-monitor.ts
@@ -43,31 +43,22 @@ export class MediaMonitor {
   }
 
   get activeOverlaps(): BreakPoint[] {
-    let items: BreakPoint[] = this._breakpoints.overlappings.reverse();
-    return items.filter((bp: BreakPoint) => {
-      return this._matchMedia.isActive(bp.mediaQuery);
-    });
+    return this._breakpoints.overlappings
+      .reverse()
+      .filter(bp => this._matchMedia.isActive(bp.mediaQuery));
   }
 
   get active(): BreakPoint | null {
-    let found: BreakPoint | null = null, items = this.breakpoints.reverse();
-    items.forEach(bp => {
-      if (bp.alias !== '') {
-        if (!found && this._matchMedia.isActive(bp.mediaQuery)) {
-          found = bp;
-        }
-      }
-    });
-
-    let first = this.breakpoints[0];
-    return found || (this._matchMedia.isActive(first.mediaQuery) ? first : null);
+    const items = this.breakpoints.reverse();
+    const first = items.find(bp => bp.alias !== '' && this._matchMedia.isActive(bp.mediaQuery));
+    return first || null;
   }
 
   /**
    * For the specified mediaQuery alias, is the mediaQuery range active?
    */
   isActive(alias: string): boolean {
-    let bp = this._breakpoints.findByAlias(alias) || this._breakpoints.findByQuery(alias);
+    const bp = this._breakpoints.findByAlias(alias) || this._breakpoints.findByQuery(alias);
     return this._matchMedia.isActive(bp ? bp.mediaQuery : alias);
   }
 
@@ -76,13 +67,12 @@ export class MediaMonitor {
    * If specific breakpoint is observed, only return *activated* events
    * otherwise return all events for BOTH activated + deactivated changes.
    */
-  observe(alias?: string): Observable<MediaChange> {
-    let bp = this._breakpoints.findByAlias(alias || '') ||
-      this._breakpoints.findByQuery(alias || '');
-    let hasAlias = (change: MediaChange) => (bp ? change.mqAlias !== '' : true);
+  observe(alias: string = ''): Observable<MediaChange> {
+    const bp = this._breakpoints.findByAlias(alias) || this._breakpoints.findByQuery(alias);
+    const hasAlias = (change: MediaChange) => (bp ? change.mqAlias !== '' : true);
     // Note: the raw MediaChange events [from MatchMedia] do not contain important alias information
 
-    let media$ = this._matchMedia.observe(bp ? bp.mediaQuery : alias);
+    const media$ = this._matchMedia.observe(bp ? bp.mediaQuery : alias);
     return media$.pipe(
       map(change => mergeAlias(change, bp)),
       filter(hasAlias)
@@ -94,7 +84,7 @@ export class MediaMonitor {
    * and prepare for immediate subscription notifications
    */
   private _registerBreakpoints() {
-    let queries = this._breakpoints.sortedItems.map(bp => bp.mediaQuery);
+    const queries = this._breakpoints.sortedItems.map(bp => bp.mediaQuery);
     this._matchMedia.registerQuery(queries);
   }
 }

--- a/src/lib/core/media-observer/index.ts
+++ b/src/lib/core/media-observer/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './media-observer';

--- a/src/lib/core/media-observer/media-observer.spec.ts
+++ b/src/lib/core/media-observer/media-observer.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {TestBed, inject, async} from '@angular/core/testing';
+import {filter, map} from 'rxjs/operators';
+
+import {BreakPoint} from '../breakpoints/break-point';
+import {BREAKPOINTS} from '../breakpoints/break-points-token';
+import {MatchMedia} from '../match-media/match-media';
+import {MediaChange} from '../media-change';
+import {MediaObserver} from './media-observer';
+import {MockMatchMedia, MockMatchMediaProvider} from '../match-media/mock/mock-match-media';
+import {BREAKPOINT} from '../tokens/breakpoint-token';
+
+describe('observable-media', () => {
+
+  describe('with default BreakPoints', () => {
+    let knownBreakPoints: BreakPoint[] = [];
+    let findMediaQuery: (alias: string) => string = (alias) => {
+      const NOT_FOUND = `${alias} not found`;
+      return knownBreakPoints.reduce((mediaQuery: string | null, bp) => {
+        return mediaQuery || ((bp.alias === alias) ? bp.mediaQuery : null);
+      }, null) as string || NOT_FOUND;
+    };
+    beforeEach(() => {
+      // Configure testbed to prepare services
+      TestBed.configureTestingModule({
+        providers: [MockMatchMediaProvider]
+      });
+    });
+    beforeEach(inject([BREAKPOINTS], (breakpoints: BreakPoint[]) => {
+      // Cache reference to list for easy testing...
+      knownBreakPoints = breakpoints;
+    }));
+
+    it('can supports the `.isActive()` API', async(inject(
+      [MediaObserver, MatchMedia],
+      (media: MediaObserver, matchMedia: MockMatchMedia) => {
+        expect(media).toBeDefined();
+
+        // Activate mediaQuery associated with 'md' alias
+        matchMedia.activate('md');
+        expect(media.isActive('md')).toBeTruthy();
+
+        matchMedia.activate('lg');
+        expect(media.isActive('lg')).toBeTruthy();
+        expect(media.isActive('md')).toBeFalsy();
+
+      })));
+
+    it('can supports RxJS operators', inject(
+      [MediaObserver, MatchMedia],
+      (mediaService: MediaObserver, matchMedia: MockMatchMedia) => {
+        let count = 0,
+          subscription = mediaService.media$.pipe(
+            filter((change: MediaChange) => change.mqAlias == 'md'),
+            map((change: MediaChange) => change.mqAlias)
+          ).subscribe(_ => {
+            count += 1;
+          });
+
+
+        // Activate mediaQuery associated with 'md' alias
+        matchMedia.activate('sm');
+        expect(count).toEqual(0);
+
+        matchMedia.activate('md');
+        expect(count).toEqual(1);
+
+        matchMedia.activate('lg');
+        expect(count).toEqual(1);
+
+        matchMedia.activate('md');
+        expect(count).toEqual(2);
+
+        matchMedia.activate('gt-md');
+        matchMedia.activate('gt-lg');
+        matchMedia.activate('invalid');
+        expect(count).toEqual(2);
+
+        subscription.unsubscribe();
+      }));
+
+    it('can subscribe to built-in mediaQueries', inject(
+      [MediaObserver, MatchMedia],
+      (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
+        let current: MediaChange;
+
+        expect(mediaObserver).toBeDefined();
+
+        let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+          current = change;
+        });
+
+        async(() => {
+          // Confirm initial match is for 'all'
+          expect(current).toBeDefined();
+          expect(current.matches).toBeTruthy();
+          expect(current.mediaQuery).toEqual('all');
+
+          try {
+            matchMedia.autoRegisterQueries = false;
+
+            // Activate mediaQuery associated with 'md' alias
+            matchMedia.activate('md');
+            expect(current.mediaQuery).toEqual(findMediaQuery('md'));
+
+            // Allow overlapping activations to be announced to observers
+            mediaObserver.filterOverlaps = false;
+
+            matchMedia.activate('gt-lg');
+            expect(current.mediaQuery).toEqual(findMediaQuery('gt-lg'));
+
+            matchMedia.activate('unknown');
+            expect(current.mediaQuery).toEqual(findMediaQuery('gt-lg'));
+
+          } finally {
+            matchMedia.autoRegisterQueries = true;
+            subscription.unsubscribe();
+          }
+        });
+      }));
+
+    it('can `.unsubscribe()` properly', inject(
+      [MediaObserver, MatchMedia],
+      (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
+        let current: MediaChange;
+        let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+          current = change;
+        });
+
+        async(() => {
+          // Activate mediaQuery associated with 'md' alias
+          matchMedia.activate('md');
+          expect(current.mediaQuery).toEqual(findMediaQuery('md'));
+
+          // Un-subscribe
+          subscription.unsubscribe();
+
+          matchMedia.activate('lg');
+          expect(current.mqAlias).toBe('md');
+
+          matchMedia.activate('xs');
+          expect(current.mqAlias).toBe('md');
+        });
+      }));
+
+    it('can observe a startup activation of XS', inject(
+      [MediaObserver, MatchMedia],
+      (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
+        let current: MediaChange;
+        let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+          current = change;
+        });
+
+        async(() => {
+          // Activate mediaQuery associated with 'md' alias
+          matchMedia.activate('xs');
+          expect(current.mediaQuery).toEqual(findMediaQuery('xs'));
+
+          // Un-subscribe
+          subscription.unsubscribe();
+
+          matchMedia.activate('lg');
+          expect(current.mqAlias).toBe('xs');
+        });
+      }));
+  });
+
+  describe('with custom BreakPoints', () => {
+    const gtXsMediaQuery = 'screen and (max-width:20px) and (orientations: landscape)';
+    const mdMediaQuery = 'print and (min-width:10000px)';
+    const CUSTOM_BREAKPOINTS = [
+      {alias: 'print.md', mediaQuery: mdMediaQuery},
+      {alias: 'tablet-gt-xs', mediaQuery: gtXsMediaQuery},
+    ];
+
+    beforeEach(() => {
+      // Configure testbed to prepare services
+      TestBed.configureTestingModule({
+        providers: [
+          MockMatchMediaProvider,
+          {provide: BREAKPOINT, useValue: CUSTOM_BREAKPOINTS, multi: true},
+        ]
+      });
+    });
+
+    it('can activate custom alias with custom mediaQueries', inject(
+      [MediaObserver, MatchMedia],
+      (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
+        let current: MediaChange;
+        let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+          current = change;
+        });
+
+        async(() => {
+          // Activate mediaQuery associated with 'md' alias
+          matchMedia.activate('print.md');
+          expect(current.mediaQuery).toEqual(mdMediaQuery);
+
+          matchMedia.activate('tablet-gt-xs');
+          expect(current.mqAlias).toBe('tablet-gt-xs');
+          expect(current.mediaQuery).toBe(gtXsMediaQuery);
+
+          subscription.unsubscribe();
+        });
+      }));
+  });
+});

--- a/src/lib/core/media-observer/media-observer.ts
+++ b/src/lib/core/media-observer/media-observer.ts
@@ -6,35 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {Injectable} from '@angular/core';
-import {Observable, PartialObserver, Subscribable, Subscription} from 'rxjs';
+import {Observable} from 'rxjs';
 import {filter, map} from 'rxjs/operators';
 
 import {BreakPointRegistry} from '../breakpoints/break-point-registry';
 import {MediaChange} from '../media-change';
 import {MatchMedia} from '../match-media/match-media';
 import {mergeAlias} from '../add-alias';
-import {BreakPoint} from '../breakpoints/break-point';
 
 /**
- * Base class for MediaService and pseudo-token for
- * @deprecated use MediaObserver instead
- * @deletion-target v7.0.0-beta.21
- */
-export abstract class ObservableMedia implements Subscribable<MediaChange> {
-  abstract isActive(query: string): boolean;
+ * Class internalizes a MatchMedia service and exposes an Observable interface.
 
-  abstract asObservable(): Observable<MediaChange>;
-
-  abstract subscribe(next?: (value: MediaChange) => void,
-                     error?: (error: any) => void,
-                     complete?: () => void): Subscription;
-  abstract subscribe(observer?: PartialObserver<MediaChange>): Subscription;
-}
-
-/**
- * Class internalizes a MatchMedia service and exposes an Subscribable and Observable interface.
-
- * This an Observable with that exposes a feature to subscribe to mediaQuery
+ * This exposes an Observable with a feature to subscribe to mediaQuery
  * changes and a validator method (`isActive(<alias>)`) to test if a mediaQuery (or alias) is
  * currently active.
  *
@@ -46,47 +29,44 @@ export abstract class ObservableMedia implements Subscribable<MediaChange> {
  *
  * !! This is not an actual Observable. It is a wrapper of an Observable used to publish additional
  * methods like `isActive(<alias>). To access the Observable and use RxJS operators, use
- * `.asObservable()` with syntax like media.asObservable().map(....).
+ * `.media$` with syntax like mediaObserver.media$.map(....).
  *
  *  @usage
  *
  *  // RxJS
- *  import {filter} from 'rxjs/operators/filter';
- *  import { ObservableMedia } from '@angular/flex-layout';
+ *  import { filter } from 'rxjs/operators';
+ *  import { MediaObserver } from '@angular/flex-layout';
  *
  *  @Component({ ... })
  *  export class AppComponent {
- *    status : string = '';
+ *    status: string = '';
  *
- *    constructor(  media:ObservableMedia ) {
- *      let onChange = (change:MediaChange) => {
+ *    constructor(mediaObserver: MediaObserver) {
+ *      const onChange = (change: MediaChange) => {
  *        this.status = change ? `'${change.mqAlias}' = (${change.mediaQuery})` : '';
  *      };
  *
  *      // Subscribe directly or access observable to use filter/map operators
- *      // e.g.
- *      //      media.subscribe(onChange);
+ *      // e.g. mediaObserver.media$.subscribe(onChange);
  *
- *      media.asObservable()
+ *      mediaObserver.media$()
  *        .pipe(
- *          filter((change:MediaChange) => true)   // silly noop filter
+ *          filter((change: MediaChange) => true)   // silly noop filter
  *        ).subscribe(onChange);
  *    }
  *  }
- *  @deprecated use MediaObserver instead
- *  @deletion-target v7.0.0-beta.21
  */
 @Injectable({providedIn: 'root'})
-export class MediaService implements ObservableMedia {
+export class MediaObserver {
   /**
-   * Should we announce gt-<xxx> breakpoint activations ?
+   * Whether to announce gt-<xxx> breakpoint activations
    */
   filterOverlaps = true;
+  readonly media$: Observable<MediaChange>;
 
-  constructor(private breakpoints: BreakPointRegistry,
-              private mediaWatcher: MatchMedia) {
+  constructor(private breakpoints: BreakPointRegistry, private mediaWatcher: MatchMedia) {
     this._registerBreakPoints();
-    this.observable$ = this._buildObservable();
+    this.media$ = this._buildObservable();
   }
 
   /**
@@ -94,30 +74,6 @@ export class MediaService implements ObservableMedia {
    */
   isActive(alias: string): boolean {
     return this.mediaWatcher.isActive(this._toMediaQuery(alias));
-  }
-
-  /**
-   * Proxy to the Observable subscribe method
-   */
-  subscribe(observerOrNext?: PartialObserver<MediaChange> | ((value: MediaChange) => void),
-            error?: (error: any) => void,
-            complete?: () => void): Subscription {
-    if (observerOrNext) {
-      if (typeof observerOrNext === 'object') {
-        return this.observable$.subscribe(observerOrNext.next, observerOrNext.error,
-          observerOrNext.complete);
-      }
-    }
-
-    return this.observable$.subscribe(observerOrNext, error, complete);
-  }
-
-  /**
-   * Access to observable for use with operators like
-   * .filter(), .map(), etc.
-   */
-  asObservable(): Observable<MediaChange> {
-    return this.observable$;
   }
 
   // ************************************************
@@ -152,12 +108,14 @@ export class MediaService implements ObservableMedia {
      * Inject associated (if any) alias information into the MediaChange event
      * Exclude mediaQuery activations for overlapping mQs. List bounded mQ ranges only
      */
-    return this.mediaWatcher.observe().pipe(
-      filter(change => change.matches),
-      filter(excludeOverlaps),
-      map((change: MediaChange) =>
-        mergeAlias(change, this._findByQuery(change.mediaQuery)))
-    );
+    return this.mediaWatcher.observe()
+      .pipe(
+        filter(change => change.matches),
+        filter(excludeOverlaps),
+        map((change: MediaChange) =>
+          mergeAlias(change, this._findByQuery(change.mediaQuery))
+        )
+      );
   }
 
   /**
@@ -178,18 +136,7 @@ export class MediaService implements ObservableMedia {
    * Find associated breakpoint (if any)
    */
   private _toMediaQuery(query: string) {
-    const bp: BreakPoint | null = this._findByAlias(query) || this._findByQuery(query);
+    const bp = this._findByAlias(query) || this._findByQuery(query);
     return bp ? bp.mediaQuery : query;
   }
-
-  private readonly observable$: Observable<MediaChange>;
 }
-
-/**
- * @deprecated
- * @deletion-target v7.0.0-beta.21
- */
-export const ObservableMediaProvider = { // tslint:disable-line:variable-name
-  provide: ObservableMedia,
-  useClass: MediaService
-};

--- a/src/lib/core/module.ts
+++ b/src/lib/core/module.ts
@@ -7,7 +7,6 @@
  */
 import {NgModule} from '@angular/core';
 
-import {ObservableMediaProvider} from './observable-media/observable-media';
 import {BROWSER_PROVIDER} from './browser-provider';
 
 /**
@@ -17,7 +16,7 @@ import {BROWSER_PROVIDER} from './browser-provider';
  */
 
 @NgModule({
-  providers: [ObservableMediaProvider, BROWSER_PROVIDER]
+  providers: [BROWSER_PROVIDER]
 })
 export class CoreModule {
 }

--- a/src/lib/core/public-api.ts
+++ b/src/lib/core/public-api.ts
@@ -16,7 +16,7 @@ export * from './base/index';
 export * from './breakpoints/index';
 export * from './match-media/index';
 export * from './media-monitor/index';
-export * from './observable-media/index';
+export * from './media-observer/index';
 
 export * from './responsive-activation/responsive-activation';
 export * from './style-utils/style-utils';

--- a/src/lib/core/responsive-activation/responsive-activation.ts
+++ b/src/lib/core/responsive-activation/responsive-activation.ts
@@ -13,8 +13,6 @@ import {BreakPoint} from '../breakpoints/break-point';
 import {MediaMonitor} from '../media-monitor/media-monitor';
 import {extendObject} from '../../utils/object-extend';
 
-export declare type SubscriptionList = Subscription[];
-
 export interface BreakPointX extends BreakPoint {
   key: string;
   baseKey: string;
@@ -40,9 +38,9 @@ export class KeyOptions {
  * NOTE: these interceptions enables the logic in the fx API directives to remain terse and clean.
  */
 export class ResponsiveActivation {
-  private _subscribers: SubscriptionList = [];
   private _activatedInputKey: string = '';
-  private _registryMap: BreakPointX[];
+  private _registryMap: BreakPointX[] = this._buildRegistryMap();
+  private _subscribers: Subscription[] = this._configureChangeObservers();
 
   /**
    * Constructor
@@ -50,8 +48,6 @@ export class ResponsiveActivation {
   constructor(private _options: KeyOptions,
               private _mediaMonitor: MediaMonitor,
               private _onMediaChanges: MediaQuerySubscriber) {
-    this._registryMap = this._buildRegistryMap();
-    this._subscribers = this._configureChangeObservers();
   }
 
   /**
@@ -62,15 +58,6 @@ export class ResponsiveActivation {
    */
   get registryFromLargest(): BreakPointX[] {
     return [...this._registryMap].reverse();
-  }
-
-  /**
-   * Accessor to the DI'ed directive property
-   * Each directive instance has a reference to the MediaMonitor which is
-   * used HERE to subscribe to mediaQuery change notifications.
-   */
-  get mediaMonitor(): MediaMonitor {
-    return this._mediaMonitor;
   }
 
   /**
@@ -89,7 +76,7 @@ export class ResponsiveActivation {
    * Get the currently activated @Input value or the fallback default @Input value
    */
   get activatedInput(): any {
-    let key = this.activatedInputKey;
+    const key = this.activatedInputKey;
     return this.hasKeyValue(key) ? this._lookupKeyValue(key) : this._options.defaultValue;
   }
 
@@ -97,17 +84,14 @@ export class ResponsiveActivation {
    * Fast validator for presence of attribute on the host element
    */
   hasKeyValue(key: string) {
-    let value = this._options.inputKeys[key];
-    return typeof value !== 'undefined';
+    return this._options.inputKeys[key] !== undefined;
   }
 
   /**
    * Remove interceptors, restore original functions, and forward the onDestroy() call
    */
   destroy() {
-    this._subscribers.forEach((link: Subscription) => {
-      link.unsubscribe();
-    });
+    this._subscribers.forEach(link => link.unsubscribe());
     this._subscribers = [];
   }
 
@@ -115,21 +99,21 @@ export class ResponsiveActivation {
    * For each *defined* API property, register a callback to `_onMonitorEvents( )`
    * Cache 1..n subscriptions for internal auto-unsubscribes when the the directive destructs
    */
-  private _configureChangeObservers(): SubscriptionList {
-    let subscriptions: Subscription[] = [];
+  private _configureChangeObservers(): Subscription[] {
+    const subscriptions: Subscription[] = [];
 
-    this._registryMap.forEach((bp: BreakPointX) => {
+    this._registryMap.forEach(bp => {
       if (this._keyInUse(bp.key)) {
         // Inject directive default property key name: to let onMediaChange() calls
         // know which property is being triggered...
-        let buildChanges = (change: MediaChange) => {
+        const buildChanges = (change: MediaChange) => {
           change = change.clone();
           change.property = this._options.baseKey;
           return change;
         };
 
         subscriptions.push(
-          this.mediaMonitor
+          this._mediaMonitor
               .observe(bp.alias)
               .pipe(map(buildChanges))
               .subscribe(change => {
@@ -147,14 +131,12 @@ export class ResponsiveActivation {
    * in the HTML markup
    */
   private _buildRegistryMap() {
-    return this.mediaMonitor.breakpoints
-        .map(bp => {
-          return <BreakPointX> extendObject({}, bp, {
-            baseKey: this._options.baseKey,             // e.g. layout, hide, self-align, flex-wrap
-            key: this._options.baseKey + bp.suffix  // e.g.  layoutGtSm, layoutMd, layoutGtLg
-          });
-        })
-        .filter(bp => this._keyInUse(bp.key));
+    return this._mediaMonitor.breakpoints
+      .map(bp => <BreakPointX>extendObject({}, bp, {
+        baseKey: this._options.baseKey,         // e.g. layout, hide, self-align, flex-wrap
+        key: this._options.baseKey + bp.suffix  // e.g. layoutGtSm, layoutMd, layoutGtLg
+      }))
+      .filter(bp => this._keyInUse(bp.key));
   }
 
   /**
@@ -162,9 +144,8 @@ export class ResponsiveActivation {
    * mq-activated input value or the default value
    */
   protected _onMonitorEvents(change: MediaChange) {
-    if (change.property == this._options.baseKey) {
+    if (change.property === this._options.baseKey) {
       change.value = this._calculateActivatedValue(change);
-
       this._onMediaChanges(change);
     }
   }
@@ -187,9 +168,9 @@ export class ResponsiveActivation {
    */
   private _calculateActivatedValue(current: MediaChange): any {
     const currentKey = this._options.baseKey + current.suffix;  // e.g. suffix == 'GtSm',
-    let newKey = this._activatedInputKey;                     // e.g. newKey == hideGtSm
+    let newKey = this._activatedInputKey;                       // e.g. newKey == hideGtSm
 
-    newKey = current.matches ? currentKey : ((newKey == currentKey) ? '' : newKey);
+    newKey = current.matches ? currentKey : ((newKey === currentKey) ? '' : newKey);
 
     this._activatedInputKey = this._validateInputKey(newKey);
     return this.activatedInput;
@@ -202,11 +183,11 @@ export class ResponsiveActivation {
    * NOTE: scans in the order defined by activeOverLaps (largest viewport ranges -> smallest ranges)
    */
   private _validateInputKey(inputKey: string) {
-    let isMissingKey = (key: string) => !this._keyInUse(key);
+    const isMissingKey = (key: string) => !this._keyInUse(key);
 
     if (isMissingKey(inputKey)) {
-      this.mediaMonitor.activeOverlaps.some(bp => {
-        let key = this._options.baseKey + bp.suffix;
+      this._mediaMonitor.activeOverlaps.some(bp => {
+        const key = this._options.baseKey + bp.suffix;
         if (!isMissingKey(key)) {
           inputKey = key;
           return true;  // exit .some()

--- a/src/lib/core/style-builder/style-builder.ts
+++ b/src/lib/core/style-builder/style-builder.ts
@@ -10,5 +10,14 @@ import {StyleDefinition} from '../style-utils/style-utils';
 
 @Injectable()
 export abstract class StyleBuilder {
-  abstract buildStyles(input: string, parent?: Object): StyleDefinition;
+  abstract buildStyles(input: string, parent?: Object): StyleBuilderOutput;
+
+  sideEffect(_input: string, _styles: StyleDefinition, _parent?: Object) {
+    // This should be a no-op unless an algorithm is provided in a subclass
+  }
+}
+
+export interface StyleBuilderOutput {
+  styles: StyleDefinition;
+  shouldCache: boolean;
 }

--- a/src/lib/core/style-builder/style-builder.ts
+++ b/src/lib/core/style-builder/style-builder.ts
@@ -5,10 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Injectable} from '@angular/core';
 import {StyleDefinition} from '../style-utils/style-utils';
 
-@Injectable()
 export abstract class StyleBuilder {
   abstract buildStyles(input: string, parent?: Object): StyleBuilderOutput;
 

--- a/src/lib/extended/show-hide/hide.spec.ts
+++ b/src/lib/extended/show-hide/hide.spec.ts
@@ -13,7 +13,7 @@ import {
   CoreModule,
   MockMatchMedia,
   MockMatchMediaProvider,
-  ObservableMedia,
+  MediaObserver,
   SERVER_TOKEN,
   StyleUtils,
 } from '@angular/flex-layout/core';
@@ -257,7 +257,7 @@ class TestHideComponent implements OnInit {
   isHidden = true;
   menuHidden = true;
 
-  constructor(public media: ObservableMedia) {
+  constructor(public media: MediaObserver) {
   }
 
   toggleMenu() {

--- a/src/lib/extended/show-hide/show.spec.ts
+++ b/src/lib/extended/show-hide/show.spec.ts
@@ -12,7 +12,7 @@ import {
   MatchMedia,
   MockMatchMedia,
   MockMatchMediaProvider,
-  ObservableMedia,
+  MediaObserver,
   SERVER_TOKEN,
   StyleUtils,
 } from '@angular/flex-layout/core';
@@ -306,7 +306,7 @@ class TestShowComponent implements OnInit {
   isHidden = false;
   menuOpen = true;
 
-  constructor(public media: ObservableMedia) {
+  constructor(public media: MediaObserver) {
   }
 
   toggleMenu() {

--- a/src/lib/flex/flex-align/flex-align.ts
+++ b/src/lib/flex/flex-align/flex-align.ts
@@ -20,29 +20,32 @@ import {
   MediaChange,
   MediaMonitor,
   StyleBuilder,
-  StyleDefinition,
-  StyleUtils
+  StyleBuilderOutput,
+  StyleUtils,
 } from '@angular/flex-layout/core';
 
 @Injectable({providedIn: 'root'})
-export class FlexAlignStyleBuilder implements StyleBuilder {
-  buildStyles(input: string): StyleDefinition {
-    const css: {[key: string]: string | number} = {};
+export class FlexAlignStyleBuilder extends StyleBuilder {
+  constructor() {
+    super();
+  }
+  buildStyles(input: string): StyleBuilderOutput {
+    const styles: {[key: string]: string | number} = {};
 
     // Cross-axis
     switch (input) {
       case 'start':
-        css['align-self'] = 'flex-start';
+        styles['align-self'] = 'flex-start';
         break;
       case 'end':
-        css['align-self'] = 'flex-end';
+        styles['align-self'] = 'flex-end';
         break;
       default:
-        css['align-self'] = input;
+        styles['align-self'] = input;
         break;
     }
 
-    return css;
+    return {styles, shouldCache: true};
   }
 }
 

--- a/src/lib/flex/flex-fill/flex-fill.ts
+++ b/src/lib/flex/flex-fill/flex-fill.ts
@@ -10,7 +10,7 @@ import {
   BaseDirective,
   MediaMonitor,
   StyleBuilder,
-  StyleDefinition,
+  StyleBuilderOutput,
   StyleUtils,
 } from '@angular/flex-layout/core';
 
@@ -23,9 +23,12 @@ const FLEX_FILL_CSS = {
 };
 
 @Injectable({providedIn: 'root'})
-export class FlexFillStyleBuilder implements StyleBuilder {
-  buildStyles(_input: string): StyleDefinition {
-    return FLEX_FILL_CSS;
+export class FlexFillStyleBuilder extends StyleBuilder {
+  constructor() {
+    super();
+  }
+  buildStyles(_input: string): StyleBuilderOutput {
+    return {styles: FLEX_FILL_CSS, shouldCache: true};
   }
 }
 

--- a/src/lib/flex/flex-offset/flex-offset.spec.ts
+++ b/src/lib/flex/flex-offset/flex-offset.spec.ts
@@ -223,9 +223,12 @@ describe('flex-offset directive', () => {
 });
 
 @Injectable({providedIn: FlexModule})
-export class MockFlexOffsetStyleBuilder implements StyleBuilder {
+export class MockFlexOffsetStyleBuilder extends StyleBuilder {
+  constructor() {
+    super();
+  }
   buildStyles(_input: string) {
-    return {'margin-top': '10px'};
+    return {styles: {'margin-top': '10px'}, shouldCache: false};
   }
 }
 

--- a/src/lib/flex/flex-offset/flex-offset.ts
+++ b/src/lib/flex/flex-offset/flex-offset.ts
@@ -23,7 +23,7 @@ import {
   MediaChange,
   MediaMonitor,
   StyleBuilder,
-  StyleDefinition,
+  StyleBuilderOutput,
   StyleUtils,
 } from '@angular/flex-layout/core';
 import {Subscription} from 'rxjs';
@@ -31,23 +31,27 @@ import {Subscription} from 'rxjs';
 import {Layout, LayoutDirective} from '../layout/layout';
 import {isFlowHorizontal} from '../../utils/layout-validator';
 
-interface FlexOffsetParent {
+export interface FlexOffsetParent {
   layout: string;
   isRtl: boolean;
 }
 
 @Injectable({providedIn: 'root'})
-export class FlexOffsetStyleBuilder implements StyleBuilder {
-  buildStyles(offset: string, parent: FlexOffsetParent): StyleDefinition {
+export class FlexOffsetStyleBuilder extends StyleBuilder {
+  constructor() {
+    super();
+  }
+  buildStyles(offset: string, parent: FlexOffsetParent): StyleBuilderOutput {
     const isPercent = String(offset).indexOf('%') > -1;
     const isPx = String(offset).indexOf('px') > -1;
     if (!isPx && !isPercent && !isNaN(+offset)) {
       offset = offset + '%';
     }
     const horizontalLayoutKey = parent.isRtl ? 'margin-right' : 'margin-left';
-
-    return isFlowHorizontal(parent.layout) ? {[horizontalLayoutKey]: `${offset}`} :
+    const styles = isFlowHorizontal(parent.layout) ? {[horizontalLayoutKey]: `${offset}`} :
       {'margin-top': `${offset}`};
+
+    return {styles, shouldCache: true};
   }
 }
 

--- a/src/lib/flex/flex-order/flex-order.ts
+++ b/src/lib/flex/flex-order/flex-order.ts
@@ -20,15 +20,19 @@ import {
   MediaChange,
   MediaMonitor,
   StyleBuilder,
-  StyleDefinition,
-  StyleUtils
+  StyleBuilderOutput,
+  StyleUtils,
 } from '@angular/flex-layout/core';
 
 @Injectable({providedIn: 'root'})
-export class FlexOrderStyleBuilder implements StyleBuilder {
-  buildStyles(value: string): StyleDefinition {
+export class FlexOrderStyleBuilder extends StyleBuilder {
+  constructor() {
+    super();
+  }
+  buildStyles(value: string): StyleBuilderOutput {
     const val = parseInt(value, 10);
-    return {order: isNaN(val) ? 0 : val};
+    const styles = {order: isNaN(val) ? 0 : val};
+    return {styles, shouldCache: true};
   }
 }
 

--- a/src/lib/flex/flex/flex.spec.ts
+++ b/src/lib/flex/flex/flex.spec.ts
@@ -926,9 +926,12 @@ describe('flex directive', () => {
 });
 
 @Injectable({providedIn: FlexModule})
-export class MockFlexStyleBuilder implements StyleBuilder {
+export class MockFlexStyleBuilder extends StyleBuilder {
+  constructor() {
+    super();
+  }
   buildStyles(_input: string) {
-    return {'flex': '1 1 30%'};
+    return {styles: {'flex': '1 1 30%'}, shouldCache: false};
   }
 }
 

--- a/src/lib/flex/flex/flex.spec.ts
+++ b/src/lib/flex/flex/flex.spec.ts
@@ -27,7 +27,6 @@ import {
   queryFor,
   expectEl,
 } from '../../utils/testing/helpers';
-import {FlexModule} from '../module';
 
 
 describe('flex directive', () => {
@@ -925,7 +924,7 @@ describe('flex directive', () => {
 
 });
 
-@Injectable({providedIn: FlexModule})
+@Injectable()
 export class MockFlexStyleBuilder extends StyleBuilder {
   constructor() {
     super();

--- a/src/lib/flex/flex/flex.ts
+++ b/src/lib/flex/flex/flex.ts
@@ -27,7 +27,7 @@ import {
   StyleUtils,
   validateBasis,
   StyleBuilder,
-  StyleDefinition,
+  StyleBuilderOutput,
 } from '@angular/flex-layout/core';
 import {Subscription} from 'rxjs';
 
@@ -45,8 +45,11 @@ interface FlexBuilderParent {
 }
 
 @Injectable({providedIn: 'root'})
-export class FlexStyleBuilder implements StyleBuilder {
-  buildStyles(input: string, parent: FlexBuilderParent): StyleDefinition {
+export class FlexStyleBuilder extends StyleBuilder {
+  constructor() {
+    super();
+  }
+  buildStyles(input: string, parent: FlexBuilderParent): StyleBuilderOutput {
     let grow: string | number;
     let shrink: string | number;
     let basis: string | number;
@@ -192,7 +195,7 @@ export class FlexStyleBuilder implements StyleBuilder {
       }
     }
 
-    return extendObject(css, {'box-sizing': 'border-box'});
+    return {styles: extendObject(css, {'box-sizing': 'border-box'}), shouldCache: true};
   }
 }
 

--- a/src/lib/flex/layout-align/layout-align.spec.ts
+++ b/src/lib/flex/layout-align/layout-align.spec.ts
@@ -452,9 +452,12 @@ describe('layout-align directive', () => {
 });
 
 @Injectable({providedIn: FlexModule})
-export class MockLayoutAlignStyleBuilder implements StyleBuilder {
+export class MockLayoutAlignStyleBuilder extends StyleBuilder {
+  constructor() {
+    super();
+  }
   buildStyles(_input: string) {
-    return {'justify-content': 'flex-end'};
+    return {styles: {'justify-content': 'flex-end'}, shouldCache: false};
   }
 }
 

--- a/src/lib/flex/layout-align/layout-align.ts
+++ b/src/lib/flex/layout-align/layout-align.ts
@@ -22,8 +22,8 @@ import {
   MediaChange,
   MediaMonitor,
   StyleBuilder,
-  StyleDefinition,
-  StyleUtils
+  StyleBuilderOutput,
+  StyleUtils,
 } from '@angular/flex-layout/core';
 import {Subscription} from 'rxjs';
 
@@ -31,13 +31,16 @@ import {extendObject} from '../../utils/object-extend';
 import {Layout, LayoutDirective} from '../layout/layout';
 import {LAYOUT_VALUES, isFlowHorizontal} from '../../utils/layout-validator';
 
-interface LayoutAlignParent {
+export interface LayoutAlignParent {
   layout: string;
 }
 
 @Injectable({providedIn: 'root'})
-export class LayoutAlignStyleBuilder implements StyleBuilder {
-  buildStyles(align: string, parent: LayoutAlignParent): StyleDefinition {
+export class LayoutAlignStyleBuilder extends StyleBuilder {
+  constructor() {
+    super();
+  }
+  buildStyles(align: string, parent: LayoutAlignParent): StyleBuilderOutput {
     let css: {[key: string]: string} = {},
       [mainAxis, crossAxis] = align.split(' ');
 
@@ -97,7 +100,7 @@ export class LayoutAlignStyleBuilder implements StyleBuilder {
         break;
     }
 
-    return extendObject(css, {
+    const styles = extendObject(css, {
       'display' : 'flex',
       'flex-direction' : parent.layout,
       'box-sizing' : 'border-box',
@@ -106,6 +109,8 @@ export class LayoutAlignStyleBuilder implements StyleBuilder {
       'max-height': crossAxis === 'stretch' ?
         isFlowHorizontal(parent.layout) ? '100%' : null : null,
     });
+
+    return {styles, shouldCache: true};
   }
 }
 

--- a/src/lib/flex/layout-gap/layout-gap.spec.ts
+++ b/src/lib/flex/layout-gap/layout-gap.spec.ts
@@ -434,9 +434,12 @@ describe('layout-gap directive', () => {
 });
 
 @Injectable({providedIn: FlexModule})
-export class MockLayoutGapStyleBuilder implements StyleBuilder {
+export class MockLayoutGapStyleBuilder extends StyleBuilder {
+  constructor() {
+    super();
+  }
   buildStyles(_input: string) {
-    return {'margin-top': '12px'};
+    return {styles: {'margin-top': '12px'}, shouldCache: false};
   }
 }
 

--- a/src/lib/flex/layout-gap/layout-gap.ts
+++ b/src/lib/flex/layout-gap/layout-gap.ts
@@ -24,6 +24,7 @@ import {
   MediaChange,
   MediaMonitor,
   StyleBuilder,
+  StyleBuilderOutput,
   StyleDefinition,
   StyleUtils
 } from '@angular/flex-layout/core';
@@ -32,10 +33,10 @@ import {Subscription} from 'rxjs';
 import {Layout, LayoutDirective} from '../layout/layout';
 import {LAYOUT_VALUES} from '../../utils/layout-validator';
 
-interface LayoutGapParent {
-  layout: string;
+export interface LayoutGapParent {
   directionality: string;
   items: HTMLElement[];
+  layout: string;
 }
 
 const CLEAR_MARGIN_CSS = {
@@ -46,56 +47,42 @@ const CLEAR_MARGIN_CSS = {
 };
 
 @Injectable({providedIn: 'root'})
-export class LayoutGapStyleBuilder implements StyleBuilder {
-  constructor(private styler: StyleUtils) {}
+export class LayoutGapStyleBuilder extends StyleBuilder {
+  constructor(private _styler: StyleUtils) {
+    super();
+  }
 
-  buildStyles(gapValue: string, parent: LayoutGapParent): StyleDefinition {
-    const items = parent.items;
+  buildStyles(gapValue: string, parent: LayoutGapParent): StyleBuilderOutput {
     if (gapValue.endsWith(GRID_SPECIFIER)) {
-      gapValue = gapValue.substring(0, gapValue.indexOf(GRID_SPECIFIER));
+      gapValue = gapValue.slice(0, gapValue.indexOf(GRID_SPECIFIER));
       // For each `element` children, set the padding
-      const paddingStyles = buildGridPadding(gapValue, parent.directionality);
       const marginStyles = buildGridMargin(gapValue, parent.directionality);
-      this.styler.applyStyleToElements(paddingStyles, items);
 
       // Add the margin to the host element
-      return marginStyles;
+      return {styles: marginStyles, shouldCache: true};
+    } else {
+      return {styles: {}, shouldCache: true};
+    }
+  }
+
+  sideEffect(gapValue: string, _styles: StyleDefinition, parent: LayoutGapParent) {
+    const items = parent.items;
+    if (gapValue.endsWith(GRID_SPECIFIER)) {
+      gapValue = gapValue.slice(0, gapValue.indexOf(GRID_SPECIFIER));
+      // For each `element` children, set the padding
+      const paddingStyles = buildGridPadding(gapValue, parent.directionality);
+      this._styler.applyStyleToElements(paddingStyles, parent.items);
     } else {
       const lastItem = items.pop();
 
       // For each `element` children EXCEPT the last,
       // set the margin right/bottom styles...
-      this.styler.applyStyleToElements(this._buildCSS(gapValue, parent), items);
+      const gapCss = buildGapCSS(gapValue, parent);
+      this._styler.applyStyleToElements(gapCss, items);
 
       // Clear all gaps for all visible elements
-      this.styler.applyStyleToElements(CLEAR_MARGIN_CSS, [lastItem!]);
-      return {};
+      this._styler.applyStyleToElements(CLEAR_MARGIN_CSS, [lastItem!]);
     }
-  }
-
-  private _buildCSS(gapValue: string, parent: LayoutGapParent): StyleDefinition {
-    let key, margins: {[key: string]: string | null} = {...CLEAR_MARGIN_CSS};
-
-    switch (parent.layout) {
-      case 'column':
-        key = 'margin-bottom';
-        break;
-      case 'column-reverse':
-        key = 'margin-top';
-        break;
-      case 'row':
-        key = parent.directionality === 'rtl' ? 'margin-left' : 'margin-right';
-        break;
-      case 'row-reverse':
-        key = parent.directionality === 'rtl' ? 'margin-right' : 'margin-left';
-        break;
-      default :
-        key = parent.directionality === 'rtl' ? 'margin-left' : 'margin-right';
-        break;
-    }
-    margins[key] = gapValue;
-
-    return margins;
   }
 }
 
@@ -137,13 +124,13 @@ export class LayoutGapDirective extends BaseDirective
  @Input('fxLayoutGap.lt-xl') set gapLtXl(val: string) { this._cacheInput('gapLtXl', val); };
 
   /* tslint:enable */
-  constructor(monitor: MediaMonitor,
-              elRef: ElementRef,
-              @Optional() @Self() container: LayoutDirective,
-              private _zone: NgZone,
-              private _directionality: Directionality,
-              styleUtils: StyleUtils,
-              styleBuilder: LayoutGapStyleBuilder) {
+  constructor(protected monitor: MediaMonitor,
+              protected elRef: ElementRef,
+              @Optional() @Self() protected container: LayoutDirective,
+              protected _zone: NgZone,
+              protected _directionality: Directionality,
+              protected styleUtils: StyleUtils,
+              protected styleBuilder: LayoutGapStyleBuilder) {
     super(monitor, elRef, styleUtils, styleBuilder);
 
     if (container) {  // Subscribe to layout direction changes
@@ -250,11 +237,9 @@ export class LayoutGapDirective extends BaseDirective
       });
 
     if (items.length > 0) {
-      this.addStyles(gapValue, {
-        directionality: this._directionality.value,
-        items,
-        layout: this._layout
-      });
+      const directionality = this._directionality.value;
+      const layout = this._layout;
+      this.addStyles(gapValue, {directionality, items, layout});
     }
   }
 }
@@ -283,4 +268,30 @@ function buildGridMargin(value: string, directionality: string): StyleDefinition
   }
 
   return {'margin': `${marginTop} ${marginRight} ${marginBottom} ${marginLeft}`};
+}
+
+function buildGapCSS(gapValue: string,
+                     parent: {directionality: string, layout: string}): StyleDefinition {
+  let key, margins: {[key: string]: string | null} = {...CLEAR_MARGIN_CSS};
+
+  switch (parent.layout) {
+    case 'column':
+      key = 'margin-bottom';
+      break;
+    case 'column-reverse':
+      key = 'margin-top';
+      break;
+    case 'row':
+      key = parent.directionality === 'rtl' ? 'margin-left' : 'margin-right';
+      break;
+    case 'row-reverse':
+      key = parent.directionality === 'rtl' ? 'margin-right' : 'margin-left';
+      break;
+    default :
+      key = parent.directionality === 'rtl' ? 'margin-left' : 'margin-right';
+      break;
+  }
+  margins[key] = gapValue;
+
+  return margins;
 }

--- a/src/lib/flex/layout/layout.spec.ts
+++ b/src/lib/flex/layout/layout.spec.ts
@@ -22,8 +22,7 @@ import {customMatchers} from '../../utils/testing/custom-matchers';
 import {makeCreateTestComponent, expectNativeEl, expectEl} from '../../utils/testing/helpers';
 import {queryFor} from '../../utils/testing/helpers';
 import {FlexModule} from '../module';
-import {Layout, LayoutStyleBuilder} from './layout';
-import {ReplaySubject} from 'rxjs';
+import {LayoutStyleBuilder} from './layout';
 
 describe('layout directive', () => {
   let fixture: ComponentFixture<any>;
@@ -365,13 +364,12 @@ describe('layout directive', () => {
 });
 
 @Injectable({providedIn: FlexModule})
-export class MockLayoutStyleBuilder implements StyleBuilder {
-  buildStyles(_input: string, parent: {announcer: ReplaySubject<Layout>}) {
-    parent.announcer.next({
-      direction: 'column',
-      wrap: false
-    });
-    return {'display': 'inline-flex'};
+export class MockLayoutStyleBuilder extends StyleBuilder {
+  constructor() {
+    super();
+  }
+  buildStyles(_input: string) {
+    return {styles: {'display': 'inline-flex', 'flex-direction': 'row'}, shouldCache: false};
   }
 }
 

--- a/src/lib/flex/layout/layout.ts
+++ b/src/lib/flex/layout/layout.ts
@@ -20,8 +20,9 @@ import {
   MediaChange,
   MediaMonitor,
   StyleBuilder,
+  StyleBuilderOutput,
   StyleDefinition,
-  StyleUtils
+  StyleUtils,
 } from '@angular/flex-layout/core';
 import {Observable, ReplaySubject} from 'rxjs';
 
@@ -32,19 +33,24 @@ export type Layout = {
   wrap: boolean;
 };
 
-interface LayoutParent {
+export interface LayoutParent {
   announcer: ReplaySubject<Layout>;
 }
 
 @Injectable({providedIn: 'root'})
-export class LayoutStyleBuilder implements StyleBuilder {
-  buildStyles(input: string, parent: LayoutParent): StyleDefinition {
-    const css = buildLayoutCSS(input);
+export class LayoutStyleBuilder extends StyleBuilder {
+  constructor() {
+    super();
+  }
+  buildStyles(input: string, _parent: LayoutParent): StyleBuilderOutput {
+    const styles = buildLayoutCSS(input);
+    return {styles, shouldCache: true};
+  }
+  sideEffect(_input: string, styles: StyleDefinition, parent: LayoutParent) {
     parent.announcer.next({
-      direction: css['flex-direction'],
-      wrap: !!css['flex-wrap'] && css['flex-wrap'] !== 'nowrap'
+      direction: styles['flex-direction'] as string,
+      wrap: !!styles['flex-wrap'] && styles['flex-wrap'] !== 'nowrap'
     });
-    return css;
   }
 }
 
@@ -140,7 +146,6 @@ export class LayoutDirective extends BaseDirective implements OnInit, OnChanges,
     if (this._mqActivation) {
       value = this._mqActivation.activatedInput;
     }
-
     this.addStyles(value || '', {announcer: this._announcer});
   }
 


### PR DESCRIPTION
BREAKING CHANGE:
* `ObservableMedia` is now deprecated in anticipation of RxJS v7. The new API is called `MediaObserver`, and provides the exact same functionality as `ObservableMedia`, except you cannot directly subscribe to it
* You can subscribe to `MediaObserver`'s `media$` property in place of subscribing directly to `ObservableMedia`

Fixes #885 
