### PR TITLE
feat(core): add centralized media marshal service

### DIFF
--- a/src/apps/demo-app/src/app/github-issues/split/split-area.directive.ts
+++ b/src/apps/demo-app/src/app/github-issues/split/split-area.directive.ts
@@ -1,5 +1,5 @@
 import {Directive, Optional, Self} from '@angular/core';
-import {FlexDirective} from '@angular/flex-layout';
+import {DefaultFlexDirective} from '@angular/flex-layout';
 
 @Directive({
   selector: '[ngxSplitArea]',
@@ -8,5 +8,5 @@ import {FlexDirective} from '@angular/flex-layout';
   }
 })
 export class SplitAreaDirective {
-  constructor(@Optional() @Self() public flex: FlexDirective) {}
+  constructor(@Optional() @Self() public flex: DefaultFlexDirective) {}
 }

--- a/src/apps/demo-app/src/app/github-issues/split/split.directive.ts
+++ b/src/apps/demo-app/src/app/github-issues/split/split.directive.ts
@@ -54,7 +54,7 @@ export class SplitDirective implements AfterContentInit, OnDestroy {
       const currentValue = flex.activatedValue;
 
       // Update Flex-Layout value to build/inject new flexbox CSS
-      flex.activatedValue = this.calculateSize(currentValue, delta);
+      flex.activatedValue = `${this.calculateSize(currentValue, delta)}`;
     });
   }
 

--- a/src/apps/universal-app/src/app/split/split-area.directive.ts
+++ b/src/apps/universal-app/src/app/split/split-area.directive.ts
@@ -1,5 +1,5 @@
 import {Directive, Optional, Self} from '@angular/core';
-import {FlexDirective} from '@angular/flex-layout';
+import {DefaultFlexDirective} from '@angular/flex-layout';
 
 @Directive({
   selector: '[ngxSplitArea]',
@@ -8,5 +8,5 @@ import {FlexDirective} from '@angular/flex-layout';
   }
 })
 export class SplitAreaDirective {
-  constructor(@Optional() @Self() public flex: FlexDirective) { }
+  constructor(@Optional() @Self() public flex: DefaultFlexDirective) { }
 }

--- a/src/apps/universal-app/src/app/split/split.directive.ts
+++ b/src/apps/universal-app/src/app/split/split.directive.ts
@@ -60,7 +60,7 @@ export class SplitDirective implements AfterContentInit, OnDestroy {
       const currentValue = flex.activatedValue;
 
       // Update Flex-Layout value to build/inject new flexbox CSS
-      flex.activatedValue = this.calculateSize(currentValue, delta);
+      flex.activatedValue = `${this.calculateSize(currentValue, delta)}`;
     });
   }
 

--- a/src/lib/core/add-alias.ts
+++ b/src/lib/core/add-alias.ts
@@ -13,7 +13,7 @@ import {extendObject} from '../utils/object-extend';
  * For the specified MediaChange, make sure it contains the breakpoint alias
  * and suffix (if available).
  */
-export function mergeAlias(dest: MediaChange, source: BreakPoint | null) {
+export function mergeAlias(dest: MediaChange, source: BreakPoint | null): MediaChange {
   return extendObject(dest, source ? {
         mqAlias: source.alias,
         suffix: source.suffix

--- a/src/lib/core/base/base-adapter.ts
+++ b/src/lib/core/base/base-adapter.ts
@@ -17,6 +17,8 @@ import {StyleUtils} from '../style-utils/style-utils';
 /**
  * Adapter to the BaseDirective abstract class so it can be used via composition.
  * @see BaseDirective
+ * @deprecated
+ * @deletion-target v7.0.0-beta.21
  */
 export class BaseDirectiveAdapter extends BaseDirective {
 

--- a/src/lib/core/base/base.ts
+++ b/src/lib/core/base/base.ts
@@ -23,7 +23,11 @@ import {MediaMonitor} from '../media-monitor/media-monitor';
 import {MediaQuerySubscriber} from '../media-change';
 import {StyleBuilder} from '../style-builder/style-builder';
 
-/** Abstract base class for the Layout API styling directives. */
+/**
+ * Abstract base class for the Layout API styling directives.
+ * @deprecated
+ * @deletion-target v7.0.0-beta.21
+ */
 export abstract class BaseDirective implements OnDestroy, OnChanges {
 
   /**

--- a/src/lib/core/base/base2.ts
+++ b/src/lib/core/base/base2.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {ElementRef, OnChanges, OnDestroy, SimpleChanges} from '@angular/core';
+import {Subject} from 'rxjs';
+
+import {StyleDefinition, StyleUtils} from '../style-utils/style-utils';
+import {StyleBuilder} from '../style-builder/style-builder';
+import {MediaMarshaller} from '../media-marshaller/media-marshaller';
+import {buildLayoutCSS} from '../../utils/layout-validator';
+
+export abstract class BaseDirective2 implements OnChanges, OnDestroy {
+
+  protected DIRECTIVE_KEY = '';
+  protected inputs: string[] = [];
+  protected destroySubject: Subject<void> = new Subject();
+
+  /** Access to host element's parent DOM node */
+  protected get parentElement(): HTMLElement | null {
+    return this.elementRef.nativeElement.parentElement;
+  }
+
+  /** Access to the HTMLElement for the directive */
+  protected get nativeElement(): HTMLElement {
+    return this.elementRef.nativeElement;
+  }
+
+  /** Access to the activated value for the directive */
+  get activatedValue(): string {
+    return this.marshal.getValue(this.nativeElement, this.DIRECTIVE_KEY);
+  }
+  set activatedValue(value: string) {
+    this.marshal.setValue(this.nativeElement, this.DIRECTIVE_KEY, value,
+      this.marshal.activatedBreakpoint);
+  }
+
+  /** Cache map for style computation */
+  protected styleCache: Map<string, StyleDefinition> = new Map();
+
+  protected constructor(protected elementRef: ElementRef,
+                        protected styleBuilder: StyleBuilder,
+                        protected styler: StyleUtils,
+                        protected marshal: MediaMarshaller) {
+  }
+
+  /** For @Input changes */
+  ngOnChanges(changes: SimpleChanges) {
+    Object.keys(changes).forEach(key => {
+      if (this.inputs.indexOf(key) !== -1) {
+        const bp = key.split('.')[1] || '';
+        const val = changes[key].currentValue;
+        this.setValue(val, bp);
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroySubject.next();
+    this.destroySubject.complete();
+    this.marshal.releaseElement(this.nativeElement);
+  }
+
+  /** Add styles to the element using predefined style builder */
+  protected addStyles(input: string, parent?: Object) {
+    const builder = this.styleBuilder;
+    const useCache = builder.shouldCache;
+
+    let genStyles: StyleDefinition | undefined = this.styleCache.get(input);
+
+    if (!genStyles || !useCache) {
+      genStyles = builder.buildStyles(input, parent);
+      if (useCache) {
+        this.styleCache.set(input, genStyles);
+      }
+    }
+
+    this.applyStyleToElement(genStyles);
+    builder.sideEffect(input, genStyles, parent);
+  }
+
+  protected triggerUpdate() {
+    const val = this.marshal.getValue(this.nativeElement, this.DIRECTIVE_KEY);
+    this.marshal.updateElement(this.nativeElement, this.DIRECTIVE_KEY, val);
+  }
+
+  /**
+   * Determine the DOM element's Flexbox flow (flex-direction).
+   *
+   * Check inline style first then check computed (stylesheet) style.
+   * And optionally add the flow value to element's inline style.
+   */
+  protected getFlexFlowDirection(target: HTMLElement, addIfMissing = false): string {
+    if (target) {
+      const [value, hasInlineValue] = this.styler.getFlowDirection(target);
+
+      if (!hasInlineValue && addIfMissing) {
+        const style = buildLayoutCSS(value);
+        const elements = [target];
+        this.styler.applyStyleToElements(style, elements);
+      }
+
+      return value.trim();
+    }
+
+    return 'row';
+  }
+
+  /** Applies styles given via string pair or object map to the directive element */
+  protected applyStyleToElement(style: StyleDefinition,
+                                value?: string | number,
+                                element: HTMLElement = this.nativeElement) {
+    this.styler.applyStyleToElement(element, style, value);
+  }
+
+  protected setValue(val: any, bp: string): void {
+    this.marshal.setValue(this.nativeElement, this.DIRECTIVE_KEY, val, bp);
+  }
+}

--- a/src/lib/core/base/index.ts
+++ b/src/lib/core/base/index.ts
@@ -8,3 +8,4 @@
 
 export * from './base';
 export * from './base-adapter';
+export * from './base2';

--- a/src/lib/core/breakpoints/break-point.ts
+++ b/src/lib/core/breakpoints/break-point.ts
@@ -10,4 +10,6 @@ export interface BreakPoint {
   alias: string;
   suffix?: string;
   overlapping?: boolean;
+  // The priority of the individual breakpoint when overlapping another breakpoint
+  priority?: number;
 }

--- a/src/lib/core/breakpoints/breakpoint-tools.ts
+++ b/src/lib/core/breakpoints/breakpoint-tools.ts
@@ -64,3 +64,9 @@ export function mergeByAlias(defaults: BreakPoint[], custom: BreakPoint[] = []):
   return validateSuffixes(Object.keys(dict).map(k => dict[k]));
 }
 
+/** HOF to sort the breakpoints by priority */
+export function prioritySort(a: BreakPoint, b: BreakPoint): number {
+  const priorityA = a.priority || 0;
+  const priorityB = b.priority || 0;
+  return priorityB - priorityA;
+}

--- a/src/lib/core/breakpoints/data/break-points.ts
+++ b/src/lib/core/breakpoints/data/break-points.ts
@@ -14,63 +14,76 @@ export const RESPONSIVE_ALIASES = [
 export const DEFAULT_BREAKPOINTS: BreakPoint[] = [
   {
     alias: 'xs',
-    mediaQuery: '(min-width: 0px) and (max-width: 599px)'
+    mediaQuery: '(min-width: 0px) and (max-width: 599px)',
+    priority: 100,
   },
   {
     alias: 'gt-xs',
     overlapping: true,
-    mediaQuery: '(min-width: 600px)'
+    mediaQuery: '(min-width: 600px)',
+    priority: 7,
   },
   {
     alias: 'lt-sm',
     overlapping: true,
-    mediaQuery: '(max-width: 599px)'
+    mediaQuery: '(max-width: 599px)',
+    priority: 10,
   },
   {
     alias: 'sm',
-    mediaQuery: '(min-width: 600px) and (max-width: 959px)'
+    mediaQuery: '(min-width: 600px) and (max-width: 959px)',
+    priority: 100,
   },
   {
     alias: 'gt-sm',
     overlapping: true,
-    mediaQuery: '(min-width: 960px)'
+    mediaQuery: '(min-width: 960px)',
+    priority: 8,
   },
   {
     alias: 'lt-md',
     overlapping: true,
-    mediaQuery: '(max-width: 959px)'
+    mediaQuery: '(max-width: 959px)',
+    priority: 9,
   },
   {
     alias: 'md',
-    mediaQuery: '(min-width: 960px) and (max-width: 1279px)'
+    mediaQuery: '(min-width: 960px) and (max-width: 1279px)',
+    priority: 100,
   },
   {
     alias: 'gt-md',
     overlapping: true,
-    mediaQuery: '(min-width: 1280px)'
+    mediaQuery: '(min-width: 1280px)',
+    priority: 9,
   },
   {
     alias: 'lt-lg',
     overlapping: true,
-    mediaQuery: '(max-width: 1279px)'
+    mediaQuery: '(max-width: 1279px)',
+    priority: 8,
   },
   {
     alias: 'lg',
-    mediaQuery: '(min-width: 1280px) and (max-width: 1919px)'
+    mediaQuery: '(min-width: 1280px) and (max-width: 1919px)',
+    priority: 100,
   },
   {
     alias: 'gt-lg',
     overlapping: true,
-    mediaQuery: '(min-width: 1920px)'
+    mediaQuery: '(min-width: 1920px)',
+    priority: 10,
   },
   {
     alias: 'lt-xl',
     overlapping: true,
-    mediaQuery: '(max-width: 1919px)'
+    mediaQuery: '(max-width: 1919px)',
+    priority: 7,
   },
   {
     alias: 'xl',
-    mediaQuery: '(min-width: 1920px) and (max-width: 5000px)'
+    mediaQuery: '(min-width: 1920px) and (max-width: 5000px)',
+    priority: 100,
   }
 ];
 

--- a/src/lib/core/breakpoints/index.ts
+++ b/src/lib/core/breakpoints/index.ts
@@ -12,3 +12,4 @@ export * from './data/orientation-break-points';
 export * from './break-point';
 export * from './break-point-registry';
 export * from './break-points-token';
+export {prioritySort} from './breakpoint-tools';

--- a/src/lib/core/match-media/mock/mock-match-media.ts
+++ b/src/lib/core/match-media/mock/mock-match-media.ts
@@ -79,32 +79,32 @@ export class MockMatchMedia extends MatchMedia {
       // Simulate activation of overlapping lt-<XXX> ranges
       switch (alias) {
         case 'lg'   :
-          this._activateByAlias('lt-xl');
+          this._activateByAlias('lt-xl', true);
           break;
         case 'md'   :
-          this._activateByAlias('lt-xl, lt-lg');
+          this._activateByAlias('lt-xl, lt-lg', true);
           break;
         case 'sm'   :
-          this._activateByAlias('lt-xl, lt-lg, lt-md');
+          this._activateByAlias('lt-xl, lt-lg, lt-md', true);
           break;
         case 'xs'   :
-          this._activateByAlias('lt-xl, lt-lg, lt-md, lt-sm');
+          this._activateByAlias('lt-xl, lt-lg, lt-md, lt-sm', true);
           break;
       }
 
       // Simulate activate of overlapping gt-<xxxx> mediaQuery ranges
       switch (alias) {
         case 'xl'   :
-          this._activateByAlias('gt-lg, gt-md, gt-sm, gt-xs');
+          this._activateByAlias('gt-lg, gt-md, gt-sm, gt-xs', true);
           break;
         case 'lg'   :
-          this._activateByAlias('gt-md, gt-sm, gt-xs');
+          this._activateByAlias('gt-md, gt-sm, gt-xs', true);
           break;
         case 'md'   :
-          this._activateByAlias('gt-sm, gt-xs');
+          this._activateByAlias('gt-sm, gt-xs', true);
           break;
         case 'sm'   :
-          this._activateByAlias('gt-xs');
+          this._activateByAlias('gt-xs', true);
           break;
       }
     }
@@ -115,10 +115,10 @@ export class MockMatchMedia extends MatchMedia {
   /**
    *
    */
-  private _activateByAlias(aliases: string) {
+  private _activateByAlias(aliases: string, useOverlaps = false) {
     const activate = (alias: string) => {
       const bp = this._breakpoints.findByAlias(alias);
-      this._activateByQuery(bp ? bp.mediaQuery : alias);
+      this._activateByQuery(bp ? bp.mediaQuery : alias, useOverlaps);
     };
     aliases.split(',').forEach(alias => activate(alias.trim()));
   }
@@ -126,10 +126,13 @@ export class MockMatchMedia extends MatchMedia {
   /**
    *
    */
-  private _activateByQuery(mediaQuery: string) {
-    const mql = this._registry.get(mediaQuery)!;
+  private _activateByQuery(mediaQuery: string, useOverlaps = false) {
+    if (useOverlaps) {
+      this._registerMediaQuery(mediaQuery);
+    }
+    const mql = this._registry.get(mediaQuery);
     const alreadyAdded = this._actives
-      .reduce((found, it) => (found || (mql && (it.media === mql.media))), false);
+      .reduce((found, it) => (found || (mql ? (it.media === mql.media) : false)), false);
 
     if (mql && !alreadyAdded) {
       this._actives.push(mql.activate());

--- a/src/lib/core/media-marshaller/media-marshaller.spec.ts
+++ b/src/lib/core/media-marshaller/media-marshaller.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {async, fakeAsync, inject, TestBed} from '@angular/core/testing';
+import {Subject} from 'rxjs';
+
+import {MockMatchMedia, MockMatchMediaProvider} from '../match-media/mock/mock-match-media';
+import {MatchMedia} from '../match-media/match-media';
+import {MediaMarshaller} from './media-marshaller';
+
+describe('media-marshaller', () => {
+  let matchMedia: MockMatchMedia;
+  let mediaMarshaller: MediaMarshaller;
+
+  beforeEach(() => {
+    // Configure testbed to prepare services
+    TestBed.configureTestingModule({
+      providers: [MockMatchMediaProvider]
+    });
+    spyOn(MediaMarshaller.prototype, 'activate').and.callThrough();
+  });
+
+  // Single async inject to save references; which are used in all tests below
+  beforeEach(async(inject([MatchMedia, MediaMarshaller],
+    (service: MockMatchMedia, marshal: MediaMarshaller) => {
+    matchMedia = service;      // inject only to manually activate mediaQuery ranges
+    mediaMarshaller = marshal;
+  })));
+  afterEach(() => {
+    matchMedia.clearAll();
+  });
+
+  it('activates when match-media activates', () => {
+    matchMedia.activate('xs');
+    expect(mediaMarshaller.activate).toHaveBeenCalled();
+  });
+
+  it('should set correct activated breakpoint', () => {
+    matchMedia.activate('lg');
+    expect(mediaMarshaller.activatedBreakpoint).toBe('lg');
+
+    matchMedia.activate('gt-md');
+    expect(mediaMarshaller.activatedBreakpoint).toBe('gt-md');
+  });
+
+  it('should init', () => {
+    let triggered = false;
+    const builder = () => {
+      triggered = true;
+    };
+    mediaMarshaller.init(fakeElement, fakeKey, builder);
+    mediaMarshaller.setValue(fakeElement, fakeKey, 0, 'xs');
+    triggered = false;
+    matchMedia.activate('xs');
+    expect(triggered).toBeTruthy();
+  });
+
+  it('should init with observables', () => {
+    let triggered = false;
+    const subject: Subject<void> = new Subject();
+    const obs = subject.asObservable();
+    const builder = () => {
+      triggered = true;
+    };
+    mediaMarshaller.init(fakeElement, fakeKey, builder, [obs]);
+    subject.next();
+    expect(triggered).toBeTruthy();
+  });
+
+  it('should updateStyles', () => {
+    let triggered = false;
+    const builder = () => {
+      triggered = true;
+    };
+    mediaMarshaller.init(fakeElement, fakeKey, builder);
+    mediaMarshaller.setValue(fakeElement, fakeKey, 0, '');
+    triggered = false;
+    mediaMarshaller.updateStyles();
+    expect(triggered).toBeTruthy();
+  });
+
+  it('should updateElement', () => {
+    let triggered = false;
+    const builder = () => {
+      triggered = true;
+    };
+    mediaMarshaller.init(fakeElement, fakeKey, builder);
+    mediaMarshaller.updateElement(fakeElement, fakeKey, 0);
+    expect(triggered).toBeTruthy();
+  });
+
+  it('should get the right value', () => {
+    const builder = () => {};
+    mediaMarshaller.init(fakeElement, fakeKey, builder);
+    mediaMarshaller.setValue(fakeElement, fakeKey, 0, '');
+    const value = mediaMarshaller.getValue(fakeElement, fakeKey);
+    expect(value).toEqual(0);
+  });
+
+  it('should track changes', fakeAsync(() => {
+    const builder = () => {};
+    let triggered = false;
+    mediaMarshaller.init(fakeElement, fakeKey, builder);
+    mediaMarshaller.trackValue(fakeElement, fakeKey).subscribe(() => {
+      triggered = true;
+    });
+    mediaMarshaller.setValue(fakeElement, fakeKey, 0, '');
+    expect(triggered).toBeTruthy();
+  }));
+
+  it('should release', () => {
+    let triggered = false;
+    const subject: Subject<void> = new Subject();
+    const obs = subject.asObservable();
+    const builder = () => {
+      triggered = true;
+    };
+    mediaMarshaller.init(fakeElement, fakeKey, builder, [obs]);
+    mediaMarshaller.releaseElement(fakeElement);
+    subject.next();
+    expect(triggered).toBeFalsy();
+  });
+});
+
+const fakeElement = {} as HTMLElement;
+const fakeKey = 'FAKE_KEY';

--- a/src/lib/core/media-marshaller/media-marshaller.ts
+++ b/src/lib/core/media-marshaller/media-marshaller.ts
@@ -1,0 +1,227 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Injectable} from '@angular/core';
+import {merge, Observable, Subject, Subscription} from 'rxjs';
+import {filter} from 'rxjs/operators';
+
+import {BreakPoint} from '../breakpoints/break-point';
+import {prioritySort} from '../breakpoints/breakpoint-tools';
+import {BreakPointRegistry} from '../breakpoints/break-point-registry';
+import {MatchMedia} from '../match-media/match-media';
+import {MediaChange} from '../media-change';
+
+type Builder = Function;
+type ValueMap = Map<string, string>;
+type BreakpointMap = Map<string, ValueMap>;
+type ElementMap = Map<HTMLElement, BreakpointMap>;
+type SubscriptionMap = Map<string, Subscription>;
+type WatcherMap = WeakMap<HTMLElement, SubscriptionMap>;
+type BuilderMap = WeakMap<HTMLElement, Map<string, Builder>>;
+
+export interface ElementMatcher {
+  element: HTMLElement;
+  key: string;
+  value: any;
+}
+
+/**
+ * MediaMarshaller - register responsive values from directives and
+ *                   trigger them based on media query events
+ */
+@Injectable({providedIn: 'root'})
+export class MediaMarshaller {
+  private activatedBreakpoints: BreakPoint[] = [];
+  private elementMap: ElementMap = new Map();
+  private watcherMap: WatcherMap = new WeakMap();
+  private builderMap: BuilderMap = new WeakMap();
+  private subject: Subject<ElementMatcher> = new Subject();
+
+  get activatedBreakpoint(): string {
+    return this.activatedBreakpoints[0] ? this.activatedBreakpoints[0].alias : '';
+  }
+
+  constructor(protected matchMedia: MatchMedia,
+              protected breakpoints: BreakPointRegistry) {
+    this.matchMedia.observe().subscribe(this.activate.bind(this));
+  }
+
+  /**
+   * activate or deactivate a given breakpoint
+   * @param mc
+   */
+  activate(mc: MediaChange) {
+    const bp: BreakPoint | null = this.findByQuery(mc.mediaQuery);
+    if (mc.matches && bp) {
+      this.activatedBreakpoints.push(bp);
+      this.activatedBreakpoints.sort(prioritySort);
+    } else if (!mc.matches && bp) {
+      // Remove the breakpoint when it's deactivated
+      this.activatedBreakpoints.splice(this.activatedBreakpoints.indexOf(bp), 1);
+    }
+    this.updateStyles();
+  }
+
+  /**
+   * initialize the marshaller with necessary elements for delegation on an element
+   * @param element
+   * @param key
+   * @param builder optional so that custom bp directives don't have to re-provide this
+   * @param observables
+   */
+  init(element: HTMLElement,
+       key: string,
+       builder?: Builder,
+       observables: Observable<any>[] = []): void {
+    if (builder) {
+      let builders = this.builderMap.get(element);
+      if (!builders) {
+        builders = new Map();
+        this.builderMap.set(element, builders);
+      }
+      builders.set(key, builder);
+    }
+    if (observables) {
+      let watchers = this.watcherMap.get(element);
+      if (!watchers) {
+        watchers = new Map();
+        this.watcherMap.set(element, watchers);
+      }
+      const subscription = watchers.get(key);
+      if (!subscription) {
+        const newSubscription = merge(...observables).subscribe(() => {
+          const currentValue = this.getValue(element, key);
+          this.updateElement(element, key, currentValue);
+        });
+        watchers.set(key, newSubscription);
+      }
+    }
+  }
+
+  /**
+   * get the value for an element and key and optionally a given breakpoint
+   * @param element
+   * @param key
+   * @param bp
+   */
+  getValue(element: HTMLElement, key: string, bp?: string): any {
+    const bpMap = this.elementMap.get(element);
+    if (bpMap) {
+      const values = bp !== undefined ? bpMap.get(bp) : this.getFallback(bpMap);
+      if (values) {
+        const value = values.get(key);
+        return value !== undefined ? value : '';
+      }
+    }
+    return '';
+  }
+
+  /**
+   * whether the element has values for a given key
+   * @param element
+   * @param key
+   */
+  hasValue(element: HTMLElement, key: string): boolean {
+    const bpMap = this.elementMap.get(element);
+    if (bpMap) {
+      const values = this.getFallback(bpMap);
+      if (values) {
+        return values.get(key) !== undefined || false;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Set the value for an input on a directive
+   * @param element the element in question
+   * @param key the type of the directive (e.g. flex, layout-gap, etc)
+   * @param bp the breakpoint suffix (empty string = default)
+   * @param val the value for the breakpoint
+   */
+  setValue(element: HTMLElement, key: string, val: any, bp: string): void {
+    let bpMap: BreakpointMap | undefined = this.elementMap.get(element);
+    if (!bpMap) {
+      bpMap = new Map().set(bp, new Map().set(key, val));
+      this.elementMap.set(element, bpMap);
+    } else {
+      const values = (bpMap.get(bp) || new Map()).set(key, val);
+      bpMap.set(bp, values);
+      this.elementMap.set(element, bpMap);
+    }
+    this.updateElement(element, key, this.getValue(element, key));
+  }
+
+  trackValue(element: HTMLElement, key: string): Observable<ElementMatcher> {
+    return this.subject.asObservable()
+      .pipe(filter(v => v.element === element && v.key === key));
+  }
+
+  /** update all styles for all elements on the current breakpoint */
+  updateStyles(): void {
+    this.elementMap.forEach((bpMap, el) => {
+      const valueMap = this.getFallback(bpMap);
+      if (valueMap) {
+        valueMap.forEach((v, k) => this.updateElement(el, k, v));
+      }
+    });
+  }
+
+  /**
+   * update a given element with the activated values for a given key
+   * @param element
+   * @param key
+   * @param value
+   */
+  updateElement(element: HTMLElement, key: string, value: any): void {
+    const builders = this.builderMap.get(element);
+    if (builders) {
+      const builder: Builder | undefined = builders.get(key);
+      if (builder) {
+        builder(value);
+        this.subject.next({element, key, value});
+      }
+    }
+  }
+
+  /**
+   * release all references to a given element
+   * @param element
+   */
+  releaseElement(element: HTMLElement): void {
+    const watcherMap = this.watcherMap.get(element);
+    if (watcherMap) {
+      watcherMap.forEach(s => s.unsubscribe());
+      this.watcherMap.delete(element);
+    }
+    const elementMap = this.elementMap.get(element);
+    if (elementMap) {
+      elementMap.forEach((_, s) => elementMap.delete(s));
+      this.elementMap.delete(element);
+    }
+  }
+
+  /** Breakpoint locator by mediaQuery */
+  private findByQuery(query: string) {
+    return this.breakpoints.findByQuery(query);
+  }
+
+  /**
+   * get the fallback breakpoint for a given element, starting with the current breakpoint
+   * @param bpMap
+   */
+  private getFallback(bpMap: BreakpointMap): ValueMap | undefined {
+    for (let i = 0; i < this.activatedBreakpoints.length; i++) {
+      const activatedBp = this.activatedBreakpoints[i];
+      const valueMap = bpMap.get(activatedBp.alias);
+      if (valueMap) {
+        return valueMap;
+      }
+    }
+    return bpMap.get('');
+  }
+}

--- a/src/lib/core/media-monitor/media-monitor.ts
+++ b/src/lib/core/media-monitor/media-monitor.ts
@@ -28,6 +28,8 @@ import {mergeAlias} from '../add-alias';
  *  - injects alias information into each raw MediaChange event
  *  - provides accessor to the currently active BreakPoint
  *  - publish list of overlapping BreakPoint(s); used by ResponsiveActivation
+ * @deprecated
+ * @deletion-target v7.0.0-beta.21
  */
 @Injectable({providedIn: 'root'})
 export class MediaMonitor {

--- a/src/lib/core/module.ts
+++ b/src/lib/core/module.ts
@@ -8,6 +8,7 @@
 import {NgModule} from '@angular/core';
 
 import {BROWSER_PROVIDER} from './browser-provider';
+import {ObservableMediaProvider} from './observable-media/observable-media';
 
 /**
  * *****************************************************************
@@ -16,7 +17,7 @@ import {BROWSER_PROVIDER} from './browser-provider';
  */
 
 @NgModule({
-  providers: [BROWSER_PROVIDER]
+  providers: [BROWSER_PROVIDER, ObservableMediaProvider]
 })
 export class CoreModule {
 }

--- a/src/lib/core/public-api.ts
+++ b/src/lib/core/public-api.ts
@@ -23,3 +23,4 @@ export * from './responsive-activation/responsive-activation';
 export * from './style-utils/style-utils';
 export * from './style-builder/style-builder';
 export * from './basis-validator/basis-validator';
+export * from './media-marshaller/media-marshaller';

--- a/src/lib/core/responsive-activation/responsive-activation.ts
+++ b/src/lib/core/responsive-activation/responsive-activation.ts
@@ -13,11 +13,19 @@ import {BreakPoint} from '../breakpoints/break-point';
 import {MediaMonitor} from '../media-monitor/media-monitor';
 import {extendObject} from '../../utils/object-extend';
 
+/**
+ * @deprecated
+ * @deletion-target v7.0.0-beta.21
+ */
 export interface BreakPointX extends BreakPoint {
   key: string;
   baseKey: string;
 }
 
+/**
+ * @deprecated
+ * @deletion-target v7.0.0-beta.21
+ */
 export class KeyOptions {
   constructor(public baseKey: string,
               public defaultValue: string|number|boolean,
@@ -36,6 +44,8 @@ export class KeyOptions {
  *   MediaQueryServices.
  *
  * NOTE: these interceptions enables the logic in the fx API directives to remain terse and clean.
+ * @deprecated
+ * @deletion-target v7.0.0-beta.21
  */
 export class ResponsiveActivation {
   private _activatedInputKey: string = '';

--- a/src/lib/extended/class/class.spec.ts
+++ b/src/lib/extended/class/class.spec.ts
@@ -18,7 +18,7 @@ import {
 
 import {customMatchers, expect} from '../../utils/testing/custom-matchers';
 import {makeCreateTestComponent, expectNativeEl, queryFor} from '../../utils/testing/helpers';
-import {ClassDirective} from './class';
+import {DefaultClassDirective} from './class';
 
 
 describe('class directive', () => {
@@ -44,7 +44,7 @@ describe('class directive', () => {
         CommonModule,
         CoreModule
       ],
-      declarations: [TestClassComponent, ClassDirective],
+      declarations: [TestClassComponent, DefaultClassDirective],
       providers: [MockMatchMediaProvider]
     });
   });

--- a/src/lib/extended/img-src/img-src.ts
+++ b/src/lib/extended/img-src/img-src.ts
@@ -5,96 +5,46 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {
-  Directive,
-  ElementRef,
-  Input,
-  OnInit,
-  OnChanges,
-  Inject,
-  Optional,
-  PLATFORM_ID,
-} from '@angular/core';
+import {Directive, ElementRef, Inject, PLATFORM_ID, Injectable, Input} from '@angular/core';
 import {isPlatformServer} from '@angular/common';
 import {
-  BaseDirective,
-  MediaMonitor,
+  MediaMarshaller,
+  BaseDirective2,
   SERVER_TOKEN,
+  StyleBuilder,
+  StyleDefinition,
   StyleUtils,
 } from '@angular/flex-layout/core';
 
+@Injectable({providedIn: 'root'})
+export class ImgSrcStyleBuilder extends StyleBuilder {
+  buildStyles(url: string) {
+    return {'content': url ? `url(${url})` : ''};
+  }
+}
 
-/**
- * This directive provides a responsive API for the HTML <img> 'src' attribute
- * and will update the img.src property upon each responsive activation.
- *
- * e.g.
- *      <img src="defaultScene.jpg" src.xs="mobileScene.jpg"></img>
- *
- * @see https://css-tricks.com/responsive-images-youre-just-changing-resolutions-use-src/
- */
-@Directive({
-  selector: `
-  img[src.xs],    img[src.sm],    img[src.md],    img[src.lg],   img[src.xl],
-  img[src.lt-sm], img[src.lt-md], img[src.lt-lg], img[src.lt-xl],
-  img[src.gt-xs], img[src.gt-sm], img[src.gt-md], img[src.gt-lg]
-`
-})
-export class ImgSrcDirective extends BaseDirective implements OnInit, OnChanges {
+export class ImgSrcDirective extends BaseDirective2 {
+  protected DIRECTIVE_KEY = 'img-src';
+  protected defaultSrc = '';
 
-  /* tslint:disable */
-  @Input('src')        set srcBase(val: string) { this.cacheDefaultSrc(val);           }
+  @Input('src')
+  set src(val: string) {
+    this.defaultSrc = val;
+    this.setValue('', this.defaultSrc);
+  }
 
-  @Input('src.xs')     set srcXs(val: string)   { this._cacheInput('srcXs', val);  }
-  @Input('src.sm')     set srcSm(val: string)   { this._cacheInput('srcSm', val);  }
-  @Input('src.md')     set srcMd(val: string)   { this._cacheInput('srcMd', val);  }
-  @Input('src.lg')     set srcLg(val: string)   { this._cacheInput('srcLg', val);  }
-  @Input('src.xl')     set srcXl(val: string)   { this._cacheInput('srcXl', val);  }
-
-  @Input('src.lt-sm')  set srcLtSm(val: string) { this._cacheInput('srcLtSm', val);  }
-  @Input('src.lt-md')  set srcLtMd(val: string) { this._cacheInput('srcLtMd', val);  }
-  @Input('src.lt-lg')  set srcLtLg(val: string) { this._cacheInput('srcLtLg', val);  }
-  @Input('src.lt-xl')  set srcLtXl(val: string) { this._cacheInput('srcLtXl', val);  }
-
-  @Input('src.gt-xs')  set srcGtXs(val: string) { this._cacheInput('srcGtXs', val);  }
-  @Input('src.gt-sm')  set srcGtSm(val: string) { this._cacheInput('srcGtSm', val);  }
-  @Input('src.gt-md')  set srcGtMd(val: string) { this._cacheInput('srcGtMd', val);  }
-  @Input('src.gt-lg')  set srcGtLg(val: string) { this._cacheInput('srcGtLg', val);  }
-  /* tslint:enable */
-
-  constructor(protected _elRef: ElementRef,
-              protected _monitor: MediaMonitor,
-              protected _styler: StyleUtils,
-              @Inject(PLATFORM_ID) protected _platformId: Object,
-              @Optional() @Inject(SERVER_TOKEN) protected _serverModuleLoaded: boolean) {
-    super(_monitor, _elRef, _styler);
-    this._cacheInput('src', _elRef.nativeElement.getAttribute('src') || '');
-    if (isPlatformServer(this._platformId) && this._serverModuleLoaded) {
+  constructor(protected elementRef: ElementRef,
+              protected styleBuilder: ImgSrcStyleBuilder,
+              protected styler: StyleUtils,
+              protected marshal: MediaMarshaller,
+              @Inject(PLATFORM_ID) protected platformId: Object,
+              @Inject(SERVER_TOKEN) protected serverModuleLoaded: boolean) {
+    super(elementRef, styleBuilder, styler, marshal);
+    this.marshal.init(this.elementRef.nativeElement, this.DIRECTIVE_KEY,
+      this.updateSrcFor.bind(this));
+    this.setValue('', this.nativeElement.getAttribute('src') || '');
+    if (isPlatformServer(this.platformId) && this.serverModuleLoaded) {
       this.nativeElement.setAttribute('src', '');
-    }
-  }
-
-  /**
-   * Listen for responsive changes to update the img.src attribute
-   */
-  ngOnInit() {
-    super.ngOnInit();
-
-    if (this.hasResponsiveKeys) {
-      // Listen for responsive changes
-      this._listenForMediaQueryChanges('src', this.defaultSrc, () => {
-        this._updateSrcFor();
-      });
-    }
-    this._updateSrcFor();
-  }
-
-  /**
-   * Update the 'src' property of the host <img> element
-   */
-  ngOnChanges() {
-    if (this.hasInitialized) {
-      this._updateSrcFor();
     }
   }
 
@@ -106,40 +56,42 @@ export class ImgSrcDirective extends BaseDirective implements OnInit, OnChanges 
    * Do nothing to standard `<img src="">` usages, only when responsive
    * keys are present do we actually call `setAttribute()`
    */
-  protected _updateSrcFor() {
-    if (this.hasResponsiveKeys) {
-      let url = this.activatedValue || this.defaultSrc;
-      if (isPlatformServer(this._platformId) && this._serverModuleLoaded) {
-        this._styler.applyStyleToElement(this.nativeElement, {'content': url ? `url(${url})` : ''});
-      } else {
-        this.nativeElement.setAttribute('src', String(url));
-      }
+  protected updateSrcFor() {
+    let url = this.activatedValue || this.defaultSrc;
+    if (isPlatformServer(this.platformId) && this.serverModuleLoaded) {
+      this.addStyles(url);
+    } else {
+      this.nativeElement.setAttribute('src', String(url));
     }
   }
 
-  /**
-   * Cache initial value of 'src', this will be used as fallback when breakpoint
-   * activations change.
-   * NOTE: The default 'src' property is not bound using @Input(), so perform
-   * a post-ngOnInit() lookup of the default src value (if any).
-   */
-  protected cacheDefaultSrc(value?: string) {
-    this._cacheInput('src', value || '');
-  }
+  protected styleCache = imgSrcCache;
+}
 
-  /**
-   * Empty values are maintained, undefined values are exposed as ''
-   */
-  protected get defaultSrc(): string {
-    return this._queryInput('src') || '';
-  }
+const imgSrcCache: Map<string, StyleDefinition> = new Map();
 
-  /**
-   * Does the <img> have 1 or more src.<xxx> responsive inputs
-   * defined... these will be mapped to activated breakpoints.
-   */
-  protected get hasResponsiveKeys() {
-    return Object.keys(this._inputMap).length > 1;
-  }
+const inputs = [
+  'src.xs', 'src.sm', 'src.md', 'src.lg', 'src.xl',
+  'src.lt-sm', 'src.lt-md', 'src.lt-lg', 'src.lt-xl',
+  'src.gt-xs', 'src.gt-sm', 'src.gt-md', 'src.gt-lg'
+];
 
+const selector = `
+  img[src.xs],    img[src.sm],    img[src.md],    img[src.lg],   img[src.xl],
+  img[src.lt-sm], img[src.lt-md], img[src.lt-lg], img[src.lt-xl],
+  img[src.gt-xs], img[src.gt-sm], img[src.gt-md], img[src.gt-lg]
+`;
+
+/**
+ * This directive provides a responsive API for the HTML <img> 'src' attribute
+ * and will update the img.src property upon each responsive activation.
+ *
+ * e.g.
+ *      <img src="defaultScene.jpg" src.xs="mobileScene.jpg"></img>
+ *
+ * @see https://css-tricks.com/responsive-images-youre-just-changing-resolutions-use-src/
+ */
+@Directive({selector, inputs})
+export class DefaultImgSrcDirective extends ImgSrcDirective {
+  protected inputs = inputs;
 }

--- a/src/lib/extended/module.ts
+++ b/src/lib/extended/module.ts
@@ -8,17 +8,17 @@
 import {NgModule} from '@angular/core';
 import {CoreModule} from '@angular/flex-layout/core';
 
-import {ImgSrcDirective} from './img-src/img-src';
-import {ClassDirective} from './class/class';
-import {ShowHideDirective} from './show-hide/show-hide';
-import {StyleDirective} from './style/style';
+import {DefaultImgSrcDirective} from './img-src/img-src';
+import {DefaultClassDirective} from './class/class';
+import {DefaultShowHideDirective} from './show-hide/show-hide';
+import {DefaultStyleDirective} from './style/style';
 
 
 const ALL_DIRECTIVES = [
-  ShowHideDirective,
-  ClassDirective,
-  StyleDirective,
-  ImgSrcDirective
+  DefaultShowHideDirective,
+  DefaultClassDirective,
+  DefaultStyleDirective,
+  DefaultImgSrcDirective
 ];
 
 /**

--- a/src/lib/extended/show-hide/hide.spec.ts
+++ b/src/lib/extended/show-hide/hide.spec.ts
@@ -22,7 +22,7 @@ import {customMatchers, expect, NgMatchers} from '../../utils/testing/custom-mat
 import {
   makeCreateTestComponent, expectNativeEl, queryFor
 } from '../../utils/testing/helpers';
-import {ShowHideDirective} from './show-hide';
+import {DefaultShowHideDirective} from './show-hide';
 
 
 describe('hide directive', () => {
@@ -60,7 +60,7 @@ describe('hide directive', () => {
     // Configure testbed to prepare services
     TestBed.configureTestingModule({
       imports: [CommonModule, CoreModule],
-      declarations: [TestHideComponent, ShowHideDirective],
+      declarations: [TestHideComponent, DefaultShowHideDirective],
       providers: [
         MockMatchMediaProvider,
         {provide: SERVER_TOKEN, useValue: true},

--- a/src/lib/extended/show-hide/show-hide.ts
+++ b/src/lib/extended/show-hide/show-hide.ts
@@ -8,50 +8,167 @@
 import {
   Directive,
   ElementRef,
-  Input,
-  OnInit,
   OnChanges,
-  OnDestroy,
   SimpleChanges,
-  Self,
   Optional,
   Inject,
   PLATFORM_ID,
-  ViewChild,
+  Injectable,
   AfterViewInit,
 } from '@angular/core';
 import {isPlatformServer} from '@angular/common';
 import {
-  BaseDirective,
+  BaseDirective2,
   LAYOUT_CONFIG,
   LayoutConfigOptions,
-  MediaChange,
-  MediaMonitor,
+  MediaMarshaller,
   SERVER_TOKEN,
   StyleUtils,
+  StyleBuilder,
 } from '@angular/flex-layout/core';
-import {FlexDirective, LayoutDirective} from '@angular/flex-layout/flex';
-import {Subscription} from 'rxjs';
-
-const FALSY = ['false', false, 0];
+import {coerceBooleanProperty} from '@angular/cdk/coercion';
+import {takeUntil} from 'rxjs/operators';
 
 /**
  * For fxHide selectors, we invert the 'value'
  * and assign to the equivalent fxShow selector cache
  *  - When 'hide' === '' === true, do NOT show the element
  *  - When 'hide' === false or 0... we WILL show the element
+ * @deprecated
+ * @deletion-target v7.0.0-beta.21
  */
 export function negativeOf(hide: any) {
   return (hide === '') ? false :
          ((hide === 'false') || (hide === 0)) ? true : !hide;
 }
 
-/**
- * 'show' Layout API directive
- *
- */
-@Directive({
-  selector: `
+export interface ShowHideParent {
+  display: string;
+}
+
+@Injectable({providedIn: 'root'})
+export class ShowHideStyleBuilder extends StyleBuilder {
+  buildStyles(show: string, parent: ShowHideParent) {
+    const shouldShow = show === 'true';
+    return {'display': shouldShow ? parent.display : 'none'};
+  }
+}
+
+export class ShowHideDirective extends BaseDirective2 implements AfterViewInit, OnChanges {
+  protected DIRECTIVE_KEY = 'show-hide';
+
+  /** Original dom Elements CSS display style */
+  protected display: string = '';
+  protected hasLayout = false;
+  protected hasFlexChild = false;
+
+  constructor(protected elementRef: ElementRef,
+              protected styleBuilder: ShowHideStyleBuilder,
+              protected styler: StyleUtils,
+              protected marshal: MediaMarshaller,
+              @Inject(LAYOUT_CONFIG) protected layoutConfig: LayoutConfigOptions,
+              @Inject(PLATFORM_ID) protected platformId: Object,
+              @Optional() @Inject(SERVER_TOKEN) protected serverModuleLoaded: boolean) {
+    super(elementRef, styleBuilder, styler, marshal);
+  }
+
+  // *********************************************
+  // Lifecycle Methods
+  // *********************************************
+
+  ngAfterViewInit() {
+    this.hasLayout = this.marshal.hasValue(this.nativeElement, 'layout');
+    this.marshal.trackValue(this.nativeElement, 'layout')
+      .pipe(takeUntil(this.destroySubject))
+      .subscribe(this.updateWithValue.bind(this));
+
+    const children = Array.from(this.nativeElement.children);
+    for (let i = 0; i < children.length; i++) {
+      if (this.marshal.hasValue(children[i] as HTMLElement, 'flex')) {
+        this.hasFlexChild = true;
+        break;
+      }
+    }
+
+    if (DISPLAY_MAP.has(this.nativeElement)) {
+      this.display = DISPLAY_MAP.get(this.nativeElement)!;
+    } else {
+      this.display = this.getDisplayStyle();
+      DISPLAY_MAP.set(this.nativeElement, this.display);
+    }
+
+    this.marshal.init(this.elementRef.nativeElement, this.DIRECTIVE_KEY,
+      this.updateWithValue.bind(this));
+    // set the default to show unless explicitly overridden
+    const defaultValue = this.marshal.getValue(this.nativeElement, this.DIRECTIVE_KEY, '');
+    if (defaultValue === undefined || defaultValue === '') {
+      this.setValue(true, '');
+    }
+    this.updateWithValue(this.marshal.getValue(this.nativeElement, this.DIRECTIVE_KEY));
+  }
+
+  /**
+   * On changes to any @Input properties...
+   * Default to use the non-responsive Input value ('fxShow')
+   * Then conditionally override with the mq-activated Input's current value
+   */
+  ngOnChanges(changes: SimpleChanges) {
+    Object.keys(changes).forEach(key => {
+      if (this.inputs.indexOf(key) !== -1) {
+        const inputKey = key.split('.');
+        const bp = inputKey[1] || '';
+        const inputValue = changes[key].currentValue;
+        let shouldShow = inputValue !== '' ?
+          inputValue !== 0 ? coerceBooleanProperty(inputValue) : false
+          : true;
+        if (inputKey[0] === 'fxHide') {
+          shouldShow = !shouldShow;
+        }
+        this.setValue(shouldShow, bp);
+      }
+    });
+  }
+
+  // *********************************************
+  // Protected methods
+  // *********************************************
+
+  /**
+   * Override accessor to the current HTMLElement's `display` style
+   * Note: Show/Hide will not change the display to 'flex' but will set it to 'block'
+   * unless it was already explicitly specified inline or in a CSS stylesheet.
+   */
+  protected getDisplayStyle(): string {
+    return (this.hasLayout || (this.hasFlexChild && this.layoutConfig.addFlexToParent)) ?
+      'flex' : this.styler.lookupStyle(this.nativeElement, 'display', true);
+  }
+
+  /** Validate the visibility value and then update the host's inline display style */
+  protected updateWithValue(value: boolean|string = true) {
+    if (value === '') {
+      return;
+    }
+    this.addStyles(value ? 'true' : 'false', {display: this.display});
+    if (isPlatformServer(this.platformId) && this.serverModuleLoaded) {
+      this.nativeElement.style.setProperty('display', '');
+    }
+  }
+}
+
+const DISPLAY_MAP: WeakMap<HTMLElement, string> = new WeakMap();
+
+const inputs = [
+  'fxShow',
+  'fxShow.xs', 'fxShow.sm', 'fxShow.md', 'fxShow.lg', 'fxShow.xl',
+  'fxShow.lt-sm', 'fxShow.lt-md', 'fxShow.lt-lg', 'fxShow.lt-xl',
+  'fxShow.gt-xs', 'fxShow.gt-sm', 'fxShow.gt-md', 'fxShow.gt-lg',
+  'fxHide',
+  'fxHide.xs', 'fxHide.sm', 'fxHide.md', 'fxHide.lg', 'fxHide.xl',
+  'fxHide.lt-sm', 'fxHide.lt-md', 'fxHide.lt-lg', 'fxHide.lt-xl',
+  'fxHide.gt-xs', 'fxHide.gt-sm', 'fxHide.gt-md', 'fxHide.gt-lg'
+];
+
+const selector = `
   [fxShow],
   [fxShow.xs], [fxShow.sm], [fxShow.md], [fxShow.lg], [fxShow.xl],
   [fxShow.lt-sm], [fxShow.lt-md], [fxShow.lt-lg], [fxShow.lt-xl],
@@ -60,160 +177,12 @@ export function negativeOf(hide: any) {
   [fxHide.xs], [fxHide.sm], [fxHide.md], [fxHide.lg], [fxHide.xl],
   [fxHide.lt-sm], [fxHide.lt-md], [fxHide.lt-lg], [fxHide.lt-xl],
   [fxHide.gt-xs], [fxHide.gt-sm], [fxHide.gt-md], [fxHide.gt-lg]
-`
-})
-export class ShowHideDirective extends BaseDirective
-  implements OnInit, OnChanges, OnDestroy, AfterViewInit {
+`;
 
-  /**
-   * Subscription to the parent flex container's layout changes.
-   * Stored so we can unsubscribe when this directive is destroyed.
-   */
-  protected _layoutWatcher?: Subscription;
-
-  /** Original dom Elements CSS display style */
-  protected _display: string = '';
-
-  /* tslint:disable */
-  @Input('fxShow')       set show(val: string) {  this._cacheInput('show', val);  }
-  @Input('fxShow.xs')    set showXs(val: string) {this._cacheInput('showXs', val);}
-  @Input('fxShow.sm')    set showSm(val: string) {this._cacheInput('showSm', val); };
-  @Input('fxShow.md')    set showMd(val: string) {this._cacheInput('showMd', val); };
-  @Input('fxShow.lg')    set showLg(val: string) {this._cacheInput('showLg', val); };
-  @Input('fxShow.xl')    set showXl(val: string) {this._cacheInput('showXl', val); };
-
-  @Input('fxShow.lt-sm') set showLtSm(val: string) { this._cacheInput('showLtSm', val); };
-  @Input('fxShow.lt-md') set showLtMd(val: string) { this._cacheInput('showLtMd', val); };
-  @Input('fxShow.lt-lg') set showLtLg(val: string) { this._cacheInput('showLtLg', val); };
-  @Input('fxShow.lt-xl') set showLtXl(val: string) { this._cacheInput('showLtXl', val); };
-
-  @Input('fxShow.gt-xs') set showGtXs(val: string) {this._cacheInput('showGtXs', val); };
-  @Input('fxShow.gt-sm') set showGtSm(val: string) {this._cacheInput('showGtSm', val); };
-  @Input('fxShow.gt-md') set showGtMd(val: string) {this._cacheInput('showGtMd', val); };
-  @Input('fxShow.gt-lg') set showGtLg(val: string) {this._cacheInput('showGtLg', val); };
-
-  @Input('fxHide')       set hide(val: string) {this._cacheInput('show', negativeOf(val));}
-  @Input('fxHide.xs')    set hideXs(val: string) {this._cacheInput('showXs', negativeOf(val));}
-  @Input('fxHide.sm')    set hideSm(val: string) {this._cacheInput('showSm', negativeOf(val)); };
-  @Input('fxHide.md')    set hideMd(val: string) {this._cacheInput('showMd', negativeOf(val)); };
-  @Input('fxHide.lg')    set hideLg(val: string) {this._cacheInput('showLg', negativeOf(val)); };
-  @Input('fxHide.xl')    set hideXl(val: string) {this._cacheInput('showXl', negativeOf(val)); };
-
-  @Input('fxHide.lt-sm') set hideLtSm(val: string) { this._cacheInput('showLtSm', negativeOf(val)); };
-  @Input('fxHide.lt-md') set hideLtMd(val: string) { this._cacheInput('showLtMd', negativeOf(val)); };
-  @Input('fxHide.lt-lg') set hideLtLg(val: string) { this._cacheInput('showLtLg', negativeOf(val)); };
-  @Input('fxHide.lt-xl') set hideLtXl(val: string) { this._cacheInput('showLtXl', negativeOf(val)); };
-
-  @Input('fxHide.gt-xs') set hideGtXs(val: string) {this._cacheInput('showGtXs', negativeOf(val)); };
-  @Input('fxHide.gt-sm') set hideGtSm(val: string) {this._cacheInput('showGtSm', negativeOf(val)); };
-  @Input('fxHide.gt-md') set hideGtMd(val: string) {this._cacheInput('showGtMd', negativeOf(val)); };
-  @Input('fxHide.gt-lg') set hideGtLg(val: string) {this._cacheInput('showGtLg', negativeOf(val)); };
-  /* tslint:enable */
-
-  @ViewChild(FlexDirective) protected _flexChild: FlexDirective | null = null;
-
-  constructor(monitor: MediaMonitor,
-              @Optional() @Self() protected layout: LayoutDirective,
-              protected elRef: ElementRef,
-              protected styleUtils: StyleUtils,
-              @Inject(PLATFORM_ID) protected platformId: Object,
-              @Optional() @Inject(SERVER_TOKEN) protected serverModuleLoaded: boolean,
-              @Inject(LAYOUT_CONFIG) protected layoutConfig: LayoutConfigOptions) {
-
-    super(monitor, elRef, styleUtils);
-  }
-
-  // *********************************************
-  // Lifecycle Methods
-  // *********************************************
-
-  /**
-   * Override accessor to the current HTMLElement's `display` style
-   * Note: Show/Hide will not change the display to 'flex' but will set it to 'block'
-   * unless it was already explicitly specified inline or in a CSS stylesheet.
-   */
-  protected _getDisplayStyle(): string {
-    return (this.layout || (this._flexChild && this.layoutConfig.addFlexToParent)) ?
-      'flex' : super._getDisplayStyle();
-  }
-
-
-  /**
-   * On changes to any @Input properties...
-   * Default to use the non-responsive Input value ('fxShow')
-   * Then conditionally override with the mq-activated Input's current value
-   */
-  ngOnChanges(changes: SimpleChanges) {
-    if (this.hasInitialized && (changes['show'] != null || this._mqActivation)) {
-      this._updateWithValue();
-    }
-  }
-
-  /**
-   * After the initial onChanges, build an mqActivation object that bridges
-   * mql change events to onMediaQueryChange handlers
-   */
-  ngOnInit() {
-    super.ngOnInit();
-  }
-
-  ngAfterViewInit() {
-    if (DISPLAY_MAP.has(this.nativeElement)) {
-      this._display = DISPLAY_MAP.get(this.nativeElement)!;
-    } else {
-      this._display = this._getDisplayStyle();
-      DISPLAY_MAP.set(this.nativeElement, this._display);
-    }
-    if (this.layout) {
-      /**
-       * The Layout can set the display:flex (and incorrectly affect the Hide/Show directives.
-       * Whenever Layout [on the same element] resets its CSS, then update the Hide/Show CSS
-       */
-      this._layoutWatcher = this.layout.layout$.subscribe(() => this._updateWithValue());
-    }
-    let value = this._getDefaultVal('show', true);
-    // Build _mqActivation controller
-    this._listenForMediaQueryChanges('show', value, (changes: MediaChange) => {
-      this._updateWithValue(changes.value);
-    });
-    this._updateWithValue();
-  }
-
-  ngOnDestroy() {
-    super.ngOnDestroy();
-    if (this._layoutWatcher) {
-      this._layoutWatcher.unsubscribe();
-    }
-  }
-
-  // *********************************************
-  // Protected methods
-  // *********************************************
-
-  /** Validate the visibility value and then update the host's inline display style */
-  protected _updateWithValue(value?: string|number|boolean) {
-    value = value || this._getDefaultVal('show', true);
-    if (this._mqActivation) {
-      value = this._mqActivation.activatedInput;
-    }
-
-    let shouldShow = this._validateTruthy(value);
-    this._applyStyleToElement(this._buildCSS(shouldShow));
-    if (isPlatformServer(this.platformId) && this.serverModuleLoaded) {
-      this.nativeElement.style.setProperty('display', '');
-    }
-  }
-
-
-  /** Build the CSS that should be assigned to the element instance */
-  protected _buildCSS(show: boolean) {
-    return {'display': show ? this._display : 'none'};
-  }
-
-  /**  Validate the to be not FALSY */
-  _validateTruthy(show: string | number | boolean = '') {
-    return (FALSY.indexOf(show) === -1);
-  }
+/**
+ * 'show' Layout API directive
+ */
+@Directive({selector, inputs})
+export class DefaultShowHideDirective extends ShowHideDirective {
+  protected inputs = inputs;
 }
-
-const DISPLAY_MAP: WeakMap<HTMLElement, string> = new WeakMap();

--- a/src/lib/extended/show-hide/show.spec.ts
+++ b/src/lib/extended/show-hide/show.spec.ts
@@ -5,24 +5,11 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {
-  Component,
-  Directive,
-  ElementRef,
-  Inject,
-  Input,
-  OnInit,
-  Optional,
-  PLATFORM_ID,
-  Self,
-} from '@angular/core';
+import {Component, Directive, OnInit, PLATFORM_ID} from '@angular/core';
 import {CommonModule, isPlatformBrowser} from '@angular/common';
 import {ComponentFixture, TestBed, inject, async} from '@angular/core/testing';
 import {
-  LAYOUT_CONFIG,
-  LayoutConfigOptions,
   MatchMedia,
-  MediaMonitor,
   MockMatchMedia,
   MockMatchMediaProvider,
   MediaObserver,
@@ -42,8 +29,7 @@ import {MatFormFieldModule} from '@angular/material/form-field';
 import {FormsModule} from '@angular/forms';
 import {MatSelectModule} from '@angular/material/select';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {negativeOf, ShowHideDirective} from './show-hide';
-import {LayoutDirective} from '@angular/flex-layout/flex';
+import {ShowHideDirective} from './show-hide';
 
 describe('show directive', () => {
   let fixture: ComponentFixture<any>;
@@ -268,25 +254,25 @@ describe('show directive', () => {
         </mat-form-field>
       `);
 
-      let selector = '[el]';
+      const elSelector = '[el]';
 
       matchMedia.useOverlaps = true;
       fixture.detectChanges();
 
       // NOTE: platform-server can't compute display for unknown elements
       if (isPlatformBrowser(platformId)) {
-        expectEl(queryFor(fixture, selector)[0]).toHaveStyle({
+        expectEl(queryFor(fixture, elSelector)[0]).toHaveCSS({
           'display': 'inline'
         }, styler);
       } else {
-        expectEl(queryFor(fixture, selector)[0]).not.toHaveStyle({
+        expectEl(queryFor(fixture, elSelector)[0]).not.toHaveStyle({
           'display': '*'
         }, styler);
       }
 
       matchMedia.activate('xs');
       fixture.detectChanges();
-      expectEl(queryFor(fixture, selector)[0]).toHaveStyle({
+      expectEl(queryFor(fixture, elSelector)[0]).toHaveStyle({
         'display': 'none'
       }, styler);
 
@@ -294,11 +280,11 @@ describe('show directive', () => {
       fixture.detectChanges();
       // NOTE: platform-server can't compute display for unknown elements
       if (isPlatformBrowser(platformId)) {
-        expectEl(queryFor(fixture, selector)[0]).toHaveStyle({
+        expectEl(queryFor(fixture, elSelector)[0]).toHaveCSS({
           'display': 'inline'
         }, styler);
       } else {
-        expectEl(queryFor(fixture, selector)[0]).not.toHaveStyle({
+        expectEl(queryFor(fixture, elSelector)[0]).not.toHaveStyle({
           'display': '*'
         }, styler);
       }
@@ -348,26 +334,13 @@ describe('show directive', () => {
 
 });
 
-@Directive({
-  selector: `[fxShow.sm-md], [fxHide.sm-md]`
-})
-class FxShowHideDirective extends ShowHideDirective {
-  constructor(monitor: MediaMonitor,
-              @Optional() @Self() protected layout: LayoutDirective,
-              protected elRef: ElementRef,
-              protected styleUtils: StyleUtils,
-              @Inject(PLATFORM_ID) protected platformId: Object,
-              @Optional() @Inject(SERVER_TOKEN) protected serverModuleLoaded: boolean,
-              @Inject(LAYOUT_CONFIG) protected layoutConfig: LayoutConfigOptions) {
-    super(monitor, layout, elRef, styleUtils, platformId, serverModuleLoaded, layoutConfig);
-  }
+const inputs = ['fxShow.sm-md', 'fxHide.sm-md'];
+const selector = `[fxShow.sm-md], [fxHide.sm-md]`;
 
-  @Input('fxShow.sm-md') set showSmMd(val: string) {
-    this._cacheInput('showSmMd', val);
-  }
-  @Input('fxHide.sm-md') set hideSmMd(val: string) {
-    this._cacheInput('showSmMd', negativeOf(val));
-  }
+// Used to test custom breakpoint functionality
+@Directive({inputs, selector})
+class FxShowHideDirective extends ShowHideDirective {
+  protected inputs = inputs;
 }
 
 

--- a/src/lib/extended/style/style.spec.ts
+++ b/src/lib/extended/style/style.spec.ts
@@ -15,9 +15,9 @@ import {
   MockMatchMediaProvider,
   StyleUtils,
 } from '@angular/flex-layout/core';
-import {LayoutDirective} from '@angular/flex-layout/flex';
+import {DefaultLayoutDirective} from '@angular/flex-layout/flex';
 
-import {StyleDirective} from './style';
+import {DefaultStyleDirective} from './style';
 import {customMatchers} from '../../utils/testing/custom-matchers';
 import {
   makeCreateTestComponent, expectNativeEl
@@ -42,7 +42,7 @@ describe('style directive', () => {
     // Configure testbed to prepare services
     TestBed.configureTestingModule({
       imports: [CommonModule, CoreModule],
-      declarations: [TestStyleComponent, LayoutDirective, StyleDirective],
+      declarations: [TestStyleComponent, DefaultLayoutDirective, DefaultStyleDirective],
       providers: [MockMatchMediaProvider]
     });
   });

--- a/src/lib/flex/flex-align/flex-align.ts
+++ b/src/lib/flex/flex-align/flex-align.ts
@@ -5,20 +5,10 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {Directive, ElementRef, Injectable, Optional} from '@angular/core';
 import {
-  Directive,
-  ElementRef,
-  Input,
-  OnInit,
-  OnChanges,
-  OnDestroy,
-  SimpleChanges,
-  Injectable,
-} from '@angular/core';
-import {
-  BaseDirective,
-  MediaChange,
-  MediaMonitor,
+  MediaMarshaller,
+  BaseDirective2,
   StyleBuilder,
   StyleDefinition,
   StyleUtils,
@@ -27,6 +17,7 @@ import {
 @Injectable({providedIn: 'root'})
 export class FlexAlignStyleBuilder extends StyleBuilder {
   buildStyles(input: string) {
+    input = input || 'stretch';
     const styles: StyleDefinition = {};
 
     // Cross-axis
@@ -46,87 +37,45 @@ export class FlexAlignStyleBuilder extends StyleBuilder {
   }
 }
 
+const inputs = [
+  'fxFlexAlign', 'fxFlexAlign.xs', 'fxFlexAlign.sm', 'fxFlexAlign.md',
+  'fxFlexAlign.lg', 'fxFlexAlign.xl', 'fxFlexAlign.lt-sm', 'fxFlexAlign.lt-md',
+  'fxFlexAlign.lt-lg', 'fxFlexAlign.lt-xl', 'fxFlexAlign.gt-xs', 'fxFlexAlign.gt-sm',
+  'fxFlexAlign.gt-md', 'fxFlexAlign.gt-lg'
+];
+const selector = `
+  [fxFlexAlign], [fxFlexAlign.xs], [fxFlexAlign.sm], [fxFlexAlign.md],
+  [fxFlexAlign.lg], [fxFlexAlign.xl], [fxFlexAlign.lt-sm], [fxFlexAlign.lt-md],
+  [fxFlexAlign.lt-lg], [fxFlexAlign.lt-xl], [fxFlexAlign.gt-xs], [fxFlexAlign.gt-sm],
+  [fxFlexAlign.gt-md], [fxFlexAlign.gt-lg]
+`;
+
 /**
  * 'flex-align' flexbox styling directive
  * Allows element-specific overrides for cross-axis alignments in a layout container
  * @see https://css-tricks.com/almanac/properties/a/align-self/
  */
-@Directive({
-  selector: `
-  [fxFlexAlign],
-  [fxFlexAlign.xs], [fxFlexAlign.sm], [fxFlexAlign.md], [fxFlexAlign.lg], [fxFlexAlign.xl],
-  [fxFlexAlign.lt-sm], [fxFlexAlign.lt-md], [fxFlexAlign.lt-lg], [fxFlexAlign.lt-xl],
-  [fxFlexAlign.gt-xs], [fxFlexAlign.gt-sm], [fxFlexAlign.gt-md], [fxFlexAlign.gt-lg]
-`
-})
-export class FlexAlignDirective extends BaseDirective implements OnInit, OnChanges, OnDestroy {
+export class FlexAlignDirective extends BaseDirective2 {
 
-  /* tslint:disable */
-  @Input('fxFlexAlign')       set align(val: string)  { this._cacheInput('align', val);  };
-  @Input('fxFlexAlign.xs')    set alignXs(val: string)  { this._cacheInput('alignXs', val);  };
-  @Input('fxFlexAlign.sm')    set alignSm(val: string)  { this._cacheInput('alignSm', val); };
-  @Input('fxFlexAlign.md')    set alignMd(val: string)  { this._cacheInput('alignMd', val); };
-  @Input('fxFlexAlign.lg')    set alignLg(val: string)  { this._cacheInput('alignLg', val); };
-  @Input('fxFlexAlign.xl')    set alignXl(val: string)  { this._cacheInput('alignXl', val); };
+  protected DIRECTIVE_KEY = 'flex-align';
 
-  @Input('fxFlexAlign.lt-sm') set alignLtSm(val: string) { this._cacheInput('alignLtSm', val); };
-  @Input('fxFlexAlign.lt-md') set alignLtMd(val: string) { this._cacheInput('alignLtMd', val); };
-  @Input('fxFlexAlign.lt-lg') set alignLtLg(val: string) { this._cacheInput('alignLtLg', val); };
-  @Input('fxFlexAlign.lt-xl') set alignLtXl(val: string) { this._cacheInput('alignLtXl', val); };
-
-  @Input('fxFlexAlign.gt-xs') set alignGtXs(val: string)  { this._cacheInput('alignGtXs', val); };
-  @Input('fxFlexAlign.gt-sm') set alignGtSm(val: string)  { this._cacheInput('alignGtSm', val); };
-  @Input('fxFlexAlign.gt-md') set alignGtMd(val: string)  { this._cacheInput('alignGtMd', val); };
-  @Input('fxFlexAlign.gt-lg') set alignGtLg(val: string)  { this._cacheInput('alignGtLg', val); };
-
-  /* tslint:enable */
-  constructor(monitor: MediaMonitor,
-              elRef: ElementRef,
-              styleUtils: StyleUtils,
-              styleBuilder: FlexAlignStyleBuilder) {
-    super(monitor, elRef, styleUtils, styleBuilder);
+  constructor(protected elRef: ElementRef,
+              protected styleUtils: StyleUtils,
+              // NOTE: not actually optional, but we need to force DI without a
+              // constructor call
+              @Optional() protected styleBuilder: FlexAlignStyleBuilder,
+              protected marshal: MediaMarshaller) {
+    super(elRef, styleBuilder, styleUtils, marshal);
+    this.marshal.init(this.elRef.nativeElement, this.DIRECTIVE_KEY,
+      this.addStyles.bind(this));
   }
 
-
-  // *********************************************
-  // Lifecycle Methods
-  // *********************************************
-
-  /**
-   * For @Input changes on the current mq activation property, see onMediaQueryChanges()
-   */
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes['align'] != null || this._mqActivation) {
-      this._updateWithValue();
-    }
-  }
-
-  /**
-   * After the initial onChanges, build an mqActivation object that bridges
-   * mql change events to onMediaQueryChange handlers
-   */
-  ngOnInit() {
-    super.ngOnInit();
-
-    this._listenForMediaQueryChanges('align', 'stretch', (changes: MediaChange) => {
-      this._updateWithValue(changes.value);
-    });
-  }
-
-  // *********************************************
-  // Protected methods
-  // *********************************************
-
-  protected _updateWithValue(value?: string|number) {
-    value = value || this._queryInput('align') || 'stretch';
-    if (this._mqActivation) {
-      value = this._mqActivation.activatedInput;
-    }
-
-    this.addStyles(value && (value + '') || '');
-  }
-
-  protected _styleCache = flexAlignCache;
+  protected styleCache = flexAlignCache;
 }
 
 const flexAlignCache: Map<string, StyleDefinition> = new Map();
+
+@Directive({selector, inputs})
+export class DefaultFlexAlignDirective extends FlexAlignDirective {
+  protected inputs = inputs;
+}

--- a/src/lib/flex/flex-fill/flex-fill.ts
+++ b/src/lib/flex/flex-fill/flex-fill.ts
@@ -7,11 +7,11 @@
  */
 import {Directive, ElementRef, Injectable} from '@angular/core';
 import {
-  BaseDirective,
-  MediaMonitor,
+  BaseDirective2,
   StyleBuilder,
   StyleDefinition,
   StyleUtils,
+  MediaMarshaller,
 } from '@angular/flex-layout/core';
 
 const FLEX_FILL_CSS = {
@@ -35,20 +35,17 @@ export class FlexFillStyleBuilder extends StyleBuilder {
  *
  *  NOTE: fxFill is NOT responsive API!!
  */
-@Directive({selector: `
-  [fxFill],
-  [fxFlexFill]
-`})
-export class FlexFillDirective extends BaseDirective {
-  constructor(monitor: MediaMonitor,
-              public elRef: ElementRef,
-              styleUtils: StyleUtils,
-              styleBuilder: FlexFillStyleBuilder) {
-    super(monitor, elRef, styleUtils, styleBuilder);
+@Directive({selector: `[fxFill], [fxFlexFill]`})
+export class FlexFillDirective extends BaseDirective2 {
+  constructor(protected elRef: ElementRef,
+              protected styleUtils: StyleUtils,
+              protected styleBuilder: FlexFillStyleBuilder,
+              protected marshal: MediaMarshaller) {
+    super(elRef, styleBuilder, styleUtils, marshal);
     this.addStyles('');
   }
 
-  protected _styleCache = flexFillCache;
+  protected styleCache = flexFillCache;
 }
 
 const flexFillCache: Map<string, StyleDefinition> = new Map();

--- a/src/lib/flex/flex-offset/flex-offset.spec.ts
+++ b/src/lib/flex/flex-offset/flex-offset.spec.ts
@@ -224,6 +224,7 @@ describe('flex-offset directive', () => {
 
 @Injectable({providedIn: FlexModule})
 export class MockFlexOffsetStyleBuilder extends StyleBuilder {
+  shouldCache = false;
   buildStyles(_input: string) {
     return {'margin-top': '10px'};
   }

--- a/src/lib/flex/flex-order/flex-order.ts
+++ b/src/lib/flex/flex-order/flex-order.ts
@@ -5,112 +5,62 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {Directive, ElementRef, OnChanges, Injectable, Optional} from '@angular/core';
 import {
-  Directive,
-  ElementRef,
-  Input,
-  OnInit,
-  OnChanges,
-  OnDestroy,
-  SimpleChanges,
-  Injectable,
-} from '@angular/core';
-import {
-  BaseDirective,
-  MediaChange,
-  MediaMonitor,
+  BaseDirective2,
   StyleBuilder,
   StyleDefinition,
   StyleUtils,
+  MediaMarshaller,
 } from '@angular/flex-layout/core';
 
 @Injectable({providedIn: 'root'})
 export class FlexOrderStyleBuilder extends StyleBuilder {
   buildStyles(value: string) {
-    const val = parseInt(value, 10);
-    const styles = {order: isNaN(val) ? 0 : val};
-    return styles;
+    const val = parseInt((value || '0'), 10);
+    return {order: isNaN(val) ? 0 : val};
   }
 }
+
+const inputs = [
+  'fxFlexOrder', 'fxFlexOrder.xs', 'fxFlexOrder.sm', 'fxFlexOrder.md',
+  'fxFlexOrder.lg', 'fxFlexOrder.xl', 'fxFlexOrder.lt-sm', 'fxFlexOrder.lt-md',
+  'fxFlexOrder.lt-lg', 'fxFlexOrder.lt-xl', 'fxFlexOrder.gt-xs', 'fxFlexOrder.gt-sm',
+  'fxFlexOrder.gt-md', 'fxFlexOrder.gt-lg'
+];
+const selector = `
+  [fxFlexOrder], [fxFlexOrder.xs], [fxFlexOrder.sm], [fxFlexOrder.md],
+  [fxFlexOrder.lg], [fxFlexOrder.xl], [fxFlexOrder.lt-sm], [fxFlexOrder.lt-md],
+  [fxFlexOrder.lt-lg], [fxFlexOrder.lt-xl], [fxFlexOrder.gt-xs], [fxFlexOrder.gt-sm],
+  [fxFlexOrder.gt-md], [fxFlexOrder.gt-lg]
+`;
 
 /**
  * 'flex-order' flexbox styling directive
  * Configures the positional ordering of the element in a sorted layout container
  * @see https://css-tricks.com/almanac/properties/o/order/
  */
-@Directive({selector: `
-  [fxFlexOrder],
-  [fxFlexOrder.xs], [fxFlexOrder.sm], [fxFlexOrder.md], [fxFlexOrder.lg], [fxFlexOrder.xl],
-  [fxFlexOrder.lt-sm], [fxFlexOrder.lt-md], [fxFlexOrder.lt-lg], [fxFlexOrder.lt-xl],
-  [fxFlexOrder.gt-xs], [fxFlexOrder.gt-sm], [fxFlexOrder.gt-md], [fxFlexOrder.gt-lg]
-`})
-export class FlexOrderDirective extends BaseDirective implements OnInit, OnChanges, OnDestroy {
+export class FlexOrderDirective extends BaseDirective2 implements OnChanges {
 
-  /* tslint:disable */
-  @Input('fxFlexOrder')       set order(val: string)     { this._cacheInput('order', val); }
-  @Input('fxFlexOrder.xs')    set orderXs(val: string)   { this._cacheInput('orderXs', val); }
-  @Input('fxFlexOrder.sm')    set orderSm(val: string)   { this._cacheInput('orderSm', val); };
-  @Input('fxFlexOrder.md')    set orderMd(val: string)   { this._cacheInput('orderMd', val); };
-  @Input('fxFlexOrder.lg')    set orderLg(val: string)   { this._cacheInput('orderLg', val); };
-  @Input('fxFlexOrder.xl')    set orderXl(val: string)   { this._cacheInput('orderXl', val); };
+  protected DIRECTIVE_KEY = 'flex-order';
 
-  @Input('fxFlexOrder.gt-xs') set orderGtXs(val: string) { this._cacheInput('orderGtXs', val); };
-  @Input('fxFlexOrder.gt-sm') set orderGtSm(val: string) { this._cacheInput('orderGtSm', val); };
-  @Input('fxFlexOrder.gt-md') set orderGtMd(val: string) { this._cacheInput('orderGtMd', val); };
-  @Input('fxFlexOrder.gt-lg') set orderGtLg(val: string) { this._cacheInput('orderGtLg', val); };
-
-  @Input('fxFlexOrder.lt-sm') set orderLtSm(val: string) { this._cacheInput('orderLtSm', val); };
-  @Input('fxFlexOrder.lt-md') set orderLtMd(val: string) { this._cacheInput('orderLtMd', val); };
-  @Input('fxFlexOrder.lt-lg') set orderLtLg(val: string) { this._cacheInput('orderLtLg', val); };
-  @Input('fxFlexOrder.lt-xl') set orderLtXl(val: string) { this._cacheInput('orderLtXl', val); };
-
-  /* tslint:enable */
-  constructor(monitor: MediaMonitor,
-              elRef: ElementRef,
-              styleUtils: StyleUtils,
-              styleBuilder: FlexOrderStyleBuilder) {
-    super(monitor, elRef, styleUtils, styleBuilder);
+  constructor(protected elRef: ElementRef,
+              protected styleUtils: StyleUtils,
+              // NOTE: not actually optional, but we need to force DI without a
+              // constructor call
+              @Optional() protected styleBuilder: FlexOrderStyleBuilder,
+              protected marshal: MediaMarshaller) {
+    super(elRef, styleBuilder, styleUtils, marshal);
+    this.marshal.init(this.elRef.nativeElement, this.DIRECTIVE_KEY,
+      this.addStyles.bind(this));
   }
 
-  // *********************************************
-  // Lifecycle Methods
-  // *********************************************
-
-  /**
-   * For @Input changes on the current mq activation property, see onMediaQueryChanges()
-   */
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes['order'] != null || this._mqActivation) {
-      this._updateWithValue();
-    }
-  }
-
-  /**
-   * After the initial onChanges, build an mqActivation object that bridges
-   * mql change events to onMediaQueryChange handlers
-   */
-  ngOnInit() {
-    super.ngOnInit();
-
-    this._listenForMediaQueryChanges('order', '0', (changes: MediaChange) => {
-      this._updateWithValue(changes.value);
-    });
-  }
-
-  // *********************************************
-  // Protected methods
-  // *********************************************
-
-  protected _updateWithValue(value?: string) {
-    value = value || this._queryInput('order') || '0';
-    if (this._mqActivation) {
-      value = this._mqActivation.activatedInput;
-    }
-
-    this.addStyles(value || '');
-  }
-
-  protected _styleCache = flexOrderCache;
+  protected styleCache = flexOrderCache;
 }
 
 const flexOrderCache: Map<string, StyleDefinition> = new Map();
+
+@Directive({selector, inputs})
+export class DefaultFlexOrderDirective extends FlexOrderDirective {
+  protected inputs = inputs;
+}

--- a/src/lib/flex/flex/flex.spec.ts
+++ b/src/lib/flex/flex/flex.spec.ts
@@ -18,8 +18,8 @@ import {
 } from '@angular/flex-layout/core';
 
 import {FlexLayoutModule} from '../../module';
-import {FlexDirective, FlexStyleBuilder} from './flex';
-import {LayoutDirective} from '../layout/layout';
+import {DefaultFlexDirective, FlexStyleBuilder} from './flex';
+import {DefaultLayoutDirective} from '../layout/layout';
 import {customMatchers, expect} from '../../utils/testing/custom-matchers';
 import {
   makeCreateTestComponent,
@@ -101,6 +101,77 @@ describe('flex directive', () => {
       expectEl(element).toHaveStyle({'width': '15px'}, styler);
       expectEl(element).toHaveStyle({'box-sizing': 'border-box'}, styler);
       expectEl(element).toHaveStyle({'flex': '10 1 auto'}, styler);
+    });
+
+    it('should add correct styles for `fxFlex` with multiple layout changes and wraps', () => {
+      componentWithTemplate(`
+        <div [fxLayout]="direction + ' wrap'" fxLayoutAlign="start center">
+          <div fxFlex="30"></div>
+        </div>
+      `);
+      fixture.detectChanges();
+      let element = queryFor(fixture, '[fxFlex]')[0];
+      expectNativeEl(fixture).toHaveStyle({'flex-direction': 'column'}, styler);
+      expectEl(element).toHaveStyle({'box-sizing': 'border-box'}, styler);
+      expectEl(element).toHaveStyle({'flex': '1 1 30%'}, styler);
+      expectEl(element).toHaveStyle({'max-height': '30%'}, styler);
+
+      fixture.debugElement.componentInstance.direction = 'row';
+      fixture.detectChanges();
+
+      expectNativeEl(fixture).toHaveStyle({'flex-direction': 'row'}, styler);
+      expectEl(element).toHaveStyle({'box-sizing': 'border-box'}, styler);
+      expectEl(element).toHaveStyle({'flex': '1 1 30%'}, styler);
+      expectEl(element).toHaveStyle({'max-width': '30%'}, styler);
+
+      fixture.debugElement.componentInstance.direction = 'column';
+      fixture.detectChanges();
+
+      expectNativeEl(fixture).toHaveStyle({'flex-direction': 'column'}, styler);
+      expectEl(element).toHaveStyle({'box-sizing': 'border-box'}, styler);
+      expectEl(element).toHaveStyle({'flex': '1 1 30%'}, styler);
+      expectEl(element).toHaveStyle({'max-height': '30%'}, styler);
+    });
+
+    it('should add correct styles for `fxFlex` with gap in grid mode and wrap parent', () => {
+      componentWithTemplate(`
+        <div [fxLayout]="direction + ' wrap'" fxLayoutGap="10px grid">
+          <div fxFlex="30"></div>
+          <div fxFlex="30"></div>
+          <div fxFlex="30"></div>
+        </div>
+      `);
+      fixture.debugElement.componentInstance.direction = 'row';
+      fixture.detectChanges();
+      let element = queryFor(fixture, '[fxFlex]')[0];
+      expectNativeEl(fixture).toHaveStyle({'flex-direction': 'row'}, styler);
+      expectEl(element).toHaveStyle({'box-sizing': 'border-box'}, styler);
+      expectEl(element).toHaveStyle({'flex': '1 1 30%'}, styler);
+      expectEl(element).toHaveStyle({'max-width': '30%'}, styler);
+
+      fixture.debugElement.componentInstance.direction = 'row-reverse';
+      fixture.detectChanges();
+
+      expectNativeEl(fixture).toHaveStyle({'flex-direction': 'row-reverse'}, styler);
+      expectEl(element).toHaveStyle({'box-sizing': 'border-box'}, styler);
+      expectEl(element).toHaveStyle({'flex': '1 1 30%'}, styler);
+      expectEl(element).toHaveStyle({'max-width': '30%'}, styler);
+
+      fixture.debugElement.componentInstance.direction = 'column';
+      fixture.detectChanges();
+
+      expectNativeEl(fixture).toHaveStyle({'flex-direction': 'column'}, styler);
+      expectEl(element).toHaveStyle({'box-sizing': 'border-box'}, styler);
+      expectEl(element).toHaveStyle({'flex': '1 1 30%'}, styler);
+      expectEl(element).toHaveStyle({'max-height': '30%'}, styler);
+
+      fixture.debugElement.componentInstance.direction = 'column-reverse';
+      fixture.detectChanges();
+
+      expectNativeEl(fixture).toHaveStyle({'flex-direction': 'column-reverse'}, styler);
+      expectEl(element).toHaveStyle({'box-sizing': 'border-box'}, styler);
+      expectEl(element).toHaveStyle({'flex': '1 1 30%'}, styler);
+      expectEl(element).toHaveStyle({'max-height': '30%'}, styler);
     });
 
     it('should add correct styles for `fxFlex` and ngStyle with multiple layout changes', () => {
@@ -699,7 +770,7 @@ describe('flex directive', () => {
         fixture = TestBed.createComponent(TestQueryWithFlexComponent);
         fixture.detectChanges();
 
-        const layout: LayoutDirective = fixture.debugElement.componentInstance.layout;
+        const layout: DefaultLayoutDirective = fixture.debugElement.componentInstance.layout;
 
         expect(layout).toBeDefined();
         expect(layout.activatedValue).toBe('');
@@ -714,13 +785,12 @@ describe('flex directive', () => {
         }, _styler);
       })
     );
-
     it('should query the ViewChild `fxFlex` directive properly', inject([StyleUtils],
       (_styler: StyleUtils) => {
         fixture = TestBed.createComponent(TestQueryWithFlexComponent);
         fixture.detectChanges();
 
-        const flex: FlexDirective = fixture.debugElement.componentInstance.flex;
+        const flex: DefaultFlexDirective = fixture.debugElement.componentInstance.flex;
 
         // Test for percentage value assignments
         expect(flex).toBeDefined();
@@ -747,14 +817,13 @@ describe('flex directive', () => {
         expectEl(nodes[0]).toHaveStyle({'max-width': '27.5px'}, _styler);
       })
     );
-
     it('should restore `fxFlex` value after breakpoint activations',
       inject([MatchMedia, StyleUtils],
         (_matchMedia: MockMatchMedia, _styler: StyleUtils) => {
           fixture = TestBed.createComponent(TestQueryWithFlexComponent);
           fixture.detectChanges();
 
-          const flex: FlexDirective = fixture.debugElement.componentInstance.flex;
+          const flex: DefaultFlexDirective = fixture.debugElement.componentInstance.flex;
 
           // Test for raw value assignments that are converted to percentages
           expect(flex).toBeDefined();
@@ -940,6 +1009,7 @@ describe('flex directive', () => {
 
 @Injectable()
 export class MockFlexStyleBuilder extends StyleBuilder {
+  shouldCache = false;
   buildStyles(_input: string) {
     return {'flex': '1 1 30%'};
   }
@@ -967,6 +1037,6 @@ class TestFlexComponent {
   `
 })
 class TestQueryWithFlexComponent {
-  @ViewChild(FlexDirective) flex!: FlexDirective;
-  @ViewChild(LayoutDirective) layout!: LayoutDirective;
+  @ViewChild(DefaultFlexDirective) flex!: DefaultFlexDirective;
+  @ViewChild(DefaultLayoutDirective) layout!: DefaultLayoutDirective;
 }

--- a/src/lib/flex/layout-gap/layout-gap.ts
+++ b/src/lib/flex/layout-gap/layout-gap.ts
@@ -8,28 +8,24 @@
 import {
   Directive,
   ElementRef,
-  Input,
-  OnChanges,
-  SimpleChanges,
-  Self,
-  AfterContentInit,
   Optional,
   OnDestroy,
   NgZone,
   Injectable,
+  AfterContentInit,
 } from '@angular/core';
 import {Directionality} from '@angular/cdk/bidi';
 import {
-  BaseDirective,
-  MediaChange,
-  MediaMonitor,
+  BaseDirective2,
   StyleBuilder,
   StyleDefinition,
-  StyleUtils
+  StyleUtils,
+  MediaMarshaller,
+  ElementMatcher,
 } from '@angular/flex-layout/core';
-import {Subscription} from 'rxjs';
+import {Subject} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
 
-import {Layout, LayoutDirective} from '../layout/layout';
 import {LAYOUT_VALUES} from '../../utils/layout-validator';
 
 export interface LayoutGapParent {
@@ -83,92 +79,70 @@ export class LayoutGapStyleBuilder extends StyleBuilder {
   }
 }
 
+const inputs = [
+  'fxLayoutGap', 'fxLayoutGap.xs', 'fxLayoutGap.sm', 'fxLayoutGap.md',
+  'fxLayoutGap.lg', 'fxLayoutGap.xl', 'fxLayoutGap.lt-sm', 'fxLayoutGap.lt-md',
+  'fxLayoutGap.lt-lg', 'fxLayoutGap.lt-xl', 'fxLayoutGap.gt-xs', 'fxLayoutGap.gt-sm',
+  'fxLayoutGap.gt-md', 'fxLayoutGap.gt-lg'
+];
+const selector = `
+  [fxLayoutGap], [fxLayoutGap.xs], [fxLayoutGap.sm], [fxLayoutGap.md],
+  [fxLayoutGap.lg], [fxLayoutGap.xl], [fxLayoutGap.lt-sm], [fxLayoutGap.lt-md],
+  [fxLayoutGap.lt-lg], [fxLayoutGap.lt-xl], [fxLayoutGap.gt-xs], [fxLayoutGap.gt-sm],
+  [fxLayoutGap.gt-md], [fxLayoutGap.gt-lg]
+`;
+
 /**
  * 'layout-padding' styling directive
  *  Defines padding of child elements in a layout container
  */
-@Directive({
-  selector: `
-  [fxLayoutGap],
-  [fxLayoutGap.xs], [fxLayoutGap.sm], [fxLayoutGap.md], [fxLayoutGap.lg], [fxLayoutGap.xl],
-  [fxLayoutGap.lt-sm], [fxLayoutGap.lt-md], [fxLayoutGap.lt-lg], [fxLayoutGap.lt-xl],
-  [fxLayoutGap.gt-xs], [fxLayoutGap.gt-sm], [fxLayoutGap.gt-md], [fxLayoutGap.gt-lg]
-`
-})
-export class LayoutGapDirective extends BaseDirective
-  implements AfterContentInit, OnChanges, OnDestroy {
-  protected _layout = 'row';  // default flex-direction
-  protected _layoutWatcher?: Subscription;
-  protected _observer?: MutationObserver;
-  private readonly _directionWatcher: Subscription;
+export class LayoutGapDirective extends BaseDirective2 implements AfterContentInit, OnDestroy {
+  protected layout = 'row';  // default flex-direction
+  protected DIRECTIVE_KEY = 'layout-gap';
+  protected observerSubject = new Subject<void>();
 
-  /* tslint:disable */
- @Input('fxLayoutGap')       set gap(val: string) { this._cacheInput('gap', val); }
- @Input('fxLayoutGap.xs')    set gapXs(val: string) { this._cacheInput('gapXs', val); }
- @Input('fxLayoutGap.sm')    set gapSm(val: string) { this._cacheInput('gapSm', val); };
- @Input('fxLayoutGap.md')    set gapMd(val: string) { this._cacheInput('gapMd', val); };
- @Input('fxLayoutGap.lg')    set gapLg(val: string) { this._cacheInput('gapLg', val); };
- @Input('fxLayoutGap.xl')    set gapXl(val: string) { this._cacheInput('gapXl', val); };
+  /** Special accessor to query for all child 'element' nodes regardless of type, class, etc */
+  protected get childrenNodes(): HTMLElement[] {
+    const obj = this.nativeElement.children;
+    const buffer: any[] = [];
 
- @Input('fxLayoutGap.gt-xs') set gapGtXs(val: string) { this._cacheInput('gapGtXs', val); };
- @Input('fxLayoutGap.gt-sm') set gapGtSm(val: string) { this._cacheInput('gapGtSm', val); };
- @Input('fxLayoutGap.gt-md') set gapGtMd(val: string) { this._cacheInput('gapGtMd', val); };
- @Input('fxLayoutGap.gt-lg') set gapGtLg(val: string) { this._cacheInput('gapGtLg', val); };
-
- @Input('fxLayoutGap.lt-sm') set gapLtSm(val: string) { this._cacheInput('gapLtSm', val); };
- @Input('fxLayoutGap.lt-md') set gapLtMd(val: string) { this._cacheInput('gapLtMd', val); };
- @Input('fxLayoutGap.lt-lg') set gapLtLg(val: string) { this._cacheInput('gapLtLg', val); };
- @Input('fxLayoutGap.lt-xl') set gapLtXl(val: string) { this._cacheInput('gapLtXl', val); };
-
-  /* tslint:enable */
-  constructor(protected monitor: MediaMonitor,
-              protected elRef: ElementRef,
-              @Optional() @Self() protected container: LayoutDirective,
-              protected _zone: NgZone,
-              protected _directionality: Directionality,
-              protected styleUtils: StyleUtils,
-              protected styleBuilder: LayoutGapStyleBuilder) {
-    super(monitor, elRef, styleUtils, styleBuilder);
-
-    if (container) {  // Subscribe to layout direction changes
-      this._layoutWatcher = container.layout$.subscribe(this._onLayoutChange.bind(this));
+    // iterate backwards ensuring that length is an UInt32
+    for (let i = obj.length; i--; ) {
+      buffer[i] = obj[i];
     }
-    this._directionWatcher =
-        this._directionality.change.subscribe(this._updateWithValue.bind(this));
+    return buffer;
+  }
+
+  constructor(protected elRef: ElementRef,
+              protected zone: NgZone,
+              protected directionality: Directionality,
+              protected styleUtils: StyleUtils,
+              // NOTE: not actually optional, but we need to force DI without a
+              // constructor call
+              @Optional() protected styleBuilder: LayoutGapStyleBuilder,
+              protected marshal: MediaMarshaller) {
+    super(elRef, styleBuilder, styleUtils, marshal);
+    this.marshal.init(this.elRef.nativeElement, this.DIRECTIVE_KEY,
+      this.updateWithValue.bind(this), [this.directionality.change,
+        this.observerSubject.asObservable()]);
+    this.marshal.trackValue(this.nativeElement, 'layout')
+      .pipe(takeUntil(this.destroySubject))
+      .subscribe(this.onLayoutChange.bind(this));
   }
 
   // *********************************************
   // Lifecycle Methods
   // *********************************************
 
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes['gap'] != null || this._mqActivation) {
-      this._updateWithValue();
-    }
-  }
-
-  /**
-   * After the initial onChanges, build an mqActivation object that bridges
-   * mql change events to onMediaQueryChange handlers
-   */
   ngAfterContentInit() {
-    this._watchContentChanges();
-    this._listenForMediaQueryChanges('gap', '0', (changes: MediaChange) => {
-      this._updateWithValue(changes.value);
-    });
-    this._updateWithValue();
+    this.buildChildObservable();
+    this.triggerUpdate();
   }
 
   ngOnDestroy() {
     super.ngOnDestroy();
-    if (this._layoutWatcher) {
-      this._layoutWatcher.unsubscribe();
-    }
-    if (this._observer) {
-      this._observer.disconnect();
-    }
-    if (this._directionWatcher) {
-      this._directionWatcher.unsubscribe();
+    if (this.observer) {
+      this.observer.disconnect();
     }
   }
 
@@ -177,55 +151,32 @@ export class LayoutGapDirective extends BaseDirective
   // *********************************************
 
   /**
-   * Watch for child nodes to be added... and apply the layout gap styles to each.
-   * NOTE: this does NOT! differentiate between viewChildren and contentChildren
-   */
-  protected _watchContentChanges() {
-    this._zone.runOutsideAngular(() => {
-
-      if (typeof MutationObserver !== 'undefined') {
-        this._observer = new MutationObserver((mutations: MutationRecord[]) => {
-          const validatedChanges = (it: MutationRecord): boolean => {
-            return (it.addedNodes && it.addedNodes.length > 0) ||
-                (it.removedNodes && it.removedNodes.length > 0);
-          };
-
-          // update gap styles only for child 'added' or 'removed' events
-          if (mutations.some(validatedChanges)) {
-            this._updateWithValue();
-          }
-        });
-        this._observer.observe(this.nativeElement, {childList: true});
-      }
-    });
-  }
-
-  /**
    * Cache the parent container 'flex-direction' and update the 'margin' styles
    */
-  protected _onLayoutChange(layout: Layout) {
-    this._layout = (layout.direction || '').toLowerCase();
-    if (!LAYOUT_VALUES.find(x => x === this._layout)) {
-      this._layout = 'row';
+  protected onLayoutChange(matcher: ElementMatcher) {
+    const layout: string = matcher.value;
+    // Make sure to filter out 'wrap' option
+    const direction = layout.split(' ');
+    this.layout = direction[0];
+    if (!LAYOUT_VALUES.find(x => x === this.layout)) {
+      this.layout = 'row';
     }
-    this._updateWithValue();
+    this.triggerUpdate();
   }
 
   /**
    *
    */
-  protected _updateWithValue(value?: string) {
-    let gapValue = value || this._queryInput('gap') || '0';
-    if (this._mqActivation) {
-      gapValue = this._mqActivation.activatedInput;
+  protected updateWithValue(value: string) {
+    if (!value) {
+      value = this.marshal.getValue(this.nativeElement, this.DIRECTIVE_KEY);
     }
-
     // Gather all non-hidden Element nodes
     const items = this.childrenNodes
-      .filter(el => el.nodeType === 1 && this._getDisplayStyle(el) != 'none')
+      .filter(el => el.nodeType === 1 && this.getDisplayStyle(el) !== 'none')
       .sort((a, b) => {
-        const orderA = +this._styler.lookupStyle(a, 'order');
-        const orderB = +this._styler.lookupStyle(b, 'order');
+        const orderA = +this.styler.lookupStyle(a, 'order');
+        const orderB = +this.styler.lookupStyle(b, 'order');
         if (isNaN(orderA) || isNaN(orderB) || orderA === orderB) {
           return 0;
         } else {
@@ -234,20 +185,56 @@ export class LayoutGapDirective extends BaseDirective
       });
 
     if (items.length > 0) {
-      const directionality = this._directionality.value;
-      const layout = this._layout;
+      const directionality = this.directionality.value;
+      const layout = this.layout;
       if (layout === 'row' && directionality === 'rtl') {
-        this._styleCache = layoutGapCacheRowRtl;
+        this.styleCache = layoutGapCacheRowRtl;
       } else if (layout === 'row' && directionality !== 'rtl') {
-        this._styleCache = layoutGapCacheRowLtr;
+        this.styleCache = layoutGapCacheRowLtr;
       } else if (layout === 'column' && directionality === 'rtl') {
-        this._styleCache = layoutGapCacheColumnRtl;
+        this.styleCache = layoutGapCacheColumnRtl;
       } else if (layout === 'column' && directionality !== 'rtl') {
-        this._styleCache = layoutGapCacheColumnLtr;
+        this.styleCache = layoutGapCacheColumnLtr;
       }
-      this.addStyles(gapValue, {directionality, items, layout});
+      this.addStyles(value, {directionality, items, layout});
     }
   }
+
+  /**
+   * Quick accessor to the current HTMLElement's `display` style
+   * Note: this allows us to preserve the original style
+   * and optional restore it when the mediaQueries deactivate
+   */
+  protected getDisplayStyle(source: HTMLElement = this.nativeElement): string {
+    const query = 'display';
+    return this.styler.lookupStyle(source, query);
+  }
+
+  protected buildChildObservable(): void {
+    this.zone.runOutsideAngular(() => {
+      if (typeof MutationObserver !== 'undefined') {
+        this.observer = new MutationObserver((mutations: MutationRecord[]) => {
+          const validatedChanges = (it: MutationRecord): boolean => {
+            return (it.addedNodes && it.addedNodes.length > 0) ||
+              (it.removedNodes && it.removedNodes.length > 0);
+          };
+
+          // update gap styles only for child 'added' or 'removed' events
+          if (mutations.some(validatedChanges)) {
+            this.observerSubject.next();
+          }
+        });
+        this.observer.observe(this.nativeElement, {childList: true});
+      }
+    });
+  }
+
+  protected observer?: MutationObserver;
+}
+
+@Directive({selector, inputs})
+export class DefaultLayoutGapDirective extends LayoutGapDirective {
+  protected inputs = inputs;
 }
 
 const layoutGapCacheRowRtl: Map<string, StyleDefinition> = new Map();

--- a/src/lib/flex/module.ts
+++ b/src/lib/flex/module.ts
@@ -9,25 +9,25 @@ import {NgModule} from '@angular/core';
 import {BidiModule} from '@angular/cdk/bidi';
 import {CoreModule} from '@angular/flex-layout/core';
 
-import {LayoutDirective} from './layout/layout';
-import {LayoutGapDirective} from './layout-gap/layout-gap';
-import {FlexDirective} from './flex/flex';
-import {FlexOrderDirective} from './flex-order/flex-order';
-import {FlexOffsetDirective} from './flex-offset/flex-offset';
-import {FlexAlignDirective} from './flex-align/flex-align';
+import {DefaultLayoutDirective} from './layout/layout';
+import {DefaultLayoutGapDirective} from './layout-gap/layout-gap';
+import {DefaultFlexDirective} from './flex/flex';
+import {DefaultFlexOrderDirective} from './flex-order/flex-order';
+import {DefaultFlexOffsetDirective} from './flex-offset/flex-offset';
+import {DefaultFlexAlignDirective} from './flex-align/flex-align';
 import {FlexFillDirective} from './flex-fill/flex-fill';
-import {LayoutAlignDirective} from './layout-align/layout-align';
+import {DefaultLayoutAlignDirective} from './layout-align/layout-align';
 
 
 const ALL_DIRECTIVES = [
-  LayoutDirective,
-  LayoutGapDirective,
-  LayoutAlignDirective,
-  FlexDirective,
-  FlexOrderDirective,
-  FlexOffsetDirective,
+  DefaultLayoutDirective,
+  DefaultLayoutGapDirective,
+  DefaultLayoutAlignDirective,
+  DefaultFlexOrderDirective,
+  DefaultFlexOffsetDirective,
   FlexFillDirective,
-  FlexAlignDirective,
+  DefaultFlexAlignDirective,
+  DefaultFlexDirective,
 ];
 
 /**

--- a/src/lib/grid/area/area.ts
+++ b/src/lib/grid/area/area.ts
@@ -5,99 +5,63 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {Directive, ElementRef, Injectable, Optional} from '@angular/core';
 import {
-  Directive,
-  ElementRef,
-  Input,
-  OnInit,
-  OnChanges,
-  OnDestroy,
-  SimpleChanges,
-} from '@angular/core';
-import {BaseDirective, MediaChange, MediaMonitor, StyleUtils} from '@angular/flex-layout/core';
+  BaseDirective2,
+  StyleUtils,
+  MediaMarshaller,
+  StyleBuilder,
+  StyleDefinition,
+} from '@angular/flex-layout/core';
 
-const CACHE_KEY = 'area';
 const DEFAULT_VALUE = 'auto';
+
+@Injectable({providedIn: 'root'})
+export class GridAreaStyleBuilder extends StyleBuilder {
+  buildStyles(input: string) {
+    return {'grid-area': input || DEFAULT_VALUE};
+  }
+}
+
+export class GridAreaDirective extends BaseDirective2 {
+
+  protected DIRECTIVE_KEY = 'grid-area';
+
+  constructor(protected elRef: ElementRef,
+              protected styleUtils: StyleUtils,
+              // NOTE: not actually optional, but we need to force DI without a
+              // constructor call
+              @Optional() protected styleBuilder: GridAreaStyleBuilder,
+              protected marshal: MediaMarshaller) {
+    super(elRef, styleBuilder, styleUtils, marshal);
+    this.marshal.init(this.elRef.nativeElement, this.DIRECTIVE_KEY,
+      this.addStyles.bind(this));
+  }
+
+  protected styleCache = gridAreaCache;
+}
+
+const gridAreaCache: Map<string, StyleDefinition> = new Map();
+
+const inputs = [
+  'gdArea',
+  'gdArea.xs', 'gdArea.sm', 'gdArea.md', 'gdArea.lg', 'gdArea.xl',
+  'gdArea.lt-sm', 'gdArea.lt-md', 'gdArea.lt-lg', 'gdArea.lt-xl',
+  'gdArea.gt-xs', 'gdArea.gt-sm', 'gdArea.gt-md', 'gdArea.gt-lg'
+];
+const selector = `
+  [gdArea],
+  [gdArea.xs], [gdArea.sm], [gdArea.md], [gdArea.lg], [gdArea.xl],
+  [gdArea.lt-sm], [gdArea.lt-md], [gdArea.lt-lg], [gdArea.lt-xl],
+  [gdArea.gt-xs], [gdArea.gt-sm], [gdArea.gt-md], [gdArea.gt-lg]
+`;
 
 /**
  * 'grid-area' CSS Grid styling directive
  * Configures the name or position of an element within the grid
  * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-27
  */
-@Directive({selector: `
-  [gdArea],
-  [gdArea.xs], [gdArea.sm], [gdArea.md], [gdArea.lg], [gdArea.xl],
-  [gdArea.lt-sm], [gdArea.lt-md], [gdArea.lt-lg], [gdArea.lt-xl],
-  [gdArea.gt-xs], [gdArea.gt-sm], [gdArea.gt-md], [gdArea.gt-lg]
-`})
-export class GridAreaDirective extends BaseDirective implements OnInit, OnChanges, OnDestroy {
-
-  /* tslint:disable */
-  @Input('gdArea')       set align(val: string)     { this._cacheInput(`${CACHE_KEY}`, val); }
-  @Input('gdArea.xs')    set alignXs(val: string)   { this._cacheInput(`${CACHE_KEY}Xs`, val); }
-  @Input('gdArea.sm')    set alignSm(val: string)   { this._cacheInput(`${CACHE_KEY}Sm`, val); };
-  @Input('gdArea.md')    set alignMd(val: string)   { this._cacheInput(`${CACHE_KEY}Md`, val); };
-  @Input('gdArea.lg')    set alignLg(val: string)   { this._cacheInput(`${CACHE_KEY}Lg`, val); };
-  @Input('gdArea.xl')    set alignXl(val: string)   { this._cacheInput(`${CACHE_KEY}Xl`, val); };
-
-  @Input('gdArea.gt-xs') set alignGtXs(val: string) { this._cacheInput(`${CACHE_KEY}GtXs`, val); };
-  @Input('gdArea.gt-sm') set alignGtSm(val: string) { this._cacheInput(`${CACHE_KEY}GtSm`, val); };
-  @Input('gdArea.gt-md') set alignGtMd(val: string) { this._cacheInput(`${CACHE_KEY}GtMd`, val); };
-  @Input('gdArea.gt-lg') set alignGtLg(val: string) { this._cacheInput(`${CACHE_KEY}GtLg`, val); };
-
-  @Input('gdArea.lt-sm') set alignLtSm(val: string) { this._cacheInput(`${CACHE_KEY}LtSm`, val); };
-  @Input('gdArea.lt-md') set alignLtMd(val: string) { this._cacheInput(`${CACHE_KEY}LtMd`, val); };
-  @Input('gdArea.lt-lg') set alignLtLg(val: string) { this._cacheInput(`${CACHE_KEY}LtLg`, val); };
-  @Input('gdArea.lt-xl') set alignLtXl(val: string) { this._cacheInput(`${CACHE_KEY}LtXl`, val); };
-
-  /* tslint:enable */
-  constructor(monitor: MediaMonitor,
-              elRef: ElementRef,
-              styleUtils: StyleUtils) {
-    super(monitor, elRef, styleUtils);
-  }
-
-  // *********************************************
-  // Lifecycle Methods
-  // *********************************************
-
-  /**
-   * For @Input changes on the current mq activation property, see onMediaQueryChanges()
-   */
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes[CACHE_KEY] != null || this._mqActivation) {
-      this._updateWithValue();
-    }
-  }
-
-  /**
-   * After the initial onChanges, build an mqActivation object that bridges
-   * mql change events to onMediaQueryChange handlers
-   */
-  ngOnInit() {
-    super.ngOnInit();
-
-    this._listenForMediaQueryChanges(CACHE_KEY, DEFAULT_VALUE, (changes: MediaChange) => {
-      this._updateWithValue(changes.value);
-    });
-    this._updateWithValue();
-  }
-
-  // *********************************************
-  // Protected methods
-  // *********************************************
-
-  protected _updateWithValue(value?: string) {
-    value = value || this._queryInput(CACHE_KEY) || DEFAULT_VALUE;
-    if (this._mqActivation) {
-      value = this._mqActivation.activatedInput;
-    }
-
-    this._applyStyleToElement(this._buildCSS(value));
-  }
-
-
-  protected _buildCSS(value: string = '') {
-    return {'grid-area': value};
-  }
+@Directive({selector, inputs})
+export class DefaultGridAreaDirective extends GridAreaDirective {
+  protected inputs = inputs;
 }

--- a/src/lib/grid/areas/areas.ts
+++ b/src/lib/grid/areas/areas.ts
@@ -5,108 +5,88 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {Directive, ElementRef, Injectable, Input, Optional} from '@angular/core';
 import {
-  Directive,
-  ElementRef,
-  Input,
-  OnInit,
-  OnChanges,
-  OnDestroy,
-  SimpleChanges,
-} from '@angular/core';
-import {BaseDirective, MediaChange, MediaMonitor, StyleUtils} from '@angular/flex-layout/core';
+  BaseDirective2,
+  StyleUtils,
+  StyleBuilder,
+  MediaMarshaller,
+  StyleDefinition,
+} from '@angular/flex-layout/core';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 
-const CACHE_KEY = 'areas';
 const DEFAULT_VALUE = 'none';
 const DELIMETER = '|';
 
-/**
- * 'grid-template-areas' CSS Grid styling directive
- * Configures the names of elements within the grid
- * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-14
- */
-@Directive({selector: `
-  [gdAreas],
-  [gdAreas.xs], [gdAreas.sm], [gdAreas.md], [gdAreas.lg], [gdAreas.xl],
-  [gdAreas.lt-sm], [gdAreas.lt-md], [gdAreas.lt-lg], [gdAreas.lt-xl],
-  [gdAreas.gt-xs], [gdAreas.gt-sm], [gdAreas.gt-md], [gdAreas.gt-lg]
-`})
-export class GridAreasDirective extends BaseDirective implements OnInit, OnChanges, OnDestroy {
+export interface GridAreasParent {
+  inline: boolean;
+}
 
-  /* tslint:disable */
-  @Input('gdAreas')       set align(val: string)     { this._cacheInput(`${CACHE_KEY}`, val); }
-  @Input('gdAreas.xs')    set alignXs(val: string)   { this._cacheInput(`${CACHE_KEY}Xs`, val); }
-  @Input('gdAreas.sm')    set alignSm(val: string)   { this._cacheInput(`${CACHE_KEY}Sm`, val); };
-  @Input('gdAreas.md')    set alignMd(val: string)   { this._cacheInput(`${CACHE_KEY}Md`, val); };
-  @Input('gdAreas.lg')    set alignLg(val: string)   { this._cacheInput(`${CACHE_KEY}Lg`, val); };
-  @Input('gdAreas.xl')    set alignXl(val: string)   { this._cacheInput(`${CACHE_KEY}Xl`, val); };
+@Injectable({providedIn: 'root'})
+export class GridAreasStyleBuiler extends StyleBuilder {
+  buildStyles(input: string, parent: GridAreasParent) {
+    const areas = (input || DEFAULT_VALUE).split(DELIMETER).map(v => `"${v.trim()}"`);
 
-  @Input('gdAreas.gt-xs') set alignGtXs(val: string) { this._cacheInput(`${CACHE_KEY}GtXs`, val); };
-  @Input('gdAreas.gt-sm') set alignGtSm(val: string) { this._cacheInput(`${CACHE_KEY}GtSm`, val); };
-  @Input('gdAreas.gt-md') set alignGtMd(val: string) { this._cacheInput(`${CACHE_KEY}GtMd`, val); };
-  @Input('gdAreas.gt-lg') set alignGtLg(val: string) { this._cacheInput(`${CACHE_KEY}GtLg`, val); };
-
-  @Input('gdAreas.lt-sm') set alignLtSm(val: string) { this._cacheInput(`${CACHE_KEY}LtSm`, val); };
-  @Input('gdAreas.lt-md') set alignLtMd(val: string) { this._cacheInput(`${CACHE_KEY}LtMd`, val); };
-  @Input('gdAreas.lt-lg') set alignLtLg(val: string) { this._cacheInput(`${CACHE_KEY}LtLg`, val); };
-  @Input('gdAreas.lt-xl') set alignLtXl(val: string) { this._cacheInput(`${CACHE_KEY}LtXl`, val); };
-
-  @Input('gdInline') set inline(val: string) { this._cacheInput('inline', coerceBooleanProperty(val)); };
-
-  /* tslint:enable */
-  constructor(monitor: MediaMonitor,
-              elRef: ElementRef,
-              styleUtils: StyleUtils) {
-    super(monitor, elRef, styleUtils);
+    return {
+      'display': parent.inline ? 'inline-grid' : 'grid',
+      'grid-template-areas': areas.join(' ')
+    };
   }
+}
 
-  // *********************************************
-  // Lifecycle Methods
-  // *********************************************
+export class GridAreasDirective extends BaseDirective2 {
 
-  /**
-   * For @Input changes on the current mq activation property, see onMediaQueryChanges()
-   */
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes[CACHE_KEY] != null || this._mqActivation) {
-      this._updateWithValue();
-    }
-  }
+  protected DIRECTIVE_KEY = 'grid-areas';
 
-  /**
-   * After the initial onChanges, build an mqActivation object that bridges
-   * mql change events to onMediaQueryChange handlers
-   */
-  ngOnInit() {
-    super.ngOnInit();
+  @Input('gdInline')
+  get inline(): boolean { return this._inline; }
+  set inline(val: boolean) { this._inline = coerceBooleanProperty(val); }
+  protected _inline = false;
 
-    this._listenForMediaQueryChanges(CACHE_KEY, DEFAULT_VALUE, (changes: MediaChange) => {
-      this._updateWithValue(changes.value);
-    });
-    this._updateWithValue();
+  constructor(protected elRef: ElementRef,
+              protected styleUtils: StyleUtils,
+              // NOTE: not actually optional, but we need to force DI without a
+              // constructor call
+              @Optional() protected styleBuilder: GridAreasStyleBuiler,
+              protected marshal: MediaMarshaller) {
+    super(elRef, styleBuilder, styleUtils, marshal);
+    this.marshal.init(this.elRef.nativeElement, this.DIRECTIVE_KEY,
+      this.updateWithValue.bind(this));
   }
 
   // *********************************************
   // Protected methods
   // *********************************************
 
-  protected _updateWithValue(value?: string) {
-    value = value || this._queryInput(CACHE_KEY) || DEFAULT_VALUE;
-    if (this._mqActivation) {
-      value = this._mqActivation.activatedInput;
-    }
-
-    this._applyStyleToElement(this._buildCSS(value));
+  protected updateWithValue(value: string) {
+    this.styleCache = this.inline ? areasInlineCache : areasCache;
+    this.addStyles(value, {inline: this.inline});
   }
+}
 
+const areasCache: Map<string, StyleDefinition> = new Map();
+const areasInlineCache: Map<string, StyleDefinition> = new Map();
 
-  protected _buildCSS(value: string = '') {
-    const areas = value.split(DELIMETER).map(v => `"${v.trim()}"`);
+const inputs = [
+  'gdAreas',
+  'gdAreas.xs', 'gdAreas.sm', 'gdAreas.md', 'gdAreas.lg', 'gdAreas.xl',
+  'gdAreas.lt-sm', 'gdAreas.lt-md', 'gdAreas.lt-lg', 'gdAreas.lt-xl',
+  'gdAreas.gt-xs', 'gdAreas.gt-sm', 'gdAreas.gt-md', 'gdAreas.gt-lg'
+];
 
-    return {
-      'display': this._queryInput('inline') ? 'inline-grid' : 'grid',
-      'grid-template-areas': areas.join(' ')
-    };
-  }
+const selector = `
+  [gdAreas],
+  [gdAreas.xs], [gdAreas.sm], [gdAreas.md], [gdAreas.lg], [gdAreas.xl],
+  [gdAreas.lt-sm], [gdAreas.lt-md], [gdAreas.lt-lg], [gdAreas.lt-xl],
+  [gdAreas.gt-xs], [gdAreas.gt-sm], [gdAreas.gt-md], [gdAreas.gt-lg]
+`;
+
+/**
+ * 'grid-template-areas' CSS Grid styling directive
+ * Configures the names of elements within the grid
+ * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-14
+ */
+@Directive({selector, inputs})
+export class DefaultGridAreasDirective extends GridAreasDirective {
+  protected inputs = inputs;
 }

--- a/src/lib/grid/auto/auto.ts
+++ b/src/lib/grid/auto/auto.ts
@@ -5,103 +5,26 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {Directive, ElementRef, Input, Optional, Injectable} from '@angular/core';
 import {
-  Directive,
-  ElementRef,
-  Input,
-  OnInit,
-  OnChanges,
-  OnDestroy,
-  SimpleChanges,
-} from '@angular/core';
-import {BaseDirective, MediaChange, MediaMonitor, StyleUtils} from '@angular/flex-layout/core';
+  BaseDirective2,
+  StyleUtils,
+  StyleBuilder,
+  MediaMarshaller,
+  StyleDefinition,
+} from '@angular/flex-layout/core';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 
-const CACHE_KEY = 'autoFlow';
 const DEFAULT_VALUE = 'initial';
 
-/**
- * 'grid-auto-flow' CSS Grid styling directive
- * Configures the auto placement algorithm for the grid
- * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-23
- */
-@Directive({selector: `
-  [gdAuto],
-  [gdAuto.xs], [gdAuto.sm], [gdAuto.md], [gdAuto.lg], [gdAuto.xl],
-  [gdAuto.lt-sm], [gdAuto.lt-md], [gdAuto.lt-lg], [gdAuto.lt-xl],
-  [gdAuto.gt-xs], [gdAuto.gt-sm], [gdAuto.gt-md], [gdAuto.gt-lg]
-`})
-export class GridAutoDirective extends BaseDirective implements OnInit, OnChanges, OnDestroy {
+export interface GridAutoParent {
+  inline: boolean;
+}
 
-  /* tslint:disable */
-  @Input('gdAuto')       set align(val: string)     { this._cacheInput(`${CACHE_KEY}`, val); }
-  @Input('gdAuto.xs')    set alignXs(val: string)   { this._cacheInput(`${CACHE_KEY}Xs`, val); }
-  @Input('gdAuto.sm')    set alignSm(val: string)   { this._cacheInput(`${CACHE_KEY}Sm`, val); };
-  @Input('gdAuto.md')    set alignMd(val: string)   { this._cacheInput(`${CACHE_KEY}Md`, val); };
-  @Input('gdAuto.lg')    set alignLg(val: string)   { this._cacheInput(`${CACHE_KEY}Lg`, val); };
-  @Input('gdAuto.xl')    set alignXl(val: string)   { this._cacheInput(`${CACHE_KEY}Xl`, val); };
-
-  @Input('gdAuto.gt-xs') set alignGtXs(val: string) { this._cacheInput(`${CACHE_KEY}GtXs`, val); };
-  @Input('gdAuto.gt-sm') set alignGtSm(val: string) { this._cacheInput(`${CACHE_KEY}GtSm`, val); };
-  @Input('gdAuto.gt-md') set alignGtMd(val: string) { this._cacheInput(`${CACHE_KEY}GtMd`, val); };
-  @Input('gdAuto.gt-lg') set alignGtLg(val: string) { this._cacheInput(`${CACHE_KEY}GtLg`, val); };
-
-  @Input('gdAuto.lt-sm') set alignLtSm(val: string) { this._cacheInput(`${CACHE_KEY}LtSm`, val); };
-  @Input('gdAuto.lt-md') set alignLtMd(val: string) { this._cacheInput(`${CACHE_KEY}LtMd`, val); };
-  @Input('gdAuto.lt-lg') set alignLtLg(val: string) { this._cacheInput(`${CACHE_KEY}LtLg`, val); };
-  @Input('gdAuto.lt-xl') set alignLtXl(val: string) { this._cacheInput(`${CACHE_KEY}LtXl`, val); };
-
-  @Input('gdInline') set inline(val: string) { this._cacheInput('inline', coerceBooleanProperty(val)); };
-
-  /* tslint:enable */
-  constructor(monitor: MediaMonitor,
-              elRef: ElementRef,
-              styleUtils: StyleUtils) {
-    super(monitor, elRef, styleUtils);
-  }
-
-  // *********************************************
-  // Lifecycle Methods
-  // *********************************************
-
-  /**
-   * For @Input changes on the current mq activation property, see onMediaQueryChanges()
-   */
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes[CACHE_KEY] != null || this._mqActivation) {
-      this._updateWithValue();
-    }
-  }
-
-  /**
-   * After the initial onChanges, build an mqActivation object that bridges
-   * mql change events to onMediaQueryChange handlers
-   */
-  ngOnInit() {
-    super.ngOnInit();
-
-    this._listenForMediaQueryChanges(CACHE_KEY, DEFAULT_VALUE, (changes: MediaChange) => {
-      this._updateWithValue(changes.value);
-    });
-    this._updateWithValue();
-  }
-
-  // *********************************************
-  // Protected methods
-  // *********************************************
-
-  protected _updateWithValue(value?: string) {
-    value = value || this._queryInput(CACHE_KEY) || DEFAULT_VALUE;
-    if (this._mqActivation) {
-      value = this._mqActivation.activatedInput;
-    }
-
-    this._applyStyleToElement(this._buildCSS(value));
-  }
-
-
-  protected _buildCSS(value: string = '') {
-    let [direction, dense] = value.split(' ');
+@Injectable({providedIn: 'root'})
+export class GridAutoStyleBuilder extends StyleBuilder {
+  buildStyles(input: string, parent: GridAutoParent) {
+    let [direction, dense] = (input || DEFAULT_VALUE).split(' ');
     if (direction !== 'column' && direction !== 'row' && direction !== 'dense') {
       direction = 'row';
     }
@@ -109,8 +32,63 @@ export class GridAutoDirective extends BaseDirective implements OnInit, OnChange
     dense = (dense === 'dense' && direction !== 'dense') ? ' dense' : '';
 
     return {
-      'display': this._queryInput('inline') ? 'inline-grid' : 'grid',
+      'display': parent.inline ? 'inline-grid' : 'grid',
       'grid-auto-flow': direction + dense
     };
   }
+}
+
+export class GridAutoDirective extends BaseDirective2 {
+  @Input('gdInline')
+  get inline(): boolean { return this._inline; }
+  set inline(val: boolean) { this._inline = coerceBooleanProperty(val); }
+  protected _inline = false;
+
+  protected DIRECTIVE_KEY = 'grid-auto';
+
+  constructor(protected elementRef: ElementRef,
+              // NOTE: not actually optional, but we need to force DI without a
+              // constructor call
+              @Optional() protected styleBuilder: GridAutoStyleBuilder,
+              protected styler: StyleUtils,
+              protected marshal: MediaMarshaller) {
+    super(elementRef, styleBuilder, styler, marshal);
+    this.marshal.init(this.elementRef.nativeElement, this.DIRECTIVE_KEY,
+      this.updateWithValue.bind(this));
+  }
+
+  // *********************************************
+  // Protected methods
+  // *********************************************
+
+  protected updateWithValue(value: string) {
+    this.styleCache = this.inline ? autoInlineCache : autoCache;
+    this.addStyles(value, {inline: this.inline});
+  }
+}
+
+const autoCache: Map<string, StyleDefinition> = new Map();
+const autoInlineCache: Map<string, StyleDefinition> = new Map();
+
+const inputs = [
+  'gdAuto',
+  'gdAuto.xs', 'gdAuto.sm', 'gdAuto.md', 'gdAuto.lg', 'gdAuto.xl',
+  'gdAuto.lt-sm', 'gdAuto.lt-md', 'gdAuto.lt-lg', 'gdAuto.lt-xl',
+  'gdAuto.gt-xs', 'gdAuto.gt-sm', 'gdAuto.gt-md', 'gdAuto.gt-lg'
+];
+const selector = `
+  [gdAuto],
+  [gdAuto.xs], [gdAuto.sm], [gdAuto.md], [gdAuto.lg], [gdAuto.xl],
+  [gdAuto.lt-sm], [gdAuto.lt-md], [gdAuto.lt-lg], [gdAuto.lt-xl],
+  [gdAuto.gt-xs], [gdAuto.gt-sm], [gdAuto.gt-md], [gdAuto.gt-lg]
+`;
+
+/**
+ * 'grid-auto-flow' CSS Grid styling directive
+ * Configures the auto placement algorithm for the grid
+ * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-23
+ */
+@Directive({selector, inputs})
+export class DefaultGridAutoDirective extends GridAutoDirective {
+  protected inputs = inputs;
 }

--- a/src/lib/grid/column/column.ts
+++ b/src/lib/grid/column/column.ts
@@ -5,99 +5,63 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {Directive, ElementRef, Optional, Injectable} from '@angular/core';
 import {
-  Directive,
-  ElementRef,
-  Input,
-  OnInit,
-  OnChanges,
-  OnDestroy,
-  SimpleChanges,
-} from '@angular/core';
-import {BaseDirective, MediaChange, MediaMonitor, StyleUtils} from '@angular/flex-layout/core';
+  BaseDirective2,
+  StyleUtils,
+  MediaMarshaller,
+  StyleBuilder,
+  StyleDefinition,
+} from '@angular/flex-layout/core';
 
-const CACHE_KEY = 'column';
 const DEFAULT_VALUE = 'auto';
+
+@Injectable({providedIn: 'root'})
+export class GridColumnStyleBuilder extends StyleBuilder {
+  buildStyles(input: string) {
+    return {'grid-column': input || DEFAULT_VALUE};
+  }
+}
+
+export class GridColumnDirective extends BaseDirective2 {
+  protected DIRECTIVE_KEY = 'grid-column';
+
+  constructor(protected elementRef: ElementRef,
+              // NOTE: not actually optional, but we need to force DI without a
+              // constructor call
+              @Optional() protected styleBuilder: GridColumnStyleBuilder,
+              protected styler: StyleUtils,
+              protected marshal: MediaMarshaller) {
+    super(elementRef, styleBuilder, styler, marshal);
+    this.marshal.init(this.elementRef.nativeElement, this.DIRECTIVE_KEY,
+      this.addStyles.bind(this));
+  }
+
+  protected styleCache = columnCache;
+}
+
+const columnCache: Map<string, StyleDefinition> = new Map();
+
+const inputs = [
+  'gdColumn',
+  'gdColumn.xs', 'gdColumn.sm', 'gdColumn.md', 'gdColumn.lg', 'gdColumn.xl',
+  'gdColumn.lt-sm', 'gdColumn.lt-md', 'gdColumn.lt-lg', 'gdColumn.lt-xl',
+  'gdColumn.gt-xs', 'gdColumn.gt-sm', 'gdColumn.gt-md', 'gdColumn.gt-lg'
+];
+
+const selector = `
+  [gdColumn],
+  [gdColumn.xs], [gdColumn.sm], [gdColumn.md], [gdColumn.lg], [gdColumn.xl],
+  [gdColumn.lt-sm], [gdColumn.lt-md], [gdColumn.lt-lg], [gdColumn.lt-xl],
+  [gdColumn.gt-xs], [gdColumn.gt-sm], [gdColumn.gt-md], [gdColumn.gt-lg]
+`;
 
 /**
  * 'grid-column' CSS Grid styling directive
  * Configures the name or position of an element within the grid
  * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-26
  */
-@Directive({selector: `
-  [gdColumn],
-  [gdColumn.xs], [gdColumn.sm], [gdColumn.md], [gdColumn.lg], [gdColumn.xl],
-  [gdColumn.lt-sm], [gdColumn.lt-md], [gdColumn.lt-lg], [gdColumn.lt-xl],
-  [gdColumn.gt-xs], [gdColumn.gt-sm], [gdColumn.gt-md], [gdColumn.gt-lg]
-`})
-export class GridColumnDirective extends BaseDirective implements OnInit, OnChanges, OnDestroy {
-
-  /* tslint:disable */
-  @Input('gdColumn')       set align(val: string)     { this._cacheInput(`${CACHE_KEY}`, val); }
-  @Input('gdColumn.xs')    set alignXs(val: string)   { this._cacheInput(`${CACHE_KEY}Xs`, val); }
-  @Input('gdColumn.sm')    set alignSm(val: string)   { this._cacheInput(`${CACHE_KEY}Sm`, val); };
-  @Input('gdColumn.md')    set alignMd(val: string)   { this._cacheInput(`${CACHE_KEY}Md`, val); };
-  @Input('gdColumn.lg')    set alignLg(val: string)   { this._cacheInput(`${CACHE_KEY}Lg`, val); };
-  @Input('gdColumn.xl')    set alignXl(val: string)   { this._cacheInput(`${CACHE_KEY}Xl`, val); };
-
-  @Input('gdColumn.gt-xs') set alignGtXs(val: string) { this._cacheInput(`${CACHE_KEY}GtXs`, val); };
-  @Input('gdColumn.gt-sm') set alignGtSm(val: string) { this._cacheInput(`${CACHE_KEY}GtSm`, val); };
-  @Input('gdColumn.gt-md') set alignGtMd(val: string) { this._cacheInput(`${CACHE_KEY}GtMd`, val); };
-  @Input('gdColumn.gt-lg') set alignGtLg(val: string) { this._cacheInput(`${CACHE_KEY}GtLg`, val); };
-
-  @Input('gdColumn.lt-sm') set alignLtSm(val: string) { this._cacheInput(`${CACHE_KEY}LtSm`, val); };
-  @Input('gdColumn.lt-md') set alignLtMd(val: string) { this._cacheInput(`${CACHE_KEY}LtMd`, val); };
-  @Input('gdColumn.lt-lg') set alignLtLg(val: string) { this._cacheInput(`${CACHE_KEY}LtLg`, val); };
-  @Input('gdColumn.lt-xl') set alignLtXl(val: string) { this._cacheInput(`${CACHE_KEY}LtXl`, val); };
-
-  /* tslint:enable */
-  constructor(monitor: MediaMonitor,
-              elRef: ElementRef,
-              styleUtils: StyleUtils) {
-    super(monitor, elRef, styleUtils);
-  }
-
-  // *********************************************
-  // Lifecycle Methods
-  // *********************************************
-
-  /**
-   * For @Input changes on the current mq activation property, see onMediaQueryChanges()
-   */
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes[CACHE_KEY] != null || this._mqActivation) {
-      this._updateWithValue();
-    }
-  }
-
-  /**
-   * After the initial onChanges, build an mqActivation object that bridges
-   * mql change events to onMediaQueryChange handlers
-   */
-  ngOnInit() {
-    super.ngOnInit();
-
-    this._listenForMediaQueryChanges(CACHE_KEY, DEFAULT_VALUE, (changes: MediaChange) => {
-      this._updateWithValue(changes.value);
-    });
-    this._updateWithValue();
-  }
-
-  // *********************************************
-  // Protected methods
-  // *********************************************
-
-  protected _updateWithValue(value?: string) {
-    value = value || this._queryInput(CACHE_KEY) || DEFAULT_VALUE;
-    if (this._mqActivation) {
-      value = this._mqActivation.activatedInput;
-    }
-
-    this._applyStyleToElement(this._buildCSS(value));
-  }
-
-
-  protected _buildCSS(value: string = '') {
-    return {'grid-column': value};
-  }
+@Directive({selector, inputs})
+export class DefaultGridColumnDirective extends GridColumnDirective {
+  protected inputs = inputs;
 }

--- a/src/lib/grid/columns/columns.ts
+++ b/src/lib/grid/columns/columns.ts
@@ -5,21 +5,90 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {Directive, ElementRef, Input, Injectable, Optional} from '@angular/core';
 import {
-  Directive,
-  ElementRef,
-  Input,
-  OnInit,
-  OnChanges,
-  OnDestroy,
-  SimpleChanges,
-} from '@angular/core';
-import {BaseDirective, MediaChange, MediaMonitor, StyleUtils} from '@angular/flex-layout/core';
+  MediaMarshaller,
+  BaseDirective2,
+  StyleBuilder,
+  StyleDefinition,
+  StyleUtils,
+} from '@angular/flex-layout/core';
 import {coerceBooleanProperty} from '@angular/cdk/coercion';
 
-const CACHE_KEY = 'columns';
 const DEFAULT_VALUE = 'none';
 const AUTO_SPECIFIER = '!';
+
+export interface GridColumnsParent {
+  inline: boolean;
+}
+
+@Injectable({providedIn: 'root'})
+export class GridColumnsStyleBuilder extends StyleBuilder {
+  buildStyles(input: string, parent: GridColumnsParent) {
+    input = input || DEFAULT_VALUE;
+    let auto = false;
+    if (input.endsWith(AUTO_SPECIFIER)) {
+      input = input.substring(0, input.indexOf(AUTO_SPECIFIER));
+      auto = true;
+    }
+
+    const css = {
+      'display': parent.inline ? 'inline-grid' : 'grid',
+      'grid-auto-columns': '',
+      'grid-template-columns': '',
+    };
+    const key = (auto ? 'grid-auto-columns' : 'grid-template-columns');
+    css[key] = input;
+
+    return css;
+  }
+}
+
+export class GridColumnsDirective extends BaseDirective2 {
+  protected DIRECTIVE_KEY = 'grid-columns';
+
+  @Input('gdInline')
+  get inline(): boolean { return this._inline; }
+  set inline(val: boolean) { this._inline = coerceBooleanProperty(val); }
+  protected _inline = false;
+
+  constructor(protected elementRef: ElementRef,
+              // NOTE: not actually optional, but we need to force DI without a
+              // constructor call
+              @Optional() protected styleBuilder: GridColumnsStyleBuilder,
+              protected styler: StyleUtils,
+              protected marshal: MediaMarshaller) {
+    super(elementRef, styleBuilder, styler, marshal);
+    this.marshal.init(this.elementRef.nativeElement, this.DIRECTIVE_KEY,
+      this.updateWithValue.bind(this));
+  }
+
+  // *********************************************
+  // Protected methods
+  // *********************************************
+
+  protected updateWithValue(value: string) {
+    this.styleCache = this.inline ? columnsInlineCache : columnsCache;
+    this.addStyles(value, {inline: this.inline});
+  }
+}
+
+const columnsCache: Map<string, StyleDefinition> = new Map();
+const columnsInlineCache: Map<string, StyleDefinition> = new Map();
+
+const inputs = [
+  'gdColumns',
+  'gdColumns.xs', 'gdColumns.sm', 'gdColumns.md', 'gdColumns.lg', 'gdColumns.xl',
+  'gdColumns.lt-sm', 'gdColumns.lt-md', 'gdColumns.lt-lg', 'gdColumns.lt-xl',
+  'gdColumns.gt-xs', 'gdColumns.gt-sm', 'gdColumns.gt-md', 'gdColumns.gt-lg'
+];
+
+const selector = `
+  [gdColumns],
+  [gdColumns.xs], [gdColumns.sm], [gdColumns.md], [gdColumns.lg], [gdColumns.xl],
+  [gdColumns.lt-sm], [gdColumns.lt-md], [gdColumns.lt-lg], [gdColumns.lt-xl],
+  [gdColumns.gt-xs], [gdColumns.gt-sm], [gdColumns.gt-md], [gdColumns.gt-lg]
+`;
 
 /**
  * 'grid-template-columns' CSS Grid styling directive
@@ -27,96 +96,7 @@ const AUTO_SPECIFIER = '!';
  * Syntax: <column value> [auto]
  * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-13
  */
-@Directive({selector: `
-  [gdColumns],
-  [gdColumns.xs], [gdColumns.sm], [gdColumns.md], [gdColumns.lg], [gdColumns.xl],
-  [gdColumns.lt-sm], [gdColumns.lt-md], [gdColumns.lt-lg], [gdColumns.lt-xl],
-  [gdColumns.gt-xs], [gdColumns.gt-sm], [gdColumns.gt-md], [gdColumns.gt-lg]
-`})
-export class GridColumnsDirective extends BaseDirective implements OnInit, OnChanges, OnDestroy {
-
-  /* tslint:disable */
-  @Input('gdColumns')       set align(val: string)     { this._cacheInput(`${CACHE_KEY}`, val); }
-  @Input('gdColumns.xs')    set alignXs(val: string)   { this._cacheInput(`${CACHE_KEY}Xs`, val); }
-  @Input('gdColumns.sm')    set alignSm(val: string)   { this._cacheInput(`${CACHE_KEY}Sm`, val); };
-  @Input('gdColumns.md')    set alignMd(val: string)   { this._cacheInput(`${CACHE_KEY}Md`, val); };
-  @Input('gdColumns.lg')    set alignLg(val: string)   { this._cacheInput(`${CACHE_KEY}Lg`, val); };
-  @Input('gdColumns.xl')    set alignXl(val: string)   { this._cacheInput(`${CACHE_KEY}Xl`, val); };
-
-  @Input('gdColumns.gt-xs') set alignGtXs(val: string) { this._cacheInput(`${CACHE_KEY}GtXs`, val); };
-  @Input('gdColumns.gt-sm') set alignGtSm(val: string) { this._cacheInput(`${CACHE_KEY}GtSm`, val); };
-  @Input('gdColumns.gt-md') set alignGtMd(val: string) { this._cacheInput(`${CACHE_KEY}GtMd`, val); };
-  @Input('gdColumns.gt-lg') set alignGtLg(val: string) { this._cacheInput(`${CACHE_KEY}GtLg`, val); };
-
-  @Input('gdColumns.lt-sm') set alignLtSm(val: string) { this._cacheInput(`${CACHE_KEY}LtSm`, val); };
-  @Input('gdColumns.lt-md') set alignLtMd(val: string) { this._cacheInput(`${CACHE_KEY}LtMd`, val); };
-  @Input('gdColumns.lt-lg') set alignLtLg(val: string) { this._cacheInput(`${CACHE_KEY}LtLg`, val); };
-  @Input('gdColumns.lt-xl') set alignLtXl(val: string) { this._cacheInput(`${CACHE_KEY}LtXl`, val); };
-
-  @Input('gdInline') set inline(val: string) { this._cacheInput('inline', coerceBooleanProperty(val)); };
-
-  /* tslint:enable */
-  constructor(monitor: MediaMonitor,
-              elRef: ElementRef,
-              styleUtils: StyleUtils) {
-    super(monitor, elRef, styleUtils);
-  }
-
-  // *********************************************
-  // Lifecycle Methods
-  // *********************************************
-
-  /**
-   * For @Input changes on the current mq activation property, see onMediaQueryChanges()
-   */
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes[CACHE_KEY] != null || this._mqActivation) {
-      this._updateWithValue();
-    }
-  }
-
-  /**
-   * After the initial onChanges, build an mqActivation object that bridges
-   * mql change events to onMediaQueryChange handlers
-   */
-  ngOnInit() {
-    super.ngOnInit();
-
-    this._listenForMediaQueryChanges(CACHE_KEY, DEFAULT_VALUE, (changes: MediaChange) => {
-      this._updateWithValue(changes.value);
-    });
-    this._updateWithValue();
-  }
-
-  // *********************************************
-  // Protected methods
-  // *********************************************
-
-  protected _updateWithValue(value?: string) {
-    value = value || this._queryInput(CACHE_KEY) || DEFAULT_VALUE;
-    if (this._mqActivation) {
-      value = this._mqActivation.activatedInput;
-    }
-
-    this._applyStyleToElement(this._buildCSS(value));
-  }
-
-
-  protected _buildCSS(value: string = '') {
-    let auto = false;
-    if (value.endsWith(AUTO_SPECIFIER)) {
-      value = value.substring(0, value.indexOf(AUTO_SPECIFIER));
-      auto = true;
-    }
-
-    let css = {
-      'display': this._queryInput('inline') ? 'inline-grid' : 'grid',
-      'grid-auto-columns': '',
-      'grid-template-columns': '',
-    };
-    const key = (auto ? 'grid-auto-columns' : 'grid-template-columns');
-    css[key] = value;
-
-    return css;
-  }
+@Directive({selector, inputs})
+export class DefaultGridColumnsDirective extends GridColumnsDirective {
+  protected inputs = inputs;
 }

--- a/src/lib/grid/grid-align/grid-align.ts
+++ b/src/lib/grid/grid-align/grid-align.ts
@@ -5,20 +5,58 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {Directive, ElementRef, Injectable, Optional} from '@angular/core';
 import {
-  Directive,
-  ElementRef,
-  Input,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  SimpleChanges,
-} from '@angular/core';
-import {BaseDirective, MediaChange, MediaMonitor, StyleUtils} from '@angular/flex-layout/core';
+  MediaMarshaller,
+  BaseDirective2,
+  StyleBuilder,
+  StyleDefinition,
+  StyleUtils,
+} from '@angular/flex-layout/core';
 
-const CACHE_KEY = 'align';
 const ROW_DEFAULT = 'stretch';
 const COL_DEFAULT = 'stretch';
+
+@Injectable({providedIn: 'root'})
+export class GridAlignStyleBuilder extends StyleBuilder {
+  buildStyles(input: string) {
+    return buildCss(input || ROW_DEFAULT);
+  }
+}
+
+export class GridAlignDirective extends BaseDirective2 {
+
+  protected DIRECTIVE_KEY = 'grid-align';
+
+  constructor(protected elementRef: ElementRef,
+              // NOTE: not actually optional, but we need to force DI without a
+              // constructor call
+              @Optional() protected styleBuilder: GridAlignStyleBuilder,
+              protected styler: StyleUtils,
+              protected marshal: MediaMarshaller) {
+    super(elementRef, styleBuilder, styler, marshal);
+    this.marshal.init(this.elementRef.nativeElement, this.DIRECTIVE_KEY,
+      this.addStyles.bind(this));
+  }
+
+  protected styleCache = alignCache;
+}
+
+const alignCache: Map<string, StyleDefinition> = new Map();
+
+const inputs = [
+  'gdGridAlign',
+  'gdGridAlign.xs', 'gdGridAlign.sm', 'gdGridAlign.md', 'gdGridAlign.lg', 'gdGridAlign.xl',
+  'gdGridAlign.lt-sm', 'gdGridAlign.lt-md', 'gdGridAlign.lt-lg', 'gdGridAlign.lt-xl',
+  'gdGridAlign.gt-xs', 'gdGridAlign.gt-sm', 'gdGridAlign.gt-md', 'gdGridAlign.gt-lg'
+];
+
+const selector = `
+  [gdGridAlign],
+  [gdGridAlign.xs], [gdGridAlign.sm], [gdGridAlign.md], [gdGridAlign.lg],[gdGridAlign.xl],
+  [gdGridAlign.lt-sm], [gdGridAlign.lt-md], [gdGridAlign.lt-lg], [gdGridAlign.lt-xl],
+  [gdGridAlign.gt-xs], [gdGridAlign.gt-sm], [gdGridAlign.gt-md], [gdGridAlign.gt-lg]
+`;
 
 /**
  * 'align' CSS Grid styling directive for grid children
@@ -28,119 +66,51 @@ const COL_DEFAULT = 'stretch';
  *  @see https://css-tricks.com/snippets/css/complete-guide-grid/#prop-justify-self
  *  @see https://css-tricks.com/snippets/css/complete-guide-grid/#prop-align-self
  */
-@Directive({selector: `
-  [gdGridAlign],
-  [gdGridAlign.xs], [gdGridAlign.sm], [gdGridAlign.md], [gdGridAlign.lg],[gdGridAlign.xl],
-  [gdGridAlign.lt-sm], [gdGridAlign.lt-md], [gdGridAlign.lt-lg], [gdGridAlign.lt-xl],
-  [gdGridAlign.gt-xs], [gdGridAlign.gt-sm], [gdGridAlign.gt-md], [gdGridAlign.gt-lg]
-`})
-export class GridAlignDirective extends BaseDirective implements OnInit, OnChanges, OnDestroy {
+@Directive({selector, inputs})
+export class DefaultGridAlignDirective extends GridAlignDirective {
+  protected inputs = inputs;
+}
 
-  /* tslint:disable */
-  @Input('gdGridAlign')       set align(val: string)     { this._cacheInput(`${CACHE_KEY}`, val); }
-  @Input('gdGridAlign.xs')    set alignXs(val: string)   { this._cacheInput(`${CACHE_KEY}Xs`, val); }
-  @Input('gdGridAlign.sm')    set alignSm(val: string)   { this._cacheInput(`${CACHE_KEY}Sm`, val); };
-  @Input('gdGridAlign.md')    set alignMd(val: string)   { this._cacheInput(`${CACHE_KEY}Md`, val); };
-  @Input('gdGridAlign.lg')    set alignLg(val: string)   { this._cacheInput(`${CACHE_KEY}Lg`, val); };
-  @Input('gdGridAlign.xl')    set alignXl(val: string)   { this._cacheInput(`${CACHE_KEY}Xl`, val); };
+function buildCss(align: string = '') {
+  const css: {[key: string]: string} = {}, [rowAxis, columnAxis] = align.split(' ');
 
-  @Input('gdGridAlign.gt-xs') set alignGtXs(val: string) { this._cacheInput(`${CACHE_KEY}GtXs`, val); };
-  @Input('gdGridAlign.gt-sm') set alignGtSm(val: string) { this._cacheInput(`${CACHE_KEY}GtSm`, val); };
-  @Input('gdGridAlign.gt-md') set alignGtMd(val: string) { this._cacheInput(`${CACHE_KEY}GtMd`, val); };
-  @Input('gdGridAlign.gt-lg') set alignGtLg(val: string) { this._cacheInput(`${CACHE_KEY}GtLg`, val); };
-
-  @Input('gdGridAlign.lt-sm') set alignLtSm(val: string) { this._cacheInput(`${CACHE_KEY}LtSm`, val); };
-  @Input('gdGridAlign.lt-md') set alignLtMd(val: string) { this._cacheInput(`${CACHE_KEY}LtMd`, val); };
-  @Input('gdGridAlign.lt-lg') set alignLtLg(val: string) { this._cacheInput(`${CACHE_KEY}LtLg`, val); };
-  @Input('gdGridAlign.lt-xl') set alignLtXl(val: string) { this._cacheInput(`${CACHE_KEY}LtXl`, val); };
-
-  /* tslint:enable */
-  constructor(monitor: MediaMonitor,
-              elRef: ElementRef,
-              styleUtils: StyleUtils) {
-    super(monitor, elRef, styleUtils);
+  // Row axis
+  switch (rowAxis) {
+    case 'end':
+      css['justify-self'] = 'end';
+      break;
+    case 'center':
+      css['justify-self'] = 'center';
+      break;
+    case 'stretch':
+      css['justify-self'] = 'stretch';
+      break;
+    case 'start':
+      css['justify-self'] = 'start';
+      break;
+    default:
+      css['justify-self'] = ROW_DEFAULT;  // default row axis
+      break;
   }
 
-  // *********************************************
-  // Lifecycle Methods
-  // *********************************************
-
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes[CACHE_KEY] != null || this._mqActivation) {
-      this._updateWithValue();
-    }
+  // Column axis
+  switch (columnAxis) {
+    case 'end':
+      css['align-self'] = 'end';
+      break;
+    case 'center':
+      css['align-self'] = 'center';
+      break;
+    case 'stretch':
+      css['align-self'] = 'stretch';
+      break;
+    case 'start':
+      css['align-self'] = 'start';
+      break;
+    default:
+      css['align-self'] = COL_DEFAULT;  // default column axis
+      break;
   }
 
-  /**
-   * After the initial onChanges, build an mqActivation object that bridges
-   * mql change events to onMediaQueryChange handlers
-   */
-  ngOnInit() {
-    super.ngOnInit();
-
-    this._listenForMediaQueryChanges(CACHE_KEY, ROW_DEFAULT, (changes: MediaChange) => {
-      this._updateWithValue(changes.value);
-    });
-    this._updateWithValue();
-  }
-
-  // *********************************************
-  // Protected methods
-  // *********************************************
-
-  /**
-   *
-   */
-  protected _updateWithValue(value?: string) {
-    value = value || this._queryInput(CACHE_KEY) || ROW_DEFAULT;
-    if (this._mqActivation) {
-      value = this._mqActivation.activatedInput;
-    }
-
-    this._applyStyleToElement(this._buildCSS(value));
-  }
-
-  protected _buildCSS(align: string = '') {
-    let css: {[key: string]: string} = {}, [rowAxis, columnAxis] = align.split(' ');
-
-    // Row axis
-    switch (rowAxis) {
-      case 'end':
-        css['justify-self'] = 'end';
-        break;
-      case 'center':
-        css['justify-self'] = 'center';
-        break;
-      case 'stretch':
-        css['justify-self'] = 'stretch';
-        break;
-      case 'start':
-        css['justify-self'] = 'start';
-        break;
-      default:
-        css['justify-self'] = ROW_DEFAULT;  // default row axis
-        break;
-    }
-
-    // Column axis
-    switch (columnAxis) {
-      case 'end':
-        css['align-self'] = 'end';
-        break;
-      case 'center':
-        css['align-self'] = 'center';
-        break;
-      case 'stretch':
-        css['align-self'] = 'stretch';
-        break;
-      case 'start':
-        css['align-self'] = 'start';
-        break;
-      default:
-        css['align-self'] = COL_DEFAULT;  // default column axis
-        break;
-    }
-
-    return css;
-  }
+  return css;
 }

--- a/src/lib/grid/module.ts
+++ b/src/lib/grid/module.ts
@@ -8,31 +8,31 @@
 import {NgModule} from '@angular/core';
 import {CoreModule} from '@angular/flex-layout/core';
 
-import {GridAlignDirective} from './grid-align/grid-align';
-import {GridAlignColumnsDirective} from './align-columns/align-columns';
-import {GridAlignRowsDirective} from './align-rows/align-rows';
-import {GridAreaDirective} from './area/area';
-import {GridAreasDirective} from './areas/areas';
-import {GridAutoDirective} from './auto/auto';
-import {GridColumnDirective} from './column/column';
-import {GridColumnsDirective} from './columns/columns';
-import {GridGapDirective} from './gap/gap';
-import {GridRowDirective} from './row/row';
-import {GridRowsDirective} from './rows/rows';
+import {DefaultGridAlignDirective} from './grid-align/grid-align';
+import {DefaultGridAlignColumnsDirective} from './align-columns/align-columns';
+import {DefaultGridAlignRowsDirective} from './align-rows/align-rows';
+import {DefaultGridAreaDirective} from './area/area';
+import {DefaultGridAreasDirective} from './areas/areas';
+import {DefaultGridAutoDirective} from './auto/auto';
+import {DefaultGridColumnDirective} from './column/column';
+import {DefaultGridColumnsDirective} from './columns/columns';
+import {DefaultGridGapDirective} from './gap/gap';
+import {DefaultGridRowDirective} from './row/row';
+import {DefaultGridRowsDirective} from './rows/rows';
 
 
 const ALL_DIRECTIVES = [
-  GridAlignDirective,
-  GridAlignColumnsDirective,
-  GridAlignRowsDirective,
-  GridAreaDirective,
-  GridAreasDirective,
-  GridAutoDirective,
-  GridColumnDirective,
-  GridColumnsDirective,
-  GridGapDirective,
-  GridRowDirective,
-  GridRowsDirective,
+  DefaultGridAlignDirective,
+  DefaultGridAlignColumnsDirective,
+  DefaultGridAlignRowsDirective,
+  DefaultGridAreaDirective,
+  DefaultGridAreasDirective,
+  DefaultGridAutoDirective,
+  DefaultGridColumnDirective,
+  DefaultGridColumnsDirective,
+  DefaultGridGapDirective,
+  DefaultGridRowDirective,
+  DefaultGridRowsDirective,
 ];
 
 /**

--- a/src/lib/grid/row/row.ts
+++ b/src/lib/grid/row/row.ts
@@ -5,99 +5,63 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {Directive, ElementRef, Optional, Injectable} from '@angular/core';
 import {
-  Directive,
-  ElementRef,
-  Input,
-  OnInit,
-  OnChanges,
-  OnDestroy,
-  SimpleChanges,
-} from '@angular/core';
-import {BaseDirective, MediaChange, MediaMonitor, StyleUtils} from '@angular/flex-layout/core';
+  BaseDirective2,
+  StyleUtils,
+  MediaMarshaller,
+  StyleBuilder,
+  StyleDefinition,
+} from '@angular/flex-layout/core';
 
-const CACHE_KEY = 'row';
 const DEFAULT_VALUE = 'auto';
+
+@Injectable({providedIn: 'root'})
+export class GridRowStyleBuilder extends StyleBuilder {
+  buildStyles(input: string) {
+    return {'grid-row': input || DEFAULT_VALUE};
+  }
+}
+
+export class GridRowDirective extends BaseDirective2 {
+  protected DIRECTIVE_KEY = 'grid-row';
+
+  constructor(protected elementRef: ElementRef,
+              // NOTE: not actually optional, but we need to force DI without a
+              // constructor call
+              @Optional() protected styleBuilder: GridRowStyleBuilder,
+              protected styler: StyleUtils,
+              protected marshal: MediaMarshaller) {
+    super(elementRef, styleBuilder, styler, marshal);
+    this.marshal.init(this.elementRef.nativeElement, this.DIRECTIVE_KEY,
+      this.addStyles.bind(this));
+  }
+
+  protected styleCache = rowCache;
+}
+
+const rowCache: Map<string, StyleDefinition> = new Map();
+
+const inputs = [
+  'gdRow',
+  'gdRow.xs', 'gdRow.sm', 'gdRow.md', 'gdRow.lg', 'gdRow.xl',
+  'gdRow.lt-sm', 'gdRow.lt-md', 'gdRow.lt-lg', 'gdRow.lt-xl',
+  'gdRow.gt-xs', 'gdRow.gt-sm', 'gdRow.gt-md', 'gdRow.gt-lg'
+];
+
+const selector = `
+  [gdRow],
+  [gdRow.xs], [gdRow.sm], [gdRow.md], [gdRow.lg], [gdRow.xl],
+  [gdRow.lt-sm], [gdRow.lt-md], [gdRow.lt-lg], [gdRow.lt-xl],
+  [gdRow.gt-xs], [gdRow.gt-sm], [gdRow.gt-md], [gdRow.gt-lg]
+`;
 
 /**
  * 'grid-row' CSS Grid styling directive
  * Configures the name or position of an element within the grid
  * @see https://css-tricks.com/snippets/css/complete-guide-grid/#article-header-id-26
  */
-@Directive({selector: `
-  [gdRow],
-  [gdRow.xs], [gdRow.sm], [gdRow.md], [gdRow.lg], [gdRow.xl],
-  [gdRow.lt-sm], [gdRow.lt-md], [gdRow.lt-lg], [gdRow.lt-xl],
-  [gdRow.gt-xs], [gdRow.gt-sm], [gdRow.gt-md], [gdRow.gt-lg]
-`})
-export class GridRowDirective extends BaseDirective implements OnInit, OnChanges, OnDestroy {
-
-  /* tslint:disable */
-  @Input('gdRow')       set align(val: string)     { this._cacheInput(`${CACHE_KEY}`, val); }
-  @Input('gdRow.xs')    set alignXs(val: string)   { this._cacheInput(`${CACHE_KEY}Xs`, val); }
-  @Input('gdRow.sm')    set alignSm(val: string)   { this._cacheInput(`${CACHE_KEY}Sm`, val); };
-  @Input('gdRow.md')    set alignMd(val: string)   { this._cacheInput(`${CACHE_KEY}Md`, val); };
-  @Input('gdRow.lg')    set alignLg(val: string)   { this._cacheInput(`${CACHE_KEY}Lg`, val); };
-  @Input('gdRow.xl')    set alignXl(val: string)   { this._cacheInput(`${CACHE_KEY}Xl`, val); };
-
-  @Input('gdRow.gt-xs') set alignGtXs(val: string) { this._cacheInput(`${CACHE_KEY}GtXs`, val); };
-  @Input('gdRow.gt-sm') set alignGtSm(val: string) { this._cacheInput(`${CACHE_KEY}GtSm`, val); };
-  @Input('gdRow.gt-md') set alignGtMd(val: string) { this._cacheInput(`${CACHE_KEY}GtMd`, val); };
-  @Input('gdRow.gt-lg') set alignGtLg(val: string) { this._cacheInput(`${CACHE_KEY}GtLg`, val); };
-
-  @Input('gdRow.lt-sm') set alignLtSm(val: string) { this._cacheInput(`${CACHE_KEY}LtSm`, val); };
-  @Input('gdRow.lt-md') set alignLtMd(val: string) { this._cacheInput(`${CACHE_KEY}LtMd`, val); };
-  @Input('gdRow.lt-lg') set alignLtLg(val: string) { this._cacheInput(`${CACHE_KEY}LtLg`, val); };
-  @Input('gdRow.lt-xl') set alignLtXl(val: string) { this._cacheInput(`${CACHE_KEY}LtXl`, val); };
-
-  /* tslint:enable */
-  constructor(monitor: MediaMonitor,
-              elRef: ElementRef,
-              styleUtils: StyleUtils) {
-    super(monitor, elRef, styleUtils);
-  }
-
-  // *********************************************
-  // Lifecycle Methods
-  // *********************************************
-
-  /**
-   * For @Input changes on the current mq activation property, see onMediaQueryChanges()
-   */
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes[CACHE_KEY] != null || this._mqActivation) {
-      this._updateWithValue();
-    }
-  }
-
-  /**
-   * After the initial onChanges, build an mqActivation object that bridges
-   * mql change events to onMediaQueryChange handlers
-   */
-  ngOnInit() {
-    super.ngOnInit();
-
-    this._listenForMediaQueryChanges(CACHE_KEY, DEFAULT_VALUE, (changes: MediaChange) => {
-      this._updateWithValue(changes.value);
-    });
-    this._updateWithValue();
-  }
-
-  // *********************************************
-  // Protected methods
-  // *********************************************
-
-  protected _updateWithValue(value?: string) {
-    value = value || this._queryInput(CACHE_KEY) || DEFAULT_VALUE;
-    if (this._mqActivation) {
-      value = this._mqActivation.activatedInput;
-    }
-
-    this._applyStyleToElement(this._buildCSS(value));
-  }
-
-
-  protected _buildCSS(value: string = '') {
-    return {'grid-row': value};
-  }
+@Directive({selector, inputs})
+export class DefaultGridRowDirective extends GridRowDirective {
+  protected inputs = inputs;
 }

--- a/src/lib/server/server-provider.ts
+++ b/src/lib/server/server-provider.ts
@@ -15,7 +15,8 @@ import {
   BreakPoint,
   MatchMedia,
   StylesheetMap,
-  ServerMatchMedia
+  ServerMatchMedia,
+  prioritySort,
 } from '@angular/flex-layout/core';
 
 
@@ -24,7 +25,7 @@ import {
  * retrieve the associated stylings from the virtual stylesheet
  * @param serverSheet the virtual stylesheet that stores styles for each
  *        element
- * @param matchMedia the service to activate/deactive breakpoints
+ * @param matchMedia the service to activate/deactivate breakpoints
  * @param breakpoints the registered breakpoints to activate/deactivate
  */
 export function generateStaticFlexLayoutStyles(serverSheet: StylesheetMap,
@@ -41,6 +42,7 @@ export function generateStaticFlexLayoutStyles(serverSheet: StylesheetMap,
   const defaultStyles = new Map(serverSheet.stylesheet);
   let styleText = generateCss(defaultStyles, 'all', classMap);
 
+  breakpoints.sort(prioritySort);
   breakpoints.reverse();
   breakpoints.forEach((bp, i) => {
     serverSheet.clearStyles();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,32 +3,32 @@
 
 
 "@angular/animations@^7.0.3":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-7.1.1.tgz#8fecbd19417364946a9ea40c8fdf32462110232f"
-  integrity sha512-iTNxhPPraCZsE4rgM23lguT1kDV4mfYAr+Bsi5J0+v9ZJA+VaKvi6eRW8ZGrx4/rDz6hzTnBn1jgPppHFbsOcw==
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-7.1.2.tgz#876598802a2722b97d7aa9ea092d3aadc05c1fa8"
+  integrity sha512-zCLzPpifD4V9C35+DG75yHiAxZrWmk7n7dudxchKXf/YpgzV1M43lTSxna6YZgMLIXRjilfjfh6jqOOP+PctoQ==
   dependencies:
     tslib "^1.9.0"
 
 "@angular/cdk@^7.0.3":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-7.1.0.tgz#7e5c3e3631947ef91413a83997ec4edec92cdd1c"
-  integrity sha512-dY740pKcIRtKr6n6NomrgqfdEj988urTZ9I/bfJjxF5fdhnSjyhEvDlB55EHsrF+bTTZbZXRmv7AwOQ9GJnD9w==
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-7.1.1.tgz#6916b2303af5e0a56a9b64ff4d54642cf191c54f"
+  integrity sha512-woW9lWDBKRuxZipMzWofrAY7YpuZd4vf/J1YPjmAqV7U94MaDFyizRLyFolbTZVYo8ggh9U3SQAWRrEBvJNsjg==
   dependencies:
     tslib "^1.7.1"
   optionalDependencies:
     parse5 "^5.0.0"
 
 "@angular/common@^7.0.3":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/common/-/common-7.1.1.tgz#f78f884614ef81ab2fd648f1aa3e83aae370a6c8"
-  integrity sha512-SngekFx9v39sjgi9pON0Wehxpu+NdUk7OEebw4Fa8dKqTgydTkuhmnNH+9WQe264asoeCt51oufPRjIqMLNohA==
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@angular/common/-/common-7.1.2.tgz#506e48b18dd8c9dd8c97e61585ad0647079e6c05"
+  integrity sha512-Ss9OilnbKpfkkwa1spUUAzgtGgd76j+Cgp1ecBBaueBoHyDZcSwD3Ioe5/91mjGF8i/MmpoBtEmk569fwmb7iQ==
   dependencies:
     tslib "^1.9.0"
 
 "@angular/compiler-cli@^7.0.3":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-7.1.1.tgz#c5f6225fb72b56f42fa78c332fdee9755c64604e"
-  integrity sha512-4NXlkDhOEQgaP3Agigqw93CvXJvsfnXa0xiglq9e/wjL+6XbtM9WcDb5lfRQz41N9RSkO3pEHGvKMweKZGgogA==
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-7.1.2.tgz#8bdf883b6e529ccd8111f1adc92c3323fa11d093"
+  integrity sha512-u686o7eOPxSokE3l+lpSMs+sGRTLiGBXGsTuNR891XPN8+E5ep7NHgimeLizVXlbwIYZiNtcQ9zRbhEsMI2ErQ==
   dependencies:
     canonical-path "1.0.0"
     chokidar "^1.4.2"
@@ -43,67 +43,67 @@
     yargs "9.0.1"
 
 "@angular/compiler@^7.0.3":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-7.1.1.tgz#4efbcad27ab43d4cd36d936a8df2e073f6d02d0a"
-  integrity sha512-oJvBe8XZ+DXF/W/DxWBTbBcixJTuPeZWdkcZIGWhJoQP7K5GnGnj8ffP9Lp6Dh4TKv85awtC6OfIKhbHxa650Q==
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-7.1.2.tgz#def5a55616ef805963288b9d9402d87411d93e7a"
+  integrity sha512-ua6Wh+c5XzxAeJT6guwAFYnwa1XzJpncppUrceRXIS9VAn9X7ApxRr45DvbVeYwXBb1iNdHWtZFm1koFVQpydA==
   dependencies:
     tslib "^1.9.0"
 
 "@angular/core@^7.0.3":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-7.1.1.tgz#9748b0103cd86226554e1ccbd0f43dd8c46f1ed1"
-  integrity sha512-Osig5SRgDRQ+Hec/liN7nq/BCJieB+4/pqRh9rFbOXezb2ptgRZqdXOXN8P17i4AwPVf308Mh55V0niJ5Eu3Rw==
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-7.1.2.tgz#08f90d8e6ecb26c10cc21e2e2e4bdca5d0b7d7a5"
+  integrity sha512-k3hKz6oj5KAaU/R034flxa73MWoR1SBBZPbpqK5zncIYbZMxvUQDgD3O7SNdQfI9G534SzdJk3AqJNEDTFUyYA==
   dependencies:
     tslib "^1.9.0"
 
 "@angular/forms@^7.0.3":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-7.1.1.tgz#d16ef10a901c007062fd19144cd77917ef55ee24"
-  integrity sha512-yCWuPjpu23Wc3XUw7v/ACNn/e249oT0bYlM8aaMQ1F5OwrmmC4NJC12Rpl9Ihza61RIHIKzNcHVEgzc7WhcSag==
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-7.1.2.tgz#17a427e27f496e41677be05c5d8033899db9e942"
+  integrity sha512-L7LtvjcZUf4DjeDKQnxm+AzC9VkmR3I+hnezyvkLT7oUHcHEpYgNtiLmNM4Ir7ZI3zuaSMmHlEBlnDn0YJlcvA==
   dependencies:
     tslib "^1.9.0"
 
 "@angular/http@^7.0.3":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/http/-/http-7.1.1.tgz#f19f17ad42e7f3cdabcf1250ca757640d0f02219"
-  integrity sha512-pRk+c/kz9aJ8te5xzCxlPLpFnwB0d/E9YkOo3/ydaXF9vZw13RTzk00YyzJ41PDzJf8oPDdXtueTQ+vtJ7Srtw==
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@angular/http/-/http-7.1.2.tgz#928fd412c39a79fec3e67b01601d428c9cc8d43d"
+  integrity sha512-8wscCWG+Cd+/IKniYrBViMFWFZFNh8eEkmUAucPInwmcSFyY//ZLWd2WJLEqbclAGT7kOkTOdUjJ6eMnnWAFuw==
   dependencies:
     tslib "^1.9.0"
 
 "@angular/material@^7.0.3":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@angular/material/-/material-7.1.0.tgz#441f2d03a97a1fa35546b61dcde86db34f0f5efc"
-  integrity sha512-bgotNpSfGLjNZ1AcTyhs6XS7trF4I7UHwQmfa0l8y3Gf9plwErPDfQe2XqnayRyG9nTwHj9f1lQ45X5mr3/0/A==
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@angular/material/-/material-7.1.1.tgz#147b7565262e04d504c8dab7317632967a3db02a"
+  integrity sha512-wjYAWsdWpb8/BgoIfoUomnycoljU00avJ3hRIgPNnEpZhB7zqiBA8tCitzDS4NK8dKBJjM9WRAOj6yl6x3+9wA==
   dependencies:
     tslib "^1.7.1"
 
 "@angular/platform-browser-dynamic@^7.0.3":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-7.1.1.tgz#6945298446173338782f437a996226110cda0d3e"
-  integrity sha512-ZIu48Vn4S6gjD7CMbGlKGaPQ8v9rYkWzlNYi4vTYzgiqKKNC3hqLsVESU3mSvr5oeQBxSIBidTdHSyafHFrA2w==
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-7.1.2.tgz#1eb7a08f011e911817c9cdfaa560523cedba959a"
+  integrity sha512-DoQ+840d3YSC34NnCVD+NlQOyes56+Re9V62ZViXKSwsWtpqgsYBiUW5yYHCO8bruS+Kn+BGTCK/w7/KEM60tg==
   dependencies:
     tslib "^1.9.0"
 
 "@angular/platform-browser@^7.0.3":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-7.1.1.tgz#a6bd408f656dc43ee5a2d8af3dfaa786c7c1dfca"
-  integrity sha512-I6OPjecynGJSbPtzu0gvEgSmIR6X6/xEAhg4L9PycW1ryjzptTC9klWRTWIqsIBqMxhVnY44uKLeRNrDwMOwyA==
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-7.1.2.tgz#7f1fa3b59473b1ddaaa658bf064cf512f27c6578"
+  integrity sha512-cxFCqOXfLznHNI3dfnKcSCokbuSrxSLlXdE4uqoZliTRQIC9/ccrxVdx4UbJjtSgWFaNG1ocxH0rckgcUEG/kg==
   dependencies:
     tslib "^1.9.0"
 
 "@angular/platform-server@^7.0.3":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/platform-server/-/platform-server-7.1.1.tgz#adecd03e586d2f62fee7417e68897067e59aa686"
-  integrity sha512-wG9Xk8R6rWkWIfDQ31IwrL7gAu0gRx/vJW2We1kz1hHKOqnCB22qOTEaFY0hPfKFlwvwcZknm4KFXAizA8ub4A==
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@angular/platform-server/-/platform-server-7.1.2.tgz#2ffac676e752125a9d70d01af309e6105f7cd903"
+  integrity sha512-w7cIzWP9tc2xAdo7r81W3UNDyYO8y37lz8G+o9QyFRj4/bdwsVyqmpwKM/NHlsCt/Gce0gNjgPAlhU9gug780Q==
   dependencies:
     domino "^2.1.0"
     tslib "^1.9.0"
     xhr2 "^0.1.4"
 
 "@angular/router@^7.0.3":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@angular/router/-/router-7.1.1.tgz#80a4cdffc03a529b73485c2ad63a30ec435364ea"
-  integrity sha512-jbnqEq/1iDBkeH8Vn13hauGPTzhwllWM+MLfmdNGTiMzGRx4pmkWa57seDOeBF/GNYBL9JjkWTCrkKFAc2FJKw==
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@angular/router/-/router-7.1.2.tgz#3a322f6ee912d309e5f65eb10c7db6cf376d82c8"
+  integrity sha512-Lht4hcbx2hAtUEcJ1YG4Q63bukKrDHxqSnELMYi1/G5y5vH8LWPQX7aoEcOJeaQWQTKroQBAIeprol/h9vkvoQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -115,17 +115,17 @@
     "@babel/highlight" "^7.0.0"
 
 "@babel/core@^7.1.2":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.1.6.tgz#3733cbee4317429bc87c62b29cf8587dba7baeb3"
-  integrity sha512-Hz6PJT6e44iUNpAn8AoyAs6B3bl60g7MJQaI0rZEar6ECzh6+srYO1xlIdssio34mPaUtAb1y+XlkkSJzok3yw==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.2.0.tgz#a4dd3814901998e93340f0086e9867fefa163ada"
+  integrity sha512-7pvAdC4B+iKjFFp9Ztj0QgBndJ++qaMeonT185wAqUnhipw8idm9Rv1UMyBuKtYjfl6ORNkgEgcsYLfHX/GpLw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.1.6"
-    "@babel/helpers" "^7.1.5"
-    "@babel/parser" "^7.1.6"
+    "@babel/generator" "^7.2.0"
+    "@babel/helpers" "^7.2.0"
+    "@babel/parser" "^7.2.0"
     "@babel/template" "^7.1.2"
     "@babel/traverse" "^7.1.6"
-    "@babel/types" "^7.1.6"
+    "@babel/types" "^7.2.0"
     convert-source-map "^1.1.0"
     debug "^4.1.0"
     json5 "^2.1.0"
@@ -134,12 +134,12 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.1.6":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.1.6.tgz#001303cf87a5b9d093494a4bf251d7b5d03d3999"
-  integrity sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==
+"@babel/generator@^7.1.6", "@babel/generator@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.2.0.tgz#eaf3821fa0301d9d4aef88e63d4bcc19b73ba16c"
+  integrity sha512-BA75MVfRlFQG2EZgFYIwyT1r6xSkwfP2bdkY/kLZusEYWiJs4xCowab/alaEaT0wSvmVuXGqiefeBlP+7V1yKg==
   dependencies:
-    "@babel/types" "^7.1.6"
+    "@babel/types" "^7.2.0"
     jsesc "^2.5.1"
     lodash "^4.17.10"
     source-map "^0.5.0"
@@ -168,14 +168,14 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
-"@babel/helpers@^7.1.5":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.1.5.tgz#68bfc1895d685f2b8f1995e788dbfe1f6ccb1996"
-  integrity sha512-2jkcdL02ywNBry1YNFAH/fViq4fXG0vdckHqeJk+75fpQ2OH+Az6076tX/M0835zA45E0Cqa6pV5Kiv9YOqjEg==
+"@babel/helpers@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.2.0.tgz#8335f3140f3144270dc63c4732a4f8b0a50b7a21"
+  integrity sha512-Fr07N+ea0dMcMN8nFpuK6dUIT7/ivt9yKQdEEnjVS83tG2pHwPi03gYmk/tyuwONnZ+sY+GFFPlWGgCtW1hF9A==
   dependencies:
     "@babel/template" "^7.1.2"
     "@babel/traverse" "^7.1.5"
-    "@babel/types" "^7.1.5"
+    "@babel/types" "^7.2.0"
 
 "@babel/highlight@^7.0.0":
   version "7.0.0"
@@ -186,10 +186,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.2", "@babel/parser@^7.1.6":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.6.tgz#16e97aca1ec1062324a01c5a6a7d0df8dd189854"
-  integrity sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ==
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.2", "@babel/parser@^7.1.6", "@babel/parser@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.2.0.tgz#02d01dbc330b6cbf36b76ac93c50752c69027065"
+  integrity sha512-M74+GvK4hn1eejD9lZ7967qAwvqTZayQa3g10ag4s9uewgR7TKjeaT0YMyoq+gVfKYABiWZ4MQD701/t5e1Jhg==
 
 "@babel/template@^7.1.0", "@babel/template@^7.1.2":
   version "7.1.2"
@@ -215,10 +215,10 @@
     globals "^11.1.0"
     lodash "^4.17.10"
 
-"@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.1.5", "@babel/types@^7.1.6":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.1.6.tgz#0adb330c3a281348a190263aceb540e10f04bcce"
-  integrity sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==
+"@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.1.6", "@babel/types@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.2.0.tgz#7941c5b2d8060e06f9601d6be7c223eef906d5d8"
+  integrity sha512-b4v7dyfApuKDvmPb+O488UlGuR1WbwMXFsO/cyqMrnfvRAChZKJAYeeglWTjUO1b9UghKKgepAQM5tsvBJca6A==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
@@ -240,17 +240,17 @@
     tslib "1.9.0"
     xmlhttprequest "1.8.0"
 
-"@firebase/auth-types@0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.3.4.tgz#253b1b2d9b520a0b945d4617c8418f0f19a4159f"
-  integrity sha512-0r3gSQk9jw5orFHCTUIgao0zan6dHt2J0BO3t/uEzbod+uwqvUn/gh+yg+kK6HX92Fg8E7y030KX4Bw/aXt0Ew==
+"@firebase/auth-types@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.5.0.tgz#5620308993d524e5b4f0d084372ad7e7dc7dee55"
+  integrity sha512-DSjtsIjTy5RSiWyGHqiGkLcDgEgFEf2aD2O0t/0+lHmAzxUGrJFO5+IkPNV6i0ffmtiJaXQDJ7z7q4OdypDBCg==
 
-"@firebase/auth@0.7.9":
-  version "0.7.9"
-  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-0.7.9.tgz#f915f8eeb6ee16b827518f48a0fa529803d39e4e"
-  integrity sha512-m8e2KZ/WvToTMovoBI5K3N0Ku8Aqt6083oqzQODUYHjf94KsAfGdoQEaJono7T7vK4o7E5xpqFgFldOM5LdgiQ==
+"@firebase/auth@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-0.9.0.tgz#c815f36c9b0e494c50a15b93ce0d958f4eed0f29"
+  integrity sha512-pNxfxFr4/tJluGfmPYUiuy2Tq/ZSRniJlWP4fj1mg+a9r+KevheeISZdWEZwJMosieXeCg+BzY0tvFD9j5ZrDw==
   dependencies:
-    "@firebase/auth-types" "0.3.4"
+    "@firebase/auth-types" "0.5.0"
 
 "@firebase/database-types@0.3.2":
   version "0.3.2"
@@ -268,20 +268,20 @@
     faye-websocket "0.11.1"
     tslib "1.9.0"
 
-"@firebase/firestore-types@0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-0.7.0.tgz#bded7892868cf6b189a121d0f0cec468f1609995"
-  integrity sha512-jyKRcKnSh3CSEPL4xGOZNoOXEiv7YmFK/JEcdd/4cAH17/Xo+Pk67gk1E648LRKh6QPghgNvzNTY5R10mKbQNw==
+"@firebase/firestore-types@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-0.8.0.tgz#a40b2ed03eda9c189af145acdff408e562976345"
+  integrity sha512-FdLy2TbZ6aAeT9eDmVMPAFsUqhjN2e+jcdVpl0Pz1W6ElRWWyr30hgTY7xIqIKpMs1iT6IF/8w9CKvI6fPbKxA==
 
-"@firebase/firestore@0.8.8":
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-0.8.8.tgz#17d7fccf7afb4b27d4c55e608f03fff55bad163a"
-  integrity sha512-8OxRQZnvkXucZNxJh0OYkRoCt0+v260ScQvSIfTPjNO26Ahxc0ULSiox6US6lHH8U1ecTEilVYroknzwV/moJw==
+"@firebase/firestore@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-0.9.0.tgz#37a6698b1805b07181455df562f7e98192d12546"
+  integrity sha512-ub9BXce75D7t2yQxqopJhqE5YrsdePLg7wP8aMLR2Twe+O89IZqOhdbE0VALjplD2rAWXkOLqf6zYsppu2hh4g==
   dependencies:
-    "@firebase/firestore-types" "0.7.0"
+    "@firebase/firestore-types" "0.8.0"
     "@firebase/logger" "0.1.2"
     "@firebase/webchannel-wrapper" "0.2.11"
-    grpc "1.16.0"
+    grpc "1.16.1"
     tslib "1.9.0"
 
 "@firebase/functions-types@0.2.1":
@@ -667,9 +667,9 @@
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
 "@types/node@*", "@types/node@^10.1.0":
-  version "10.12.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.10.tgz#4fa76e6598b7de3f0cb6ec3abacc4f59e5b3a2ce"
-  integrity sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w==
+  version "10.12.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.12.tgz#e15a9d034d9210f00320ef718a50c4a799417c47"
+  integrity sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A==
 
 "@types/node@^6.0.46":
   version "6.14.2"
@@ -1248,15 +1248,15 @@ atob@^2.1.1:
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 autoprefixer@^9.0.0:
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.3.1.tgz#71b622174de2b783d5fd99f9ad617b7a3c78443e"
-  integrity sha512-DY9gOh8z3tnCbJ13JIWaeQsoYncTGdsrgCceBaQSIL4nvdrLxgbRSBPevg2XbX7u4QCSfLheSJEEIUUSlkbx6Q==
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.4.2.tgz#0234d20900684fc4bfb67926493deb68384067f5"
+  integrity sha512-tYQYJvZvqlJCzF+BLC//uAcdT/Yy4ik9bwZRXr/EehUJ/bjjpTthsWTy8dpowdoIE1sLCDf1ch4Eb2cOSzZC9w==
   dependencies:
-    browserslist "^4.3.3"
-    caniuse-lite "^1.0.30000898"
+    browserslist "^4.3.5"
+    caniuse-lite "^1.0.30000914"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
-    postcss "^7.0.5"
+    postcss "^7.0.6"
     postcss-value-parser "^3.3.1"
 
 aws-sign2@~0.7.0:
@@ -1379,9 +1379,9 @@ better-assert@~1.0.0:
     callsite "1.0.0"
 
 big-integer@^1.6.17:
-  version "1.6.36"
-  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.36.tgz#78631076265d4ae3555c04f85e7d9d2f3a071a36"
-  integrity sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==
+  version "1.6.40"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.40.tgz#02e4cd4d6e266c4d9ece2469c05cb6439149fc78"
+  integrity sha512-CjhtJp0BViLzP1ZkEnoywjgtFQXS2pomKjAJtIISTCnuHILkLcAXLdFLG/nxsHc4s9kJfc+82Xpg8WNyhfACzQ==
 
 binary-extensions@^1.0.0:
   version "1.12.0"
@@ -1512,14 +1512,14 @@ braces@^2.3.0, braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-browserslist@^4.3.3:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.3.4.tgz#4477b737db6a1b07077275b24791e680d4300425"
-  integrity sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==
+browserslist@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.3.5.tgz#1a917678acc07b55606748ea1adf9846ea8920f7"
+  integrity sha512-z9ZhGc3d9e/sJ9dIx5NFXkKoaiQTnrvrMsN3R1fGb1tkWWNSz12UewJn9TNxGo1l7J23h0MRaPmk7jfeTZYs1w==
   dependencies:
-    caniuse-lite "^1.0.30000899"
-    electron-to-chromium "^1.3.82"
-    node-releases "^1.0.1"
+    caniuse-lite "^1.0.30000912"
+    electron-to-chromium "^1.3.86"
+    node-releases "^1.0.5"
 
 browserstack@1.5.0:
   version "1.5.0"
@@ -1742,10 +1742,10 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
-caniuse-lite@^1.0.30000898, caniuse-lite@^1.0.30000899:
-  version "1.0.30000912"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000912.tgz#08e650d4090a9c0ab06bfd2b46b7d3ad6dcaea28"
-  integrity sha512-M3zAtV36U+xw5mMROlTXpAHClmPAor6GPKAMD5Yi7glCB5sbMPFtnQ3rGpk4XqPdUrrTIaVYSJZxREZWNy8QJg==
+caniuse-lite@^1.0.30000912, caniuse-lite@^1.0.30000914:
+  version "1.0.30000916"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000916.tgz#3428d3f529f0a7b2bfaaec65e796037bdd433aab"
+  integrity sha512-D6J9jloPm2MPkg0PXcODLMQAJKkeixKO9xhqTUMvtd44MtTYMyyDXPQ2Lk9IgBq5FH0frwiPa/N/w8ncQf7kIQ==
 
 canonical-path@0.0.2, canonical-path@~0.0.2:
   version "0.0.2"
@@ -2517,9 +2517,9 @@ core-js@2.5.5:
   integrity sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=
 
 core-js@^2.0.0, core-js@^2.2.0, core-js@^2.5.7:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
-  integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.0.tgz#1e30793e9ee5782b307e37ffa22da0eacddd84d4"
+  integrity sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw==
 
 core-js@~2.3.0:
   version "2.3.0"
@@ -3046,15 +3046,10 @@ dom-storage@2.1.0:
   resolved "https://registry.yarnpkg.com/dom-storage/-/dom-storage-2.1.0.tgz#00fb868bc9201357ea243c7bcfd3304c1e34ea39"
   integrity sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==
 
-domelementtype@1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.2.1.tgz#578558ef23befac043a1abb0db07635509393479"
-  integrity sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA==
-
-domelementtype@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
-  integrity sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=
+domelementtype@1, domelementtype@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
+  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
 domelementtype@~1.1.1:
   version "1.1.3"
@@ -3069,9 +3064,9 @@ domhandler@^2.3.0:
     domelementtype "1"
 
 domino@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/domino/-/domino-2.1.0.tgz#653ba7d331441113b42e40ba05f24253ec86e02e"
-  integrity sha512-xINSODvrnuQcm3eXJN4IkBR+JxqLrJN8Ge4fd00y1b7HsY0A4huKN5BflSS/oo8quBWmocTfWdFvrw2H8TjGqQ==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/domino/-/domino-2.1.1.tgz#cd5c639940db72bb7cde1cdb5beea466a4113136"
+  integrity sha512-fqoTi6oQ881wYRENIEmz78hKVoc3X9HqVpklo419yxzebys6dtU5c83iVh3UYvvexPFdAuwlDYCsUM9//CrMMg==
 
 domutils@^1.5.1:
   version "1.7.0"
@@ -3121,11 +3116,6 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
-duplexer@^0.1.1, duplexer@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
-  integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
-
 duplexify@^3.2.0, duplexify@^3.5.0, duplexify@^3.6.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.6.1.tgz#b1a7a29c4abfd639585efaecce80d666b1e34125"
@@ -3169,10 +3159,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.82:
-  version "1.3.85"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.85.tgz#5c46f790aa96445cabc57eb9d17346b1e46476fe"
-  integrity sha512-kWSDVVF9t3mft2OHVZy4K85X2beP6c6mFm3teFS/mLSDJpQwuFIWHrULCX+w6H1E55ZYmFRlT+ATAFRwhrYzsw==
+electron-to-chromium@^1.3.86:
+  version "1.3.88"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.88.tgz#f36ab32634f49ef2b0fdc1e82e2d1cc17feb29e7"
+  integrity sha512-UPV4NuQMKeUh1S0OWRvwg0PI8ASHN9kBC8yDTk1ROXLC85W5GnhTRu/MZu3Teqx3JjlQYuckuHYXSUSgtb3J+A==
 
 empower-core@^1.2.0:
   version "1.2.0"
@@ -3455,19 +3445,6 @@ event-emitter@^0.3.5, event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
-event-stream@^3.3.4:
-  version "3.3.5"
-  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.5.tgz#e5dd8989543630d94c6cf4d657120341fa31636b"
-  integrity sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==
-  dependencies:
-    duplexer "^0.1.1"
-    from "^0.1.7"
-    map-stream "0.0.7"
-    pause-stream "^0.0.11"
-    split "^1.0.1"
-    stream-combiner "^0.2.2"
-    through "^2.3.8"
-
 eventemitter3@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
@@ -3657,12 +3634,13 @@ eyes@0.1.x:
   integrity sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
 
 fancy-log@^1.1.0, fancy-log@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.2.tgz#f41125e3d84f2e7d89a43d06d958c8f78be16be1"
-  integrity sha1-9BEl49hPLn2JpD0G2VjI94vha+E=
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.3.tgz#dbc19154f558690150a23953a0adbd035be45fc7"
+  integrity sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==
   dependencies:
     ansi-gray "^0.1.1"
     color-support "^1.1.3"
+    parse-node-version "^1.0.0"
     time-stamp "^1.0.0"
 
 fast-deep-equal@^2.0.1:
@@ -3930,14 +3908,14 @@ firebase@2.x.x:
     faye-websocket ">=0.6.0"
 
 firebase@^5.5.8:
-  version "5.5.9"
-  resolved "https://registry.yarnpkg.com/firebase/-/firebase-5.5.9.tgz#1e20172d7c7dfafdc75a18378439e0493bc12753"
-  integrity sha512-IFABX9++5Bq7S00zYGdkdnqikq67cJuub26iyap4qNPnc05qXxx/5waomMIyEvfH74K7ywOaVWEy0E1BFNKk7g==
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/firebase/-/firebase-5.7.0.tgz#4e43e3f6521cfb4c1b4caf1b269a402c83713dd4"
+  integrity sha512-8sQYXCUbUuzpyZS+XpBogstQE/7lvX6tPWtrUH0Cf4mH7flH/Sue5GUvZzwBpkgKOrMpI+clzuoYm/ffGi/TjQ==
   dependencies:
     "@firebase/app" "0.3.5"
-    "@firebase/auth" "0.7.9"
+    "@firebase/auth" "0.9.0"
     "@firebase/database" "0.3.7"
-    "@firebase/firestore" "0.8.8"
+    "@firebase/firestore" "0.9.0"
     "@firebase/functions" "0.3.3"
     "@firebase/messaging" "0.3.7"
     "@firebase/polyfill" "0.3.3"
@@ -3972,6 +3950,11 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     rimraf "~2.6.2"
     write "^0.2.1"
+
+flatted@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
+  integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
 flatten@^1.0.2:
   version "1.0.2"
@@ -4047,11 +4030,6 @@ from2@^2.1.1:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
-
-from@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
-  integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
 
 fs-access@^1.0.0:
   version "1.0.1"
@@ -4592,12 +4570,12 @@ google-p12-pem@^0.1.0:
     node-forge "^0.7.1"
 
 google-p12-pem@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-1.0.2.tgz#c8a3843504012283a0dbffc7430b7c753ecd4b07"
-  integrity sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-1.0.3.tgz#3d8acc140573339a5bca7b2f6a4b206bbea6d8d7"
+  integrity sha512-KGnAiMMWaJp4j4tYVvAjfP3wCKZRLv9M1Nir2wRRNWUYO7j1aX8O9Qgz+a8/EQ5rAvuo4SIu79n6SIdkNl7Msg==
   dependencies:
-    node-forge "^0.7.4"
-    pify "^3.0.0"
+    node-forge "^0.7.5"
+    pify "^4.0.0"
 
 google-proto-files@^0.16.0, google-proto-files@^0.16.1:
   version "0.16.1"
@@ -4697,17 +4675,7 @@ graphviz@^0.0.8:
   dependencies:
     temp "~0.4.0"
 
-grpc@1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.16.0.tgz#cdf56d6ede2f1b6ab5224ad467cb22e1b3ec36fc"
-  integrity sha512-+p8YRIng7Gihkn2jycAXwXdA9aQ10SikRrcHY+/r3W1Z1Pr9NFIbLcmBZPoaTbzzLDv/ysqwqFEZriAdd8tveQ==
-  dependencies:
-    lodash "^4.17.5"
-    nan "^2.0.0"
-    node-pre-gyp "^0.10.0"
-    protobufjs "^5.0.3"
-
-grpc@^1.12.2:
+grpc@1.16.1, grpc@^1.12.2:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.16.1.tgz#533316f38cea68111ef577728c3f4e8e9e554543"
   integrity sha512-7uHN1Nd3UqfvwgQ6f5U3+EZb/0iuHJ9mbPH+ydaTkszJsUi3nwdz6DuSh0eJwYVXXn6Gojv2khiQAadMongGKg==
@@ -4782,15 +4750,15 @@ gulp-cli@^2.0.1:
     yargs "^7.1.0"
 
 gulp-connect@^5.6.1:
-  version "5.6.1"
-  resolved "https://registry.yarnpkg.com/gulp-connect/-/gulp-connect-5.6.1.tgz#ba25bc7b1ec17e2fdae3a7368b510bf9edaa8991"
-  integrity sha512-FknHeA6smZhiRNrK/3UVH8BHLCFHS7WZdE7Y2VbZHtxye1UTIa5ZY0Cnst6O9n3kL8z7y43QI+acx3nUtJoiHw==
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/gulp-connect/-/gulp-connect-5.7.0.tgz#7e925f5e4c34ebfedf9f318576966e8fe8840d5a"
+  integrity sha512-8tRcC6wgXMLakpPw9M7GRJIhxkYdgZsXwn7n56BA2bQYGLR9NOPhMzx7js+qYDy6vhNkbApGKURjAw1FjY4pNA==
   dependencies:
     ansi-colors "^2.0.5"
     connect "^3.6.6"
     connect-livereload "^0.6.0"
-    event-stream "^3.3.4"
     fancy-log "^1.3.2"
+    map-stream "^0.0.7"
     send "^0.16.2"
     serve-index "^1.9.1"
     serve-static "^1.13.2"
@@ -6209,9 +6177,9 @@ karma-sourcemap-loader@^0.3.7:
     graceful-fs "^4.1.2"
 
 karma@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-3.1.1.tgz#94c8edd20fb9597ccde343326da009737fb0423a"
-  integrity sha512-NetT3wPCQMNB36uiL9LLyhrOt8SQwrEKt0xD3+KpTCfm0VxVyUJdPL5oTq2Ic5ouemgL/Iz4wqXEbF3zea9kQQ==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-3.1.3.tgz#6e251648e3aff900927bc1126dbcbcb92d3edd61"
+  integrity sha512-JU4FYUtFEGsLZd6ZJzLrivcPj0TkteBiIRDcXWFsltPMGgZMDtby/MIzNOzgyZv/9dahs9vHpSxerC/ZfeX9Qw==
   dependencies:
     bluebird "^3.3.0"
     body-parser "^1.16.1"
@@ -6223,11 +6191,12 @@ karma@^3.1.1:
     di "^0.0.1"
     dom-serialize "^2.2.0"
     expand-braces "^0.1.1"
+    flatted "^2.0.0"
     glob "^7.1.1"
     graceful-fs "^4.1.2"
     http-proxy "^1.13.0"
     isbinaryfile "^3.0.0"
-    lodash "^4.17.4"
+    lodash "^4.17.5"
     log4js "^3.0.0"
     mime "^2.3.1"
     minimatch "^3.0.2"
@@ -6239,7 +6208,7 @@ karma@^3.1.1:
     socket.io "2.1.1"
     source-map "^0.6.1"
     tmp "0.0.33"
-    useragent "2.2.1"
+    useragent "2.3.0"
 
 keyv@3.0.0:
   version "3.0.0"
@@ -6800,18 +6769,13 @@ lru-cache@2:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
   integrity sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=
 
-lru-cache@2.2.x:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
-  integrity sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=
-
-lru-cache@^4.0.1, lru-cache@^4.1.3:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.4.tgz#51cc46e8e6d9530771c857e24ccc720ecdbcc031"
-  integrity sha512-EPstzZ23znHUVLKj+lcXO1KvZkrlw+ZirdwvOmnAnA/1PB4ggyXJ77LRkCqkff+ShQ+cqoxCxLQOh4cKITO5iA==
+lru-cache@4.1.x, lru-cache@^4.0.1, lru-cache@^4.1.3:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
   dependencies:
     pseudomap "^1.0.2"
-    yallist "^3.0.2"
+    yallist "^2.1.2"
 
 lru-queue@0.1:
   version "0.1.0"
@@ -6886,7 +6850,7 @@ map-obj@^2.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
   integrity sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
 
-map-stream@0.0.7:
+map-stream@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.0.7.tgz#8a1f07896d82b10926bd3744a2420009f88974a8"
   integrity sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=
@@ -7186,9 +7150,9 @@ minipass@^2.2.1, minipass@^2.3.4:
     yallist "^3.0.0"
 
 minizlib@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.1.tgz#6734acc045a46e61d596a43bb9d9cd326e19cc42"
-  integrity sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
+  integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
   dependencies:
     minipass "^2.2.1"
 
@@ -7380,7 +7344,7 @@ node-forge@0.7.4:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.4.tgz#8e6e9f563a1e32213aa7508cded22aa791dbf986"
   integrity sha512-8Df0906+tq/omxuCZD6PqhPaQDYuyJ1d+VITgxoIA8zvQd1ru+nMJcDChHH324MWitIgbVkAkQoGEEVJNpn/PA==
 
-node-forge@^0.7.1, node-forge@^0.7.4:
+node-forge@^0.7.1, node-forge@^0.7.5:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
   integrity sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==
@@ -7440,17 +7404,17 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.0.1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.0.5.tgz#a641adcc968b039a27345d92ef10b093e5cbd41d"
-  integrity sha512-Ky7q0BO1BBkG/rQz6PkEZ59rwo+aSfhczHP1wwq8IowoVdN/FpiP7qp0XW0P2+BVCWe5fQUBozdbVd54q1RbCQ==
+node-releases@^1.0.5:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.0.tgz#be7464fa8d877808237520fd49436d5e79191c3d"
+  integrity sha512-+qV91QMDBvARuPxUEfI/mRF/BY+UAkTIn3pvmvM2iOLIRvv6RNYklFXBgrkky6P1wXUqQW1P3qKlWxxy4JZbfg==
   dependencies:
     semver "^5.3.0"
 
 node-sass@^4.8.3, node-sass@^4.9.0:
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.10.0.tgz#dcc2b364c0913630945ccbf7a2bbf1f926effca4"
-  integrity sha512-fDQJfXszw6vek63Fe/ldkYXmRYK/QS6NbvM3i5oEo9ntPDy4XX7BcKZyTKv+/kSSxRtXXc7l+MSwEmYc0CSy6Q==
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.11.0.tgz#183faec398e9cbe93ba43362e2768ca988a6369a"
+  integrity sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -7943,6 +7907,11 @@ parse-ms@^2.0.0:
   resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.0.0.tgz#7b3640295100caf3fa0100ccceb56635b62f9d62"
   integrity sha512-AddiXFSLLCqj+tCRJ9MrUtHZB4DWojO3tk0NVZ+g5MaMQHF2+p2ktqxuoXyPFLljz/aUK0Nfhd/uGWnhXVXEyA==
 
+parse-node-version@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-node-version/-/parse-node-version-1.0.0.tgz#33d9aa8920dcc3c0d33658ec18ce237009a56d53"
+  integrity sha512-02GTVHD1u0nWc20n2G7WX/PgdhNFG04j5fi1OkaJzPWLTcf6vh6229Lta1wTmXG/7Dg42tCssgkccVt7qvd8Kg==
+
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
@@ -8081,13 +8050,6 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
-pause-stream@^0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
-  integrity sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=
-  dependencies:
-    through "~2.3"
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -8153,9 +8115,9 @@ pluralize@^7.0.0:
   integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
 
 portfinder@^1.0.13:
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.19.tgz#07e87914a55242dcda5b833d42f018d6875b595f"
-  integrity sha512-23aeQKW9KgHe6citUrG3r9HjeX6vls0h713TAa+CwTKZwNIr/pD2ApaxYF4Um3ZZyq4ar+Siv3+fhoHaIwSOSw==
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.20.tgz#bea68632e54b2e13ab7b0c4775e9b41bf270e44a"
+  integrity sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==
   dependencies:
     async "^1.5.2"
     debug "^2.2.0"
@@ -8272,7 +8234,7 @@ postcss-values-parser@^1.5.0:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.2, postcss@^7.0.3, postcss@^7.0.5:
+postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.2, postcss@^7.0.3, postcss@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.6.tgz#6dcaa1e999cdd4a255dcd7d4d9547f4ca010cdc2"
   integrity sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==
@@ -8452,9 +8414,9 @@ process-nextick-args@~1.0.6:
   integrity sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=
 
 progress@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
-  integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 promise-polyfill@7.1.2:
   version "7.1.2"
@@ -9700,9 +9662,9 @@ sparkles@^1.0.0:
   integrity sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==
 
 spdx-correct@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.2.tgz#19bb409e91b47b1ad54159243f7312a858db3c2e"
-  integrity sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
+  integrity sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
   dependencies:
     spdx-expression-parse "^3.0.0"
     spdx-license-ids "^3.0.0"
@@ -9764,7 +9726,7 @@ split2@^2.0.0:
   dependencies:
     through2 "^2.0.2"
 
-split@^1.0.0, split@^1.0.1:
+split@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
   integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
@@ -9830,14 +9792,6 @@ stdout-stream@^1.4.0:
   integrity sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==
   dependencies:
     readable-stream "^2.0.1"
-
-stream-combiner@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.2.2.tgz#aec8cbac177b56b6f4fa479ced8c1912cee52858"
-  integrity sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=
-  dependencies:
-    duplexer "~0.1.1"
-    through "~2.3.4"
 
 stream-consume@~0.1.0:
   version "0.1.1"
@@ -10330,7 +10284,7 @@ through2@^2.0.0, through2@^2.0.1, through2@^2.0.2, through2@^2.0.3:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.4:
+through@2, "through@>=2.2.7 <3", through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -10658,15 +10612,20 @@ typescript-eslint-parser@^18.0.0:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@^3.0.3, typescript@~3.1.1:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
-  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+typescript@^3.0.3:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
+  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
 
 typescript@~2.7.1:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
   integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+
+typescript@~3.1.1:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
 
 uglify-js@3.4.x, uglify-js@^3.1.4:
   version "3.4.9"
@@ -10960,12 +10919,12 @@ user-home@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
-useragent@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/useragent/-/useragent-2.2.1.tgz#cf593ef4f2d175875e8bb658ea92e18a4fd06d8e"
-  integrity sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=
+useragent@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/useragent/-/useragent-2.3.0.tgz#217f943ad540cb2128658ab23fc960f6a88c9972"
+  integrity sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==
   dependencies:
-    lru-cache "2.2.x"
+    lru-cache "4.1.x"
     tmp "0.0.x"
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
@@ -11467,6 +11426,11 @@ y18n@^3.2.0, y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
   integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.3"


### PR DESCRIPTION
### Summary
This design change marks a number of departures from the current Angular Layout configuration:

1. A number of APIs are deprecated in favor of a more polished, integrated API
2. A new semantics for creating custom breakpoint directives is introduced
3. A number of bugs caught along the way and design changes missed in past PRs are rectified

>  **PLEASE NOTE**: There will be **no end-user API changes** as a result of this PR. 

Unless custom breakpoints are configured, devs should see no change in how the library usage. These changes will deliver notice significant size & performance improvements.

### New APIs

* `MediaMarshaller`
	A centralized data store for elements, breakpoints, and key-value pairs. The `MediaMarshaller` responds to mediaQuery changes and triggers appropriate Layout directives. This class also introduces a way to track changes for arbitrary elements and directive types
* `BaseDirective2`
	A new directive with stripped-down functionality from the old `BaseDirective` that is designed to work in symbiosis with the `MediaMarshaller`

### Custom Breakpoints

The custom breakpoints story has changed significantly. Instead of extending directives that contain the default breakpoints and writing lengthy constructors, the process has been paired down to the following (i.e. for `fxFlexOffset`):

```ts
const inputs = ['fxFlexOffset.xss'];
const selector = `[fxFlexOffset.xss]`;

@Directive({selector, inputs})
export class XssFlexOffsetDirective extends FlexOffsetDirective {
	protected inputs = inputs;
}
```

Never again will a change in the base directive constructor require an entire rewrite of custom breakpoint directives. And registering a new directive no longer brings collisions and double-registrations competing with the default directives. Everything is separated and improved.

### Features

* All of the Grid and extended Flex directives have been updated to the new standards; namely, they have been refactored to the new API with `StyleBuilder`s. The notable exception is `show-hide`, which uses a `StyleBuilder`, but does not have a cache for the results. 
> FxShowHide does not use a stylebuilder cache as to avoid complexity for cache-shifting based on the host `display` property. If needed, an internal cache can be easily added later.

### Bug Fixes

* A number of APIs had the default values calculated in the directives instead of the `StyleBuilder`, meaning that it would be much harder to override by end-users. This has been fixed
* An issue where `fxLayoutGap` was canceling out `fxFlexOffset` has been corrected

### Deprecated APIs

* `MediaMonitor` (use `MediaMarshaller`)
* `ResponsiveActivation`
* `BreakpointX`
* `KeyOptions`
* `negativeOf`
* `BaseDirective` (use `BaseDirective2`)
* `BaseAdapter`

### Build Improvements

The minified size of the Angular Layout library has decreased *~38%* from **132KB** to **82KB**, a total savings of 50KB.  After the deprecated APIs are deleted (Beta.21), the build size will be reduced yet again. 

### Performance Improvements

It should also bring about performance improvements as a result of fewer RxJS subscriptions, memoized style lookups, and other API processing. 

### Stabilization 

It is our hope that along with the added `StyleBuilder` functionality, and migration away from `ObservableMedia`, this represents the end-stage towards stability for Angular Layout.

Closes #903 
Fixes #692