### PR TITLE
fix(core): improve use of breakpoint priorities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ node_modules
 
 # misc
 .DS_Store
+/.firebase
 /.sass-cache
 /connect.lock
 /coverage/*

--- a/src/lib/core/breakpoints/break-point.ts
+++ b/src/lib/core/breakpoints/break-point.ts
@@ -9,7 +9,6 @@ export interface BreakPoint {
   mediaQuery: string;
   alias: string;
   suffix?: string;
-  overlapping?: boolean;
-  // The priority of the individual breakpoint when overlapping another breakpoint
-  priority?: number;
+  overlapping?: boolean;  // Does this range overlap with any other ranges
+  priority?: number;      // determine order of activation reporting: higher is last reported
 }

--- a/src/lib/core/breakpoints/breakpoint-tools.ts
+++ b/src/lib/core/breakpoints/breakpoint-tools.ts
@@ -65,8 +65,14 @@ export function mergeByAlias(defaults: BreakPoint[], custom: BreakPoint[] = []):
 }
 
 /** HOF to sort the breakpoints by priority */
-export function prioritySort(a: BreakPoint, b: BreakPoint): number {
+export function sortDescendingPriority(a: BreakPoint, b: BreakPoint): number {
   const priorityA = a.priority || 0;
   const priorityB = b.priority || 0;
   return priorityB - priorityA;
+}
+
+export function sortAscendingPriority(a: BreakPoint, b: BreakPoint): number {
+  const pA = a.priority || 0;
+  const pB = b.priority || 0;
+  return pA - pB;
 }

--- a/src/lib/core/breakpoints/data/break-points.spec.ts
+++ b/src/lib/core/breakpoints/data/break-points.spec.ts
@@ -28,7 +28,7 @@ describe('break-point-provider', () => {
     it('has the standard breakpoints', () => {
       expect(breakPoints.length).toEqual(DEFAULT_BREAKPOINTS.length);
       expect(breakPoints[0].alias).toEqual('xs');
-      expect(breakPoints[breakPoints.length - 1].alias).toEqual('xl');
+      expect(breakPoints[breakPoints.length - 1].alias).toEqual('lt-xl');
     });
   });
 

--- a/src/lib/core/breakpoints/data/break-points.ts
+++ b/src/lib/core/breakpoints/data/break-points.ts
@@ -7,83 +7,83 @@
  */
 import {BreakPoint} from '../break-point';
 
-export const RESPONSIVE_ALIASES = [
-  'xs', 'gt-xs', 'sm', 'gt-sm', 'md', 'gt-md', 'lg', 'gt-lg', 'xl'
-];
-
+/**
+ * NOTE: Smaller ranges have HIGHER priority since the match is more specific
+ */
 export const DEFAULT_BREAKPOINTS: BreakPoint[] = [
   {
     alias: 'xs',
-    mediaQuery: '(min-width: 0px) and (max-width: 599px)',
-    priority: 100,
+    mediaQuery: 'screen and (min-width: 0px) and (max-width: 599px)',
+    priority: 10000,
+  },
+  {
+    alias: 'sm',
+    mediaQuery: 'screen and (min-width: 600px) and (max-width: 959px)',
+    priority: 9000,
+  },
+  {
+    alias: 'md',
+    mediaQuery: 'screen and (min-width: 960px) and (max-width: 1279px)',
+    priority: 8000,
+  },
+  {
+    alias: 'lg',
+    mediaQuery: 'screen and (min-width: 1280px) and (max-width: 1919px)',
+    priority: 7000,
+  },
+  {
+    alias: 'xl',
+    mediaQuery: 'screen and (min-width: 1920px) and (max-width: 5000px)',
+    priority: 6000,
   },
   {
     alias: 'gt-xs',
     overlapping: true,
-    mediaQuery: '(min-width: 600px)',
-    priority: 7,
-  },
-  {
-    alias: 'lt-sm',
-    overlapping: true,
-    mediaQuery: '(max-width: 599px)',
-    priority: 10,
-  },
-  {
-    alias: 'sm',
-    mediaQuery: '(min-width: 600px) and (max-width: 959px)',
-    priority: 100,
+    mediaQuery: 'screen and (min-width: 600px)',
+    priority: 200,
   },
   {
     alias: 'gt-sm',
     overlapping: true,
-    mediaQuery: '(min-width: 960px)',
-    priority: 8,
-  },
-  {
-    alias: 'lt-md',
-    overlapping: true,
-    mediaQuery: '(max-width: 959px)',
-    priority: 9,
-  },
-  {
-    alias: 'md',
-    mediaQuery: '(min-width: 960px) and (max-width: 1279px)',
-    priority: 100,
-  },
-  {
+    mediaQuery: 'screen and (min-width: 960px)',
+    priority: 300,
+  }, {
     alias: 'gt-md',
     overlapping: true,
-    mediaQuery: '(min-width: 1280px)',
-    priority: 9,
-  },
-  {
-    alias: 'lt-lg',
-    overlapping: true,
-    mediaQuery: '(max-width: 1279px)',
-    priority: 8,
-  },
-  {
-    alias: 'lg',
-    mediaQuery: '(min-width: 1280px) and (max-width: 1919px)',
-    priority: 100,
+    mediaQuery: 'screen and (min-width: 1280px)',
+    priority: 400,
   },
   {
     alias: 'gt-lg',
     overlapping: true,
-    mediaQuery: '(min-width: 1920px)',
-    priority: 10,
+    mediaQuery: 'screen and (min-width: 1920px)',
+    priority: 500,
   },
   {
-    alias: 'lt-xl',
+    alias: 'lt-sm',
     overlapping: true,
-    mediaQuery: '(max-width: 1919px)',
-    priority: 7,
+    mediaQuery: 'screen and (max-width: 599px)',
+    priority: 1000,
+  },
+
+  {
+    alias: 'lt-md',
+    overlapping: true,
+    mediaQuery: 'screen and (max-width: 959px)',
+    priority: 800,
+  },
+
+  {
+    alias: 'lt-lg',
+    overlapping: true,
+    mediaQuery: 'screen and (max-width: 1279px)',
+    priority: 700,
   },
   {
-    alias: 'xl',
-    mediaQuery: '(min-width: 1920px) and (max-width: 5000px)',
-    priority: 100,
-  }
+     alias: 'lt-xl',
+     overlapping: true,
+     priority: 600,
+     mediaQuery: 'screen and (max-width: 1919px)',
+   }
 ];
 

--- a/src/lib/core/breakpoints/index.ts
+++ b/src/lib/core/breakpoints/index.ts
@@ -12,4 +12,8 @@ export * from './data/orientation-break-points';
 export * from './break-point';
 export * from './break-point-registry';
 export * from './break-points-token';
-export {prioritySort} from './breakpoint-tools';
+
+export {
+  sortDescendingPriority,
+  sortAscendingPriority
+} from './breakpoint-tools';

--- a/src/lib/core/match-media/match-media.spec.ts
+++ b/src/lib/core/match-media/match-media.spec.ts
@@ -8,7 +8,6 @@
 import {TestBed, inject, async} from '@angular/core/testing';
 
 import {MediaChange} from '../media-change';
-import {BreakPoint} from '../breakpoints/break-point';
 import {MockMatchMedia, MockMatchMediaProvider} from './mock/mock-match-media';
 import {BreakPointRegistry} from '../breakpoints/break-point-registry';
 import {MatchMedia} from './match-media';
@@ -51,11 +50,8 @@ describe('match-media', () => {
     let query1 = 'screen and (min-width: 610px) and (max-width: 620px)';
     let query2 = '(min-width: 730px) and (max-width: 950px)';
 
-    matchMedia.registerQuery(query1);
-    matchMedia.registerQuery(query2);
-
-    let media$ = matchMedia.observe();
-    let subscription = media$.subscribe((change: MediaChange) => {
+    const queries = [query1, query2];
+    let subscription = matchMedia.observe(queries).subscribe((change: MediaChange) => {
       current = change;
     });
 
@@ -83,7 +79,7 @@ describe('match-media', () => {
 
     matchMedia.registerQuery([query1, query2]);
 
-    let subscription = matchMedia.observe(query1).subscribe((change: MediaChange) => {
+    let subscription = matchMedia.observe([query1]).subscribe((change: MediaChange) => {
       current = change;
     });
 
@@ -128,11 +124,6 @@ describe('match-media-observable', () => {
       matchMedia = _matchMedia;      // inject only to manually activate mediaQuery ranges
       breakPoints = _breakPoints;
       mediaObserver = _mediaObserver;
-
-      // Quick register all breakpoint mediaQueries
-      breakPoints.items.forEach((bp: BreakPoint) => {
-        matchMedia.observe(bp.mediaQuery);
-      });
     })));
   afterEach(() => {
     matchMedia.clearAll();
@@ -206,6 +197,8 @@ describe('match-media-observable', () => {
   it('ignores mediaQuery de-activations', () => {
     let activationCount = 0;
     let deactivationCount = 0;
+
+    mediaObserver.filterOverlaps = false;
     let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
       if (change.matches) {
         ++activationCount;

--- a/src/lib/core/match-media/mock/mock-match-media.spec.ts
+++ b/src/lib/core/match-media/mock/mock-match-media.spec.ts
@@ -31,7 +31,7 @@ describe('mock-match-media', () => {
     breakPoints = _breakPoints;
 
     breakPoints.items.forEach((bp: BreakPoint) => {
-      matchMedia.observe(bp.mediaQuery);
+      matchMedia.observe([bp.mediaQuery]);
     });
   })));
   afterEach(() => {
@@ -41,7 +41,7 @@ describe('mock-match-media', () => {
   it('can observe custom mediaQuery ranges', () => {
     let current: MediaChange;
     let customQuery = 'screen and (min-width: 610px) and (max-width: 620px';
-    let subscription = matchMedia.observe(customQuery)
+    let subscription = matchMedia.observe([customQuery])
       .subscribe((change: MediaChange) => {
         current = change;
       });
@@ -105,7 +105,7 @@ describe('mock-match-media', () => {
       bpGtSM = breakPoints.findByAlias('gt-sm'),
       bpLg = breakPoints.findByAlias('lg');
 
-    let subscription = matchMedia.observe(bpLg!.mediaQuery).subscribe((change: MediaChange) => {
+    let subscription = matchMedia.observe([bpLg!.mediaQuery]).subscribe((change: MediaChange) => {
       current = change;
     });
 
@@ -159,7 +159,7 @@ describe('mock-match-media', () => {
     let bpGtSM = breakPoints.findByAlias('gt-sm'),
       bpLg = breakPoints.findByAlias('lg');
 
-    let subscription = matchMedia.observe(bpGtSM!.mediaQuery).subscribe((change: MediaChange) => {
+    let subscription = matchMedia.observe([bpGtSM!.mediaQuery]).subscribe((change: MediaChange) => {
       if (change.matches) {
         ++activates;
       } else {
@@ -246,7 +246,7 @@ describe('mock-match-media', () => {
       bpXS = breakPoints.findByAlias('xs');
 
     matchMedia.activate(bpXS!.mediaQuery);
-    let subscription = matchMedia.observe(bpXS!.mediaQuery)
+    let subscription = matchMedia.observe([bpXS!.mediaQuery])
       .subscribe((change: MediaChange) => {
         current = change;
       });

--- a/src/lib/core/match-media/mock/mock-match-media.ts
+++ b/src/lib/core/match-media/mock/mock-match-media.ts
@@ -160,7 +160,7 @@ export class MockMatchMedia extends MatchMedia {
    * Call window.matchMedia() to build a MediaQueryList; which
    * supports 0..n listeners for activation/deactivation
    */
-  protected _buildMQL(query: string): MediaQueryList {
+  protected buildMQL(query: string): MediaQueryList {
     return new MockMediaQueryList(query);
   }
 

--- a/src/lib/core/match-media/server-match-media.ts
+++ b/src/lib/core/match-media/server-match-media.ts
@@ -141,7 +141,7 @@ export class ServerMatchMedia extends MatchMedia {
    * Call window.matchMedia() to build a MediaQueryList; which
    * supports 0..n listeners for activation/deactivation
    */
-  protected _buildMQL(query: string): ServerMediaQueryList {
+  protected buildMQL(query: string): ServerMediaQueryList {
     return new ServerMediaQueryList(query);
   }
 }

--- a/src/lib/core/media-marshaller/media-marshaller.ts
+++ b/src/lib/core/media-marshaller/media-marshaller.ts
@@ -10,14 +10,15 @@ import {merge, Observable, Subject, Subscription} from 'rxjs';
 import {filter} from 'rxjs/operators';
 
 import {BreakPoint} from '../breakpoints/break-point';
-import {prioritySort} from '../breakpoints/breakpoint-tools';
+import {sortDescendingPriority} from '../breakpoints/breakpoint-tools';
 import {BreakPointRegistry} from '../breakpoints/break-point-registry';
 import {MatchMedia} from '../match-media/match-media';
 import {MediaChange} from '../media-change';
 
-type Builder = Function;
 type ClearCallback = () => void;
 type UpdateCallback = (val: any) => void;
+type Builder = UpdateCallback | ClearCallback;
+
 type ValueMap = Map<string, string>;
 type BreakpointMap = Map<string, ValueMap>;
 type ElementMap = Map<HTMLElement, BreakpointMap>;
@@ -53,10 +54,7 @@ export class MediaMarshaller {
 
   constructor(protected matchMedia: MatchMedia,
               protected breakpoints: BreakPointRegistry) {
-    this.matchMedia
-      .observe()
-      .subscribe(this.activate.bind(this));
-    this.registerBreakpoints();
+    this.observeActivations();
   }
 
   /**
@@ -68,7 +66,7 @@ export class MediaMarshaller {
     if (bp) {
       if (mc.matches && this.activatedBreakpoints.indexOf(bp) === -1) {
         this.activatedBreakpoints.push(bp);
-        this.activatedBreakpoints.sort(prioritySort);
+        this.activatedBreakpoints.sort(sortDescendingPriority);
         this.updateStyles();
       } else if (!mc.matches && this.activatedBreakpoints.indexOf(bp) !== -1) {
         // Remove the breakpoint when it's deactivated
@@ -188,9 +186,9 @@ export class MediaMarshaller {
   clearElement(element: HTMLElement, key: string): void {
     const builders = this.clearBuilderMap.get(element);
     if (builders) {
-      const builder: Builder | undefined = builders.get(key);
-      if (builder) {
-        builder();
+      const clearFn: ClearCallback = builders.get(key) as ClearCallback;
+      if (!!clearFn) {
+        clearFn();
         this.subject.next({element, key, value: ''});
       }
     }
@@ -205,9 +203,9 @@ export class MediaMarshaller {
   updateElement(element: HTMLElement, key: string, value: any): void {
     const builders = this.builderMap.get(element);
     if (builders) {
-      const builder: Builder | undefined = builders.get(key);
-      if (builder) {
-        builder(value);
+      const updateFn: UpdateCallback = builders.get(key) as UpdateCallback;
+      if (!!updateFn) {
+        updateFn(value);
         this.subject.next({element, key, value});
       }
     }
@@ -289,9 +287,14 @@ export class MediaMarshaller {
     return bpMap.get('');
   }
 
-  private registerBreakpoints() {
-    const queries = this.breakpoints.sortedItems.map(bp => bp.mediaQuery);
-    this.matchMedia.registerQuery(queries);
+  /**
+   * Watch for mediaQuery breakpoint activations
+   */
+  private observeActivations() {
+    const queries = this.breakpoints.items.map(bp => bp.mediaQuery);
+    this.matchMedia
+        .observe(queries)
+        .subscribe(this.activate.bind(this));
   }
 }
 

--- a/src/lib/server/server-provider.ts
+++ b/src/lib/server/server-provider.ts
@@ -16,7 +16,7 @@ import {
   MatchMedia,
   StylesheetMap,
   ServerMatchMedia,
-  prioritySort,
+  sortAscendingPriority
 } from '@angular/flex-layout/core';
 
 
@@ -36,15 +36,12 @@ export function generateStaticFlexLayoutStyles(serverSheet: StylesheetMap,
   // be referenced in the static media queries
   const classMap = new Map<HTMLElement, string>();
 
-  // Get the initial stylings for all of the directives, and initialize
-  // the fallback block of stylings, then reverse the breakpoints list
-  // to traverse in the proper order
+  // Get the initial stylings for all of the directives,
+  // and initialize the fallback block of stylings
   const defaultStyles = new Map(serverSheet.stylesheet);
   let styleText = generateCss(defaultStyles, 'all', classMap);
 
-  breakpoints.sort(prioritySort);
-  breakpoints.reverse();
-  breakpoints.forEach((bp, i) => {
+  [...breakpoints].sort(sortAscendingPriority).forEach((bp, i) => {
     serverSheet.clearStyles();
     (matchMedia as ServerMatchMedia).activateBreakpoint(bp);
     const stylesheet = new Map(serverSheet.stylesheet);
@@ -165,3 +162,4 @@ function getClassName(element: HTMLElement, classMap: Map<HTMLElement, string>) 
 
   return className;
 }
+


### PR DESCRIPTION
Use breakpoint priority as the only sorting/scanning mechanism;
used to ensure correct MediaChange event notifications.

* prioritize breakpoints: non-overlaps hightest, lt-<xxx> lowest
* consistently sort breakpoints ascending by priority
  * highest priority === smallest range
  * remove hackery with reverse(), etc.
* memoize BreakPointRegistry findBy<xxx> lookups
* fix MatchMedia::observe() to support lazy breakpoint registration
* fix fragile logic in MediaMarshaller
  * fix breakpoint registration usage
  * clarify update/clear builder function callbacks
* fix MediaObserver breakpoint registration usage