### PR TITLE
fix(core): improve use of breakpoint priorities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ node_modules
 
 # misc
 .DS_Store
+/.firebase
 /.sass-cache
 /connect.lock
 /coverage/*

--- a/src/lib/core/breakpoints/break-point-registry.spec.ts
+++ b/src/lib/core/breakpoints/break-point-registry.spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {TestBed, inject, async} from '@angular/core/testing';
+import {TestBed, inject} from '@angular/core/testing';
 
 import {BreakPoint} from './break-point';
 import {BreakPointRegistry} from './break-point-registry';
@@ -52,11 +52,11 @@ describe('break-points', () => {
       });
     });
 
-    it('has the custom breakpoints', async(inject([BREAKPOINTS], (list: BreakPoint[]) => {
+    it('has the custom breakpoints', inject([BREAKPOINTS], (list: BreakPoint[]) => {
       expect(list.length).toEqual(CUSTOM_BPS.length);
       expect(list[0].alias).toEqual('ab');
       expect(list[list.length - 1].suffix).toEqual('Cd');
-    })));
+    }));
   });
 
 });

--- a/src/lib/core/breakpoints/break-point.ts
+++ b/src/lib/core/breakpoints/break-point.ts
@@ -9,7 +9,6 @@ export interface BreakPoint {
   mediaQuery: string;
   alias: string;
   suffix?: string;
-  overlapping?: boolean;
-  // The priority of the individual breakpoint when overlapping another breakpoint
-  priority?: number;
+  overlapping?: boolean;  // Does this range overlap with any other ranges
+  priority?: number;      // determine order of activation reporting: higher is last reported
 }

--- a/src/lib/core/breakpoints/breakpoint-tools.spec.ts
+++ b/src/lib/core/breakpoints/breakpoint-tools.spec.ts
@@ -5,30 +5,36 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {fakeAsync} from '@angular/core/testing';
-
 import {BreakPoint} from './break-point';
 import {validateSuffixes, mergeByAlias} from './breakpoint-tools';
 import {DEFAULT_BREAKPOINTS} from './data/break-points';
 import {ORIENTATION_BREAKPOINTS} from './data/orientation-break-points';
 
 describe('breakpoint-tools', () => {
-  let all: BreakPoint[];
-  let findByAlias = (alias: string): BreakPoint|null => all.reduce((pos: BreakPoint | null, it) => {
-    return pos || ((it.alias == alias) ? it : null);
-  }, null);
+  let allBreakPoints: BreakPoint[] = [];
+  const findByAlias = (alias: string): BreakPoint => {
+    let result = {mediaQuery: '', alias: ''};
+    allBreakPoints.forEach(bp => {
+      if (bp.alias === alias) {
+        result = {...bp};
+      }
+    });
+    return result;
+  };
 
   beforeEach(() => {
-    all = DEFAULT_BREAKPOINTS.concat(ORIENTATION_BREAKPOINTS);
+    allBreakPoints = validateSuffixes([...DEFAULT_BREAKPOINTS, ...ORIENTATION_BREAKPOINTS]);
   });
 
-  describe('validation', () => {
+  describe('validation ', () => {
+
     it('should not replace an existing suffix', () => {
       let validated = validateSuffixes([
         {alias: 'handset-portrait', suffix: 'Handset', mediaQuery: 'screen'}
       ]);
       expect(validated[0].suffix).toEqual('Handset');
     });
+
     it('should add valid suffixes to breakpoints', () => {
       let validated = validateSuffixes([
         {alias: 'xs', mediaQuery: 'screen and (max-width: 599px)'},
@@ -43,21 +49,19 @@ describe('breakpoint-tools', () => {
       expect(validated[3].suffix).toEqual('GtXs');
       expect(validated[4].suffix).toEqual('HandsetPortrait');
     });
+
     it('should auto-validate the DEFAULT_BREAKPOINTS', () => {
-      fakeAsync(() => {
-        let xsBp: BreakPoint = findByAlias('xs')!;
-        let gtLgBp: BreakPoint = findByAlias('gt-lg')!;
-        let xlBp: BreakPoint = findByAlias('xl')!;
+      let xsBp: BreakPoint = findByAlias('xs');
+      expect(xsBp.alias).toEqual('xs');
+      expect(xsBp.suffix).toEqual('Xs');
 
-        expect(xsBp.alias).toEqual('xs');
-        expect(xsBp.suffix).toEqual('Xs');
+      let gtLgBp: BreakPoint = findByAlias('gt-lg');
+      expect(gtLgBp.alias).toEqual('gt-lg');
+      expect(gtLgBp.suffix).toEqual('GtLg');
 
-        expect(gtLgBp.alias).toEqual('gt-lg');
-        expect(gtLgBp.suffix).toEqual('GtLg');
-
-        expect(xlBp.alias).toEqual('xl');
-        expect(xlBp.suffix).toEqual('Xl');
-      });
+      let xlBp: BreakPoint = findByAlias('xl');
+      expect(xlBp.alias).toEqual('xl');
+      expect(xlBp.suffix).toEqual('Xl');
     });
   });
 
@@ -67,19 +71,19 @@ describe('breakpoint-tools', () => {
         {alias: 'sm', mediaQuery: 'screen'},
         {alias: 'md', mediaQuery: 'screen'},
       ];
-      all = mergeByAlias(defaults, custom);
+      allBreakPoints = mergeByAlias(defaults, custom);
 
-      expect(all.length).toEqual(2);
+      expect(allBreakPoints.length).toEqual(2);
       expect(findByAlias('sm')!.suffix).toEqual('Sm');
       expect(findByAlias('md')!.suffix).toEqual('Md');
     });
     it('should add custom breakpoints with unique aliases', () => {
       let defaults = [{alias: 'xs', mediaQuery: 'screen and (max-width: 599px)'}],
-        custom = [{alias: 'sm', mediaQuery: 'screen'}, {alias: 'md', mediaQuery: 'screen'}];
+          custom = [{alias: 'sm', mediaQuery: 'screen'}, {alias: 'md', mediaQuery: 'screen'}];
 
-      all = mergeByAlias(defaults, custom);
+      allBreakPoints = mergeByAlias(defaults, custom);
 
-      expect(all.length).toEqual(3);
+      expect(allBreakPoints.length).toEqual(3);
       expect(findByAlias('xs')!.suffix).toEqual('Xs');
       expect(findByAlias('sm')!.suffix).toEqual('Sm');
       expect(findByAlias('md')!.suffix).toEqual('Md');
@@ -88,9 +92,9 @@ describe('breakpoint-tools', () => {
       let defaults = [{alias: 'xs', mediaQuery: 'screen and (max-width: 599px)'}];
       let custom = [{alias: 'xs', mediaQuery: 'screen and none'}];
 
-      all = mergeByAlias(defaults, custom);
+      allBreakPoints = mergeByAlias(defaults, custom);
 
-      expect(all.length).toEqual(1);
+      expect(allBreakPoints.length).toEqual(1);
       expect(findByAlias('xs')!.suffix).toEqual('Xs');
       expect(findByAlias('xs')!.mediaQuery).toEqual('screen and none');
     });

--- a/src/lib/core/breakpoints/breakpoint-tools.ts
+++ b/src/lib/core/breakpoints/breakpoint-tools.ts
@@ -65,8 +65,14 @@ export function mergeByAlias(defaults: BreakPoint[], custom: BreakPoint[] = []):
 }
 
 /** HOF to sort the breakpoints by priority */
-export function prioritySort(a: BreakPoint, b: BreakPoint): number {
+export function sortDescendingPriority(a: BreakPoint, b: BreakPoint): number {
   const priorityA = a.priority || 0;
   const priorityB = b.priority || 0;
   return priorityB - priorityA;
+}
+
+export function sortAscendingPriority(a: BreakPoint, b: BreakPoint): number {
+  const pA = a.priority || 0;
+  const pB = b.priority || 0;
+  return pA - pB;
 }

--- a/src/lib/core/breakpoints/data/break-points.spec.ts
+++ b/src/lib/core/breakpoints/data/break-points.spec.ts
@@ -5,7 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {TestBed, inject, async} from '@angular/core/testing';
+import {TestBed, inject} from '@angular/core/testing';
+import {sortDescendingPriority} from '../breakpoint-tools';
 
 import {BreakPoint} from '../break-point';
 import {BREAKPOINTS} from '../break-points-token';
@@ -21,14 +22,14 @@ describe('break-point-provider', () => {
         providers: [{provide: BREAKPOINTS, useValue: DEFAULT_BREAKPOINTS}]
       });
     });
-    beforeEach(async(inject([BREAKPOINTS], (bps: BreakPoint[]) => {
-      breakPoints = bps;
-    })));
+    beforeEach(inject([BREAKPOINTS], (bps: BreakPoint[]) => {
+      breakPoints = [...bps].sort(sortDescendingPriority);
+    }));
 
     it('has the standard breakpoints', () => {
       expect(breakPoints.length).toEqual(DEFAULT_BREAKPOINTS.length);
       expect(breakPoints[0].alias).toEqual('xs');
-      expect(breakPoints[breakPoints.length - 1].alias).toEqual('xl');
+      expect(breakPoints[breakPoints.length - 1].alias).toEqual('gt-xs');
     });
   });
 
@@ -57,9 +58,9 @@ describe('break-point-provider', () => {
       });
     });
     // tslint:disable-next-line:no-shadowed-variable
-    beforeEach(async(inject([BREAKPOINTS], (breakPoints: BreakPoint[]) => {
+    beforeEach(inject([BREAKPOINTS], (breakPoints: BreakPoint[]) => {
       bpList = breakPoints;
-    })));
+    }));
 
     it('has the custom breakpoints', () => {
       expect(bpList.length).toEqual(CUSTOM_BPS.length);

--- a/src/lib/core/breakpoints/data/break-points.ts
+++ b/src/lib/core/breakpoints/data/break-points.ts
@@ -7,83 +7,81 @@
  */
 import {BreakPoint} from '../break-point';
 
-export const RESPONSIVE_ALIASES = [
-  'xs', 'gt-xs', 'sm', 'gt-sm', 'md', 'gt-md', 'lg', 'gt-lg', 'xl'
-];
-
+/**
+ * NOTE: Smaller ranges have HIGHER priority since the match is more specific
+ */
 export const DEFAULT_BREAKPOINTS: BreakPoint[] = [
   {
     alias: 'xs',
-    mediaQuery: '(min-width: 0px) and (max-width: 599px)',
-    priority: 100,
+    mediaQuery: 'screen and (min-width: 0px) and (max-width: 599px)',
+    priority: 1000,
   },
   {
-    alias: 'gt-xs',
-    overlapping: true,
-    mediaQuery: '(min-width: 600px)',
-    priority: 7,
+    alias: 'sm',
+    mediaQuery: 'screen and (min-width: 600px) and (max-width: 959px)',
+    priority: 900,
+  },
+  {
+    alias: 'md',
+    mediaQuery: 'screen and (min-width: 960px) and (max-width: 1279px)',
+    priority: 800,
+  },
+  {
+    alias: 'lg',
+    mediaQuery: 'screen and (min-width: 1280px) and (max-width: 1919px)',
+    priority: 700,
+  },
+  {
+    alias: 'xl',
+    mediaQuery: 'screen and (min-width: 1920px) and (max-width: 5000px)',
+    priority: 600,
   },
   {
     alias: 'lt-sm',
     overlapping: true,
-    mediaQuery: '(max-width: 599px)',
-    priority: 10,
-  },
-  {
-    alias: 'sm',
-    mediaQuery: '(min-width: 600px) and (max-width: 959px)',
-    priority: 100,
-  },
-  {
-    alias: 'gt-sm',
-    overlapping: true,
-    mediaQuery: '(min-width: 960px)',
-    priority: 8,
+    mediaQuery: 'screen and (max-width: 599px)',
+    priority: 950,
   },
   {
     alias: 'lt-md',
     overlapping: true,
-    mediaQuery: '(max-width: 959px)',
-    priority: 9,
-  },
-  {
-    alias: 'md',
-    mediaQuery: '(min-width: 960px) and (max-width: 1279px)',
-    priority: 100,
-  },
-  {
-    alias: 'gt-md',
-    overlapping: true,
-    mediaQuery: '(min-width: 1280px)',
-    priority: 9,
+    mediaQuery: 'screen and (max-width: 959px)',
+    priority: 850,
   },
   {
     alias: 'lt-lg',
     overlapping: true,
-    mediaQuery: '(max-width: 1279px)',
-    priority: 8,
-  },
-  {
-    alias: 'lg',
-    mediaQuery: '(min-width: 1280px) and (max-width: 1919px)',
-    priority: 100,
-  },
-  {
-    alias: 'gt-lg',
-    overlapping: true,
-    mediaQuery: '(min-width: 1920px)',
-    priority: 10,
+    mediaQuery: 'screen and (max-width: 1279px)',
+    priority: 750,
   },
   {
     alias: 'lt-xl',
     overlapping: true,
-    mediaQuery: '(max-width: 1919px)',
-    priority: 7,
+    priority: 650,
+    mediaQuery: 'screen and (max-width: 1919px)',
   },
   {
-    alias: 'xl',
-    mediaQuery: '(min-width: 1920px) and (max-width: 5000px)',
-    priority: 100,
+    alias: 'gt-xs',
+    overlapping: true,
+    mediaQuery: 'screen and (min-width: 600px)',
+    priority: -950,
+  },
+  {
+    alias: 'gt-sm',
+    overlapping: true,
+    mediaQuery: 'screen and (min-width: 960px)',
+    priority: -850,
+  }, {
+    alias: 'gt-md',
+    overlapping: true,
+    mediaQuery: 'screen and (min-width: 1280px)',
+    priority: -750,
+  },
+  {
+    alias: 'gt-lg',
+    overlapping: true,
+    mediaQuery: 'screen and (min-width: 1920px)',
+    priority: -650,
   }
 ];
 

--- a/src/lib/core/breakpoints/data/orientation-break-points.spec.ts
+++ b/src/lib/core/breakpoints/data/orientation-break-points.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {TestBed, inject, async} from '@angular/core/testing';
+import {TestBed, inject} from '@angular/core/testing';
 
 import {BreakPoint} from '../break-point';
 import {DEFAULT_BREAKPOINTS} from './break-points';
@@ -16,13 +16,20 @@ import {FlexLayoutModule} from '../../../module';
 
 describe('break-point-provider', () => {
   let breakPoints: BreakPoint[];
-  let findByAlias = (alias: string): BreakPoint|null => breakPoints.reduce(
-    (pos: BreakPoint | null, it) =>  pos || ((it.alias == alias) ? it : null), null);
+  const findByAlias = (alias: string): BreakPoint|null => {
+      let result = null;
+       breakPoints.forEach(bp => {
+          if (bp.alias === alias) {
+            result = {...bp};
+          }
+      });
+      return result;
+    };
 
   describe('with default breakpoints only', () => {
-    beforeEach(async(inject([BREAKPOINTS], (bps: BreakPoint[]) => {
+    beforeEach(inject([BREAKPOINTS], (bps: BreakPoint[]) => {
       breakPoints = bps;
-    })));
+    }));
 
     it('has the only standard default breakpoints without internal custom breakpoints', () => {
       const total = DEFAULT_BREAKPOINTS.length;
@@ -46,9 +53,9 @@ describe('break-point-provider', () => {
         imports: [FlexLayoutModule.withConfig({}, EXTRAS)]
       });
     });
-    beforeEach(async(inject([BREAKPOINTS], (bps: BreakPoint[]) => {
+    beforeEach(inject([BREAKPOINTS], (bps: BreakPoint[]) => {
       bpList = bps;
-    })));
+    }));
 
     it('has the custom breakpoints', () => {
       const total = DEFAULT_BREAKPOINTS.length + EXTRAS.length;
@@ -84,9 +91,9 @@ describe('break-point-provider', () => {
       });
     });
     // tslint:disable-next-line:no-shadowed-variable
-    beforeEach(async(inject([BREAKPOINTS], (breakPoints: BreakPoint[]) => {
+    beforeEach(inject([BREAKPOINTS], (breakPoints: BreakPoint[]) => {
       bpList = breakPoints;
-    })));
+    }));
 
     it('has merged the custom breakpoints as overrides to existing defaults', () => {
       const total = ORIENTATION_BREAKPOINTS.length + DEFAULT_BREAKPOINTS.length + NUM_EXTRAS;
@@ -124,9 +131,9 @@ describe('break-point-provider', () => {
         imports: [FlexLayoutModule.withConfig({disableDefaultBps: true}, EXTRAS)]
       });
     });
-    beforeEach(async(inject([BREAKPOINTS], (bps: BreakPoint[]) => {
+    beforeEach(inject([BREAKPOINTS], (bps: BreakPoint[]) => {
       bpList = bps;
-    })));
+    }));
 
     it('has the only the registered custom breakpoints; defaults are excluded.', () => {
       const total = EXTRAS.length;

--- a/src/lib/core/breakpoints/data/orientation-break-points.ts
+++ b/src/lib/core/breakpoints/data/orientation-break-points.ts
@@ -36,15 +36,15 @@ export const ScreenTypes = {
  * Extended Breakpoints for handset/tablets with landscape or portrait orientations
  */
 export const ORIENTATION_BREAKPOINTS : BreakPoint[] = [
-  {'alias': 'handset',            'mediaQuery': ScreenTypes.HANDSET},
-  {'alias': 'handset.landscape',  'mediaQuery': ScreenTypes.HANDSET_LANDSCAPE},
-  {'alias': 'handset.portrait',   'mediaQuery': ScreenTypes.HANDSET_PORTRAIT},
+  {'alias': 'handset',            priority: 10000, 'mediaQuery': ScreenTypes.HANDSET},
+  {'alias': 'handset.landscape',  priority: 10000, 'mediaQuery': ScreenTypes.HANDSET_LANDSCAPE},
+  {'alias': 'handset.portrait',   priority: 10000, 'mediaQuery': ScreenTypes.HANDSET_PORTRAIT},
 
-  {'alias': 'tablet',             'mediaQuery': ScreenTypes.TABLET},
-  {'alias': 'tablet.landscape',   'mediaQuery': ScreenTypes.TABLET},
-  {'alias': 'tablet.portrait',    'mediaQuery': ScreenTypes.TABLET_PORTRAIT},
+  {'alias': 'tablet',             priority: 8000, 'mediaQuery': ScreenTypes.TABLET},
+  {'alias': 'tablet.landscape',   priority: 8000, 'mediaQuery': ScreenTypes.TABLET},
+  {'alias': 'tablet.portrait',    priority: 8000, 'mediaQuery': ScreenTypes.TABLET_PORTRAIT},
 
-  {'alias': 'web',                'mediaQuery': ScreenTypes.WEB, overlapping : true },
-  {'alias': 'web.landscape',      'mediaQuery': ScreenTypes.WEB_LANDSCAPE, overlapping : true },
-  {'alias': 'web.portrait',       'mediaQuery': ScreenTypes.WEB_PORTRAIT, overlapping : true }
+  {'alias': 'web',                priority: 9000, 'mediaQuery': ScreenTypes.WEB, overlapping : true },
+  {'alias': 'web.landscape',      priority: 9000, 'mediaQuery': ScreenTypes.WEB_LANDSCAPE, overlapping : true },
+  {'alias': 'web.portrait',       priority: 9000, 'mediaQuery': ScreenTypes.WEB_PORTRAIT, overlapping : true }
 ];

--- a/src/lib/core/breakpoints/index.ts
+++ b/src/lib/core/breakpoints/index.ts
@@ -12,4 +12,8 @@ export * from './data/orientation-break-points';
 export * from './break-point';
 export * from './break-point-registry';
 export * from './break-points-token';
-export {prioritySort} from './breakpoint-tools';
+
+export {
+  sortDescendingPriority,
+  sortAscendingPriority
+} from './breakpoint-tools';

--- a/src/lib/core/match-media/match-media.ts
+++ b/src/lib/core/match-media/match-media.ts
@@ -7,7 +7,7 @@
  */
 import {Inject, Injectable, NgZone, PLATFORM_ID} from '@angular/core';
 import {DOCUMENT, isPlatformBrowser} from '@angular/common';
-import {BehaviorSubject, Observable} from 'rxjs';
+import {BehaviorSubject, Observable, merge, Observer} from 'rxjs';
 import {filter} from 'rxjs/operators';
 
 import {MediaChange} from '../media-change';
@@ -21,8 +21,10 @@ import {MediaChange} from '../media-change';
  */
 @Injectable({providedIn: 'root'})
 export class MatchMedia {
-  protected _registry = new Map<string, MediaQueryList>();
+  /** Initialize with 'all' so all non-responsive APIs trigger style updates */
   protected _source = new BehaviorSubject<MediaChange>(new MediaChange(true));
+
+  protected _registry = new Map<string, MediaQueryList>();
   protected _observable$ = this._source.asObservable();
 
   constructor(protected _zone: NgZone,
@@ -40,20 +42,45 @@ export class MatchMedia {
 
   /**
    * External observers can watch for all (or a specific) mql changes.
+   *
+   * If a mediaQuery is not specified, then ALL mediaQuery activations will
+   * be announced.
+   */
+  observe(): Observable<MediaChange>;
+  observe(mediaQueries: string[]): Observable<MediaChange>;
+  observe(mediaQueries: string[], filterOthers: boolean): Observable<MediaChange>;
+
+  /**
+   * External observers can watch for all (or a specific) mql changes.
    * Typically used by the MediaQueryAdaptor; optionally available to components
    * who wish to use the MediaMonitor as mediaMonitor$ observable service.
    *
-   * NOTE: if a mediaQuery is not specified, then ALL mediaQuery activations will
-   *       be announced.
+   * Use deferred registration process to register breakpoints only on subscription
+   * This logic also enforces logic to register all mediaQueries BEFORE notify
+   * subscribers of notifications.
    */
-  observe(mediaQuery?: string): Observable<MediaChange> {
-    if (mediaQuery) {
-      this.registerQuery(mediaQuery);
+  observe(mqList?: string[], filterOthers = false): Observable<MediaChange> {
+    if (mqList) {
+      const matchMedia$: Observable<MediaChange> = this._observable$.pipe(
+          filter((change: MediaChange) => {
+            return !filterOthers ? true : (mqList.indexOf(change.mediaQuery) > -1);
+          })
+      );
+      const registration$: Observable<MediaChange> = new Observable((observer: Observer<MediaChange>) => {  // tslint:disable-line:max-line-length
+        const matches: Array<MediaChange> = this.registerQuery(mqList);
+        if (matches.length) {
+          const lastChange = matches.pop()!;
+          matches.forEach((e: MediaChange) => {
+            observer.next(e);
+          });
+          this._source.next(lastChange); // last match is cached
+        }
+        observer.complete();
+      });
+      return merge(registration$, matchMedia$);
     }
 
-    return this._observable$.pipe(
-      filter(change => (mediaQuery ? (change.mediaQuery === mediaQuery) : true))
-    );
+    return this._observable$;
   }
 
   /**
@@ -61,36 +88,36 @@ export class MatchMedia {
    * mediaQuery. Each listener emits specific MediaChange data to observers
    */
   registerQuery(mediaQuery: string | string[]) {
-    const list = Array.isArray(mediaQuery) ? Array.from(new Set(mediaQuery)) : [mediaQuery];
+    const list = Array.isArray(mediaQuery) ? mediaQuery : [mediaQuery];
+    const matches: MediaChange[] = [];
 
-    if (list.length > 0) {
-      buildQueryCss(list, this._document);
-    }
+    buildQueryCss(list, this._document);
 
-    list.forEach(query => {
+    list.forEach((query: string) => {
       const onMQLEvent = (e: MediaQueryListEvent) => {
         this._zone.run(() => this._source.next(new MediaChange(e.matches, query)));
       };
 
       let mql = this._registry.get(query);
-
       if (!mql) {
-        mql = this._buildMQL(query);
+        mql = this.buildMQL(query);
         mql.addListener(onMQLEvent);
         this._registry.set(query, mql);
       }
 
       if (mql.matches) {
-        onMQLEvent(mql as unknown as MediaQueryListEvent);
+        matches.push(new MediaChange(true, query));
       }
     });
+
+    return matches;
   }
 
   /**
    * Call window.matchMedia() to build a MediaQueryList; which
    * supports 0..n listeners for activation/deactivation
    */
-  protected _buildMQL(query: string): MediaQueryList {
+  protected buildMQL(query: string): MediaQueryList {
     return constructMql(query, isPlatformBrowser(this._platformId));
   }
 }
@@ -99,7 +126,7 @@ export class MatchMedia {
  * Private global registry for all dynamically-created, injected style tags
  * @see prepare(query)
  */
-const ALL_STYLES: {[key: string]: any} = {};
+const ALL_STYLES: { [key: string]: any } = {};
 
 /**
  * For Webkit engines that only trigger the MediaQueryList Listener
@@ -124,7 +151,7 @@ function buildQueryCss(mediaQueries: string[], _document: Document) {
   see http://bit.ly/2sd4HMP
 */
 @media ${query} {.fx-query-test{ }}
-` ;
+`;
         styleEl.appendChild(_document.createTextNode(cssText));
       }
 

--- a/src/lib/core/match-media/mock/mock-match-media.ts
+++ b/src/lib/core/match-media/mock/mock-match-media.ts
@@ -129,7 +129,7 @@ export class MockMatchMedia extends MatchMedia {
   private _activateByQuery(mediaQuery: string) {
     const mql = this._registry.get(mediaQuery);
     const alreadyAdded = this._actives
-      .reduce((found, it) => (found || (mql ? (it.media === mql.media) : false)), false);
+        .reduce((found, it) => (found || (mql ? (it.media === mql.media) : false)), false);
 
     if (mql && !alreadyAdded) {
       this._actives.push(mql.activate());
@@ -160,7 +160,7 @@ export class MockMatchMedia extends MatchMedia {
    * Call window.matchMedia() to build a MediaQueryList; which
    * supports 0..n listeners for activation/deactivation
    */
-  protected _buildMQL(query: string): MediaQueryList {
+  protected buildMQL(query: string): MediaQueryList {
     return new MockMediaQueryList(query);
   }
 
@@ -188,7 +188,8 @@ export class MockMediaQueryList implements MediaQueryList {
     return this._mediaQuery;
   }
 
-  constructor(private _mediaQuery: string) {}
+  constructor(private _mediaQuery: string) {
+  }
 
   /**
    * Destroy the current list by deactivating the
@@ -238,24 +239,28 @@ export class MockMediaQueryList implements MediaQueryList {
   removeListener(_: EventListenerOrEventListenerObject | null) {
   }
 
-  addEventListener<K extends keyof
-    MediaQueryListEventMap>(_: K,
-                            __: (this: MediaQueryList,
-                                 ev: MediaQueryListEventMap[K]) => any,
-                            ___?: boolean | AddEventListenerOptions): void;
-  addEventListener(_: string,
-                   __: EventListenerOrEventListenerObject,
-                   ___?: boolean | AddEventListenerOptions) {
+  addEventListener<K extends keyof MediaQueryListEventMap>(
+      _: K,
+      __: (this: MediaQueryList,
+      ev: MediaQueryListEventMap[K]) => any,
+      ___?: boolean | AddEventListenerOptions): void;
+
+  addEventListener(
+      _: string,
+      __: EventListenerOrEventListenerObject,
+      ___?: boolean | AddEventListenerOptions) {
   }
 
-  removeEventListener<K extends keyof
-    MediaQueryListEventMap>(_: K,
-                            __: (this: MediaQueryList,
-                                  ev: MediaQueryListEventMap[K]) => any,
-                            ___?: boolean | EventListenerOptions): void;
-  removeEventListener(_: string,
-                      __: EventListenerOrEventListenerObject,
-                      ___?: boolean | EventListenerOptions) {
+  removeEventListener<K extends keyof MediaQueryListEventMap>(
+      _: K,
+      __: (this: MediaQueryList,
+      ev: MediaQueryListEventMap[K]) => any,
+      ___?: boolean | EventListenerOptions): void;
+
+  removeEventListener(
+      _: string,
+      __: EventListenerOrEventListenerObject,
+      ___?: boolean | EventListenerOptions) {
   }
 
   dispatchEvent(_: Event): boolean {

--- a/src/lib/core/match-media/server-match-media.ts
+++ b/src/lib/core/match-media/server-match-media.ts
@@ -141,7 +141,7 @@ export class ServerMatchMedia extends MatchMedia {
    * Call window.matchMedia() to build a MediaQueryList; which
    * supports 0..n listeners for activation/deactivation
    */
-  protected _buildMQL(query: string): ServerMediaQueryList {
+  protected buildMQL(query: string): ServerMediaQueryList {
     return new ServerMediaQueryList(query);
   }
 }

--- a/src/lib/core/media-marshaller/media-marshaller.spec.ts
+++ b/src/lib/core/media-marshaller/media-marshaller.spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {async, fakeAsync, inject, TestBed} from '@angular/core/testing';
+import {inject, TestBed} from '@angular/core/testing';
 import {Subject} from 'rxjs';
 
 import {MockMatchMedia, MockMatchMediaProvider} from '../match-media/mock/mock-match-media';
@@ -25,12 +25,11 @@ describe('media-marshaller', () => {
     spyOn(MediaMarshaller.prototype, 'updateStyles').and.callThrough();
   });
 
-  // Single async inject to save references; which are used in all tests below
-  beforeEach(async(inject([MatchMedia, MediaMarshaller],
-    (service: MockMatchMedia, marshal: MediaMarshaller) => {
-    matchMedia = service;      // inject only to manually activate mediaQuery ranges
-    mediaMarshaller = marshal;
-  })));
+  beforeEach(inject([MatchMedia, MediaMarshaller],
+      (service: MockMatchMedia, marshal: MediaMarshaller) => {
+        matchMedia = service;      // inject only to manually activate mediaQuery ranges
+        mediaMarshaller = marshal;
+      }));
   afterEach(() => {
     matchMedia.clearAll();
   });
@@ -73,7 +72,8 @@ describe('media-marshaller', () => {
     const builder = () => {
       triggered = true;
     };
-    mediaMarshaller.init(fakeElement, fakeKey, builder, () => {}, [obs]);
+    mediaMarshaller.init(fakeElement, fakeKey, builder, () => {
+    }, [obs]);
     subject.next();
     expect(triggered).toBeTruthy();
   });
@@ -101,15 +101,17 @@ describe('media-marshaller', () => {
   });
 
   it('should get the right value', () => {
-    const builder = () => {};
+    const builder = () => {
+    };
     mediaMarshaller.init(fakeElement, fakeKey, builder);
     mediaMarshaller.setValue(fakeElement, fakeKey, 0, '');
     const value = mediaMarshaller.getValue(fakeElement, fakeKey);
     expect(value).toEqual(0);
   });
 
-  it('should track changes', fakeAsync(() => {
-    const builder = () => {};
+  it('should track changes', () => {
+    const builder = () => {
+    };
     let triggered = false;
     mediaMarshaller.init(fakeElement, fakeKey, builder);
     mediaMarshaller.trackValue(fakeElement, fakeKey).subscribe(() => {
@@ -117,7 +119,7 @@ describe('media-marshaller', () => {
     });
     mediaMarshaller.setValue(fakeElement, fakeKey, 0, '');
     expect(triggered).toBeTruthy();
-  }));
+  });
 
   it('should release', () => {
     let triggered = false;
@@ -126,7 +128,8 @@ describe('media-marshaller', () => {
     const builder = () => {
       triggered = true;
     };
-    mediaMarshaller.init(fakeElement, fakeKey, builder, () => {}, [obs]);
+    mediaMarshaller.init(fakeElement, fakeKey, builder, () => {
+    }, [obs]);
     mediaMarshaller.releaseElement(fakeElement);
     subject.next();
     expect(triggered).toBeFalsy();

--- a/src/lib/core/media-observer/media-observer.spec.ts
+++ b/src/lib/core/media-observer/media-observer.spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {TestBed, inject, async} from '@angular/core/testing';
+import {TestBed, inject} from '@angular/core/testing';
 import {filter, map} from 'rxjs/operators';
 
 import {BreakPoint} from '../breakpoints/break-point';
@@ -16,7 +16,7 @@ import {MediaObserver} from './media-observer';
 import {MockMatchMedia, MockMatchMediaProvider} from '../match-media/mock/mock-match-media';
 import {BREAKPOINT} from '../tokens/breakpoint-token';
 
-describe('observable-media', () => {
+describe('media-observer', () => {
 
   describe('with default BreakPoints', () => {
     let knownBreakPoints: BreakPoint[] = [];
@@ -37,80 +37,35 @@ describe('observable-media', () => {
       knownBreakPoints = breakpoints;
     }));
 
-    it('can supports the `.isActive()` API', async(inject(
-      [MediaObserver, MatchMedia],
-      (media: MediaObserver, matchMedia: MockMatchMedia) => {
-        expect(media).toBeDefined();
+    it('can subscribe to built-in mediaQueries', inject(
+        [MediaObserver, MatchMedia],
+        (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
+          let current: MediaChange = new MediaChange(false, 'unknown');
+          let subscription = matchMedia.observe().subscribe((change: MediaChange) => {
+            current = change;
+          });
+          expect(current.matches).toBeTruthy();
+          expect(current.mediaQuery).toEqual('all');
+          subscription.unsubscribe();
 
-        // Activate mediaQuery associated with 'md' alias
-        matchMedia.activate('md');
-        expect(media.isActive('md')).toBeTruthy();
-
-        matchMedia.activate('lg');
-        expect(media.isActive('lg')).toBeTruthy();
-        expect(media.isActive('md')).toBeFalsy();
-
-      })));
-
-    it('can supports RxJS operators', inject(
-      [MediaObserver, MatchMedia],
-      (mediaService: MediaObserver, matchMedia: MockMatchMedia) => {
-        let count = 0,
-          subscription = mediaService.media$.pipe(
-            filter((change: MediaChange) => change.mqAlias == 'md'),
-            map((change: MediaChange) => change.mqAlias)
-          ).subscribe(_ => {
-            count += 1;
+          expect(mediaObserver).toBeDefined();
+          current = new MediaChange(true);
+          subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+            current = change;
           });
 
-
-        // Activate mediaQuery associated with 'md' alias
-        matchMedia.activate('sm');
-        expect(count).toEqual(0);
-
-        matchMedia.activate('md');
-        expect(count).toEqual(1);
-
-        matchMedia.activate('lg');
-        expect(count).toEqual(1);
-
-        matchMedia.activate('md');
-        expect(count).toEqual(2);
-
-        matchMedia.activate('gt-md');
-        matchMedia.activate('gt-lg');
-        matchMedia.activate('invalid');
-        expect(count).toEqual(2);
-
-        subscription.unsubscribe();
-      }));
-
-    it('can subscribe to built-in mediaQueries', inject(
-      [MediaObserver, MatchMedia],
-      (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
-        let current: MediaChange;
-
-        expect(mediaObserver).toBeDefined();
-
-        let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
-          current = change;
-        });
-
-        async(() => {
           // Confirm initial match is for 'all'
-          expect(current).toBeDefined();
           expect(current.matches).toBeTruthy();
           expect(current.mediaQuery).toEqual('all');
 
           try {
+            // Allow overlapping activations to be announced to observers
             matchMedia.autoRegisterQueries = false;
+            mediaObserver.filterOverlaps = false;
 
             // Activate mediaQuery associated with 'md' alias
             matchMedia.activate('md');
             expect(current.mediaQuery).toEqual(findMediaQuery('md'));
-
-            // Allow overlapping activations to be announced to observers
-            mediaObserver.filterOverlaps = false;
 
             matchMedia.activate('gt-lg');
             expect(current.mediaQuery).toEqual(findMediaQuery('gt-lg'));
@@ -122,18 +77,64 @@ describe('observable-media', () => {
             matchMedia.autoRegisterQueries = true;
             subscription.unsubscribe();
           }
-        });
-      }));
+
+        }));
+
+    it('can supports the `.isActive()` API', inject(
+        [MediaObserver, MatchMedia],
+        (media: MediaObserver, matchMedia: MockMatchMedia) => {
+          expect(media).toBeDefined();
+
+          // Activate mediaQuery associated with 'md' alias
+          matchMedia.activate('md');
+          expect(media.isActive('md')).toBeTruthy();
+
+          matchMedia.activate('lg');
+          expect(media.isActive('lg')).toBeTruthy();
+          expect(media.isActive('md')).toBeFalsy();
+
+        }));
+
+    it('can supports RxJS operators', inject(
+        [MediaObserver, MatchMedia],
+        (mediaService: MediaObserver, matchMedia: MockMatchMedia) => {
+          let count = 0,
+              subscription = mediaService.media$.pipe(
+                  filter((change: MediaChange) => change.mqAlias == 'md'),
+                  map((change: MediaChange) => change.mqAlias)
+              ).subscribe(_ => {
+                count += 1;
+              });
+
+          // Activate mediaQuery associated with 'md' alias
+          matchMedia.activate('sm');
+          expect(count).toEqual(0);
+
+          matchMedia.activate('md');
+          expect(count).toEqual(1);
+
+          matchMedia.activate('lg');
+          expect(count).toEqual(1);
+
+          matchMedia.activate('md');
+          expect(count).toEqual(2);
+
+          matchMedia.activate('gt-md');
+          matchMedia.activate('gt-lg');
+          matchMedia.activate('invalid');
+          expect(count).toEqual(2);
+
+          subscription.unsubscribe();
+        }));
 
     it('can `.unsubscribe()` properly', inject(
-      [MediaObserver, MatchMedia],
-      (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
-        let current: MediaChange;
-        let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
-          current = change;
-        });
+        [MediaObserver, MatchMedia],
+        (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
+          let current: MediaChange = new MediaChange();
+          let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+            current = change;
+          });
 
-        async(() => {
           // Activate mediaQuery associated with 'md' alias
           matchMedia.activate('md');
           expect(current.mediaQuery).toEqual(findMediaQuery('md'));
@@ -146,18 +147,16 @@ describe('observable-media', () => {
 
           matchMedia.activate('xs');
           expect(current.mqAlias).toBe('md');
-        });
-      }));
+        }));
 
     it('can observe a startup activation of XS', inject(
-      [MediaObserver, MatchMedia],
-      (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
-        let current: MediaChange;
-        let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
-          current = change;
-        });
+        [MediaObserver, MatchMedia],
+        (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
+          let current: MediaChange = new MediaChange();
+          let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+            current = change;
+          });
 
-        async(() => {
           // Activate mediaQuery associated with 'md' alias
           matchMedia.activate('xs');
           expect(current.mediaQuery).toEqual(findMediaQuery('xs'));
@@ -167,16 +166,15 @@ describe('observable-media', () => {
 
           matchMedia.activate('lg');
           expect(current.mqAlias).toBe('xs');
-        });
-      }));
+        }));
   });
 
   describe('with custom BreakPoints', () => {
     const gtXsMediaQuery = 'screen and (max-width:20px) and (orientations: landscape)';
-    const mdMediaQuery = 'print and (min-width:10000px)';
+    const superLgMediaQuery = 'screen and (min-width:10000px)';
     const CUSTOM_BREAKPOINTS = [
-      {alias: 'print.md', mediaQuery: mdMediaQuery},
-      {alias: 'tablet-gt-xs', mediaQuery: gtXsMediaQuery},
+      {alias: 'super-xxl', mediaQuery: superLgMediaQuery, priority: 2000},
+      {alias: 'tablet-gt-xs', mediaQuery: gtXsMediaQuery, priority: 2000},
     ];
 
     beforeEach(() => {
@@ -190,24 +188,25 @@ describe('observable-media', () => {
     });
 
     it('can activate custom alias with custom mediaQueries', inject(
-      [MediaObserver, MatchMedia],
-      (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
-        let current: MediaChange;
-        let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
-          current = change;
-        });
+        [MediaObserver, MatchMedia],
+        (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
+          let current: MediaChange = new MediaChange();
+          let subscription = mediaObserver
+                .media$
+                .subscribe((change: MediaChange) => {
+                  current = change;
+                });
 
-        async(() => {
           // Activate mediaQuery associated with 'md' alias
-          matchMedia.activate('print.md');
-          expect(current.mediaQuery).toEqual(mdMediaQuery);
+          matchMedia.activate('super-xxl');
+          expect(current.mediaQuery).toEqual(superLgMediaQuery);
 
           matchMedia.activate('tablet-gt-xs');
           expect(current.mqAlias).toBe('tablet-gt-xs');
           expect(current.mediaQuery).toBe(gtXsMediaQuery);
 
           subscription.unsubscribe();
-        });
-      }));
+        }));
   });
+
 });

--- a/src/lib/core/media-observer/media-observer.ts
+++ b/src/lib/core/media-observer/media-observer.ts
@@ -65,15 +65,14 @@ export class MediaObserver {
   readonly media$: Observable<MediaChange>;
 
   constructor(private breakpoints: BreakPointRegistry, private mediaWatcher: MatchMedia) {
-    this._registerBreakPoints();
-    this.media$ = this._buildObservable();
+    this.media$ = this.watchActivations();
   }
 
   /**
    * Test if specified query/alias is active.
    */
   isActive(alias: string): boolean {
-    return this.mediaWatcher.isActive(this._toMediaQuery(alias));
+    return this.mediaWatcher.isActive(this.toMediaQuery(alias));
   }
 
   // ************************************************
@@ -85,9 +84,9 @@ export class MediaObserver {
    * This is needed so subscribers can be auto-notified of all standard, registered
    * mediaQuery activations
    */
-  private _registerBreakPoints() {
-    const queries = this.breakpoints.sortedItems.map(bp => bp.mediaQuery);
-    this.mediaWatcher.registerQuery(queries);
+  private watchActivations() {
+    const queries = this.breakpoints.items.map(bp => bp.mediaQuery);
+    return this.buildObservable(queries);
   }
 
   /**
@@ -97,9 +96,10 @@ export class MediaObserver {
    *       contain important alias information; as such this info
    *       must be injected into the MediaChange
    */
-  private _buildObservable() {
+  private buildObservable(mqList: string[]): Observable<MediaChange> {
+    const locator = this.breakpoints;
     const excludeOverlaps = (change: MediaChange) => {
-      const bp = this.breakpoints.findByQuery(change.mediaQuery);
+      const bp = locator.findByQuery(change.mediaQuery);
       return !bp ? true : !(this.filterOverlaps && bp.overlapping);
     };
 
@@ -108,35 +108,22 @@ export class MediaObserver {
      * Inject associated (if any) alias information into the MediaChange event
      * Exclude mediaQuery activations for overlapping mQs. List bounded mQ ranges only
      */
-    return this.mediaWatcher.observe()
-      .pipe(
-        filter(change => change.matches),
-        filter(excludeOverlaps),
-        map((change: MediaChange) =>
-          mergeAlias(change, this._findByQuery(change.mediaQuery))
-        )
-      );
-  }
-
-  /**
-   * Breakpoint locator by alias
-   */
-  private _findByAlias(alias: string) {
-    return this.breakpoints.findByAlias(alias);
-  }
-
-  /**
-   * Breakpoint locator by mediaQuery
-   */
-  private _findByQuery(query: string) {
-    return this.breakpoints.findByQuery(query);
+    return this.mediaWatcher.observe(mqList)
+        .pipe(
+            filter(change => change.matches),
+            filter(excludeOverlaps),
+            map((change: MediaChange) => {
+              return mergeAlias(change, locator.findByQuery(change.mediaQuery));
+            })
+        );
   }
 
   /**
    * Find associated breakpoint (if any)
    */
-  private _toMediaQuery(query: string) {
-    const bp = this._findByAlias(query) || this._findByQuery(query);
+  private toMediaQuery(query: string) {
+    const locator = this.breakpoints;
+    const bp = locator.findByAlias(query) || locator.findByQuery(query);
     return bp ? bp.mediaQuery : query;
   }
 }

--- a/src/lib/extended/show-hide/show.spec.ts
+++ b/src/lib/extended/show-hide/show.spec.ts
@@ -7,7 +7,7 @@
  */
 import {Component, Directive, OnInit, PLATFORM_ID} from '@angular/core';
 import {CommonModule, isPlatformBrowser} from '@angular/common';
-import {ComponentFixture, TestBed, inject, async} from '@angular/core/testing';
+import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {
   MatchMedia,
   MockMatchMedia,
@@ -323,7 +323,7 @@ describe('show directive', () => {
       });
     });
 
-    it('should respond to custom breakpoint', async(() => {
+    it('should respond to custom breakpoint', () => {
       createTestComponent(`
         <p fxFlex="100%" fxHide="true" fxShow.sm-md="true" fxShow.sm.lg="true"></p>
       `);
@@ -341,7 +341,7 @@ describe('show directive', () => {
       matchMedia.activate('sm.lg');
 
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
-    }));
+    });
   });
 
 });

--- a/src/lib/flex/flex-offset/flex-offset.spec.ts
+++ b/src/lib/flex/flex-offset/flex-offset.spec.ts
@@ -7,7 +7,7 @@
  */
 import {Component, Injectable, PLATFORM_ID} from '@angular/core';
 import {CommonModule, isPlatformServer} from '@angular/common';
-import {async, ComponentFixture, inject, TestBed} from '@angular/core/testing';
+import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
 import {DIR_DOCUMENT} from '@angular/cdk/bidi';
 import {
   MockMatchMediaProvider,
@@ -208,7 +208,7 @@ describe('flex-offset directive', () => {
       });
     });
 
-    it('should set flex offset not to input', async(() => {
+    it('should set flex offset not to input', () => {
       componentWithTemplate(`
         <div fxLayout='column'>
           <div fxFlexOffset="25"></div>
@@ -217,7 +217,7 @@ describe('flex-offset directive', () => {
       fixture.detectChanges();
       let element = queryFor(fixture, '[fxFlexOffset]')[0];
       expectEl(element).toHaveStyle({'margin-top': '10px'}, styler);
-    }));
+    });
   });
 
 });

--- a/src/lib/flex/flex/flex.spec.ts
+++ b/src/lib/flex/flex/flex.spec.ts
@@ -7,7 +7,7 @@
  */
 import {Component, Injectable, PLATFORM_ID, ViewChild} from '@angular/core';
 import {CommonModule, isPlatformServer} from '@angular/common';
-import {ComponentFixture, TestBed, async, inject} from '@angular/core/testing';
+import {ComponentFixture, TestBed, inject, fakeAsync} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
   MatchMedia,
@@ -379,7 +379,7 @@ describe('flex directive', () => {
       }
     });
 
-    it('should work with non-direct-parent fxLayouts', async(() => {
+    it('should work with non-direct-parent fxLayouts', fakeAsync(() => {
       componentWithTemplate(`
         <div fxLayout='column'>
           <div class='test'>
@@ -387,18 +387,17 @@ describe('flex directive', () => {
           </div>
         </div>
       `);
+
       fixture.detectChanges();
       let element = queryFor(fixture, '[fxFlex]')[0];
       let parent = queryFor(fixture, '.test')[0];
 
-      setTimeout(() => {
         // The parent flex-direction not found;
         // A flex-direction should have been auto-injected to the parent...
         // fallback to 'row' and set child width styles accordingly
         expectEl(parent).toHaveStyle({'flex-direction': 'row'}, styler);
         expectEl(element).toHaveStyle({'min-width': '40px'}, styler);
         expectEl(element).not.toHaveStyle({'min-height': '40px'}, styler);
-      });
 
     }));
 
@@ -453,19 +452,17 @@ describe('flex directive', () => {
       }
     });
 
-    it('should work with calc without internal whitespaces', async(() => {
+    it('should work with calc without internal whitespaces', fakeAsync(() => {
       // @see http://caniuse.com/#feat=calc for IE issues with calc()
       componentWithTemplate('<div fxFlex="calc(75%-10px)"></div>');
       if (!(platform.FIREFOX || platform.EDGE)) {
         fixture.detectChanges();
-        setTimeout(() => {
-          expectNativeEl(fixture).toHaveStyle({
-            'box-sizing': 'border-box',
-            'flex-grow': '1',
-            'flex-shrink': '1',
-            'flex-basis': 'calc(75% - 10px)' // correct version has whitespace
-          }, styler);
-        });
+        expectNativeEl(fixture).toHaveStyle({
+          'box-sizing': 'border-box',
+          'flex-grow': '1',
+          'flex-shrink': '1',
+          'flex-basis': 'calc(75% - 10px)' // correct version has whitespace
+        }, styler);
       }
     }));
 
@@ -629,7 +626,7 @@ describe('flex directive', () => {
 
   describe('with responsive features', () => {
 
-    it('should initialize the component with the largest matching breakpoint', () => {
+    it('should initialize the component with the largest gt-xxx matching breakpoint', () => {
       componentWithTemplate(`
         <div  fxFlex='auto'
               fxFlex.gt-xs='33%'
@@ -652,6 +649,38 @@ describe('flex directive', () => {
         'flex': '1 1 100%',
         'max-width': '33%'
       }, styler);
+    });
+
+    it('should initialize the component with the smallest lt-xxx matching breakpoint', () => {
+      componentWithTemplate(`
+        <div fxFlex="25px" fxFlex.lt-sm='33%' fxFlex.lt-lg='50%' >
+        </div>
+      `);
+
+      matchMedia.activate('xl', true);
+      fixture.detectChanges();
+
+      expectNativeEl(fixture).toHaveStyle({
+        'flex': '1 1 25px',
+        'max-width': '25px'
+      }, styler);
+
+      matchMedia.activate('md', true);
+      fixture.detectChanges();
+
+      expectNativeEl(fixture).toHaveStyle({
+        'flex': '1 1 100%',
+        'max-width': '50%'
+      }, styler);
+
+      matchMedia.activate('xs', true);
+      fixture.detectChanges();
+
+      expectNativeEl(fixture).toHaveStyle({
+        'flex': '1 1 100%',
+        'max-width': '33%'
+      }, styler);
+
     });
 
     it('should fallback properly to default flex values', () => {
@@ -868,7 +897,7 @@ describe('flex directive', () => {
       });
     });
 
-    it('should work with non-direct-parent fxLayouts', async(() => {
+    it('should work with non-direct-parent fxLayouts', fakeAsync(() => {
       componentWithTemplate(`
         <div fxLayout='column'>
           <div class='test'>
@@ -880,14 +909,12 @@ describe('flex directive', () => {
       let element = queryFor(fixture, '[fxFlex]')[0];
       let parent = queryFor(fixture, '.test')[0];
 
-      setTimeout(() => {
-        // The parent flex-direction not found;
-        // A flex-direction should have been auto-injected to the parent...
-        // fallback to 'row' and set child width styles accordingly
-        expectEl(parent).toHaveStyle({'flex-direction': 'row'}, styler);
-        expectEl(element).toHaveStyle({'min-width': '40px'}, styler);
-        expectEl(element).not.toHaveStyle({'min-height': '40px'}, styler);
-      });
+      // The parent flex-direction not found;
+      // A flex-direction should have been auto-injected to the parent...
+      // fallback to 'row' and set child width styles accordingly
+      expectEl(parent).toHaveStyle({'flex-direction': 'row'}, styler);
+      expectEl(element).toHaveStyle({'min-width': '40px'}, styler);
+      expectEl(element).not.toHaveStyle({'min-height': '40px'}, styler);
 
     }));
   });
@@ -910,7 +937,7 @@ describe('flex directive', () => {
       });
     });
 
-    it('should work with non-direct-parent fxLayouts', async(() => {
+    it('should work with non-direct-parent fxLayouts', fakeAsync(() => {
       componentWithTemplate(`
         <div fxLayout='column'>
           <div class='test'>
@@ -922,14 +949,12 @@ describe('flex directive', () => {
       let element = queryFor(fixture, '[fxFlex]')[0];
       let parent = queryFor(fixture, '.test')[0];
 
-      setTimeout(() => {
-        // The parent flex-direction not found;
-        // A flex-direction should have been auto-injected to the parent...
-        // fallback to 'row' and set child width styles accordingly
-        expect(parent.nativeElement.getAttribute('style')).not.toContain('-webkit-flex-direction');
-        expectEl(element).toHaveStyle({'min-width': '40px'}, styler);
-        expectEl(element).not.toHaveStyle({'min-height': '40px'}, styler);
-      });
+      // The parent flex-direction not found;
+      // A flex-direction should have been auto-injected to the parent...
+      // fallback to 'row' and set child width styles accordingly
+      expect(parent.nativeElement.getAttribute('style')).not.toContain('-webkit-flex-direction');
+      expectEl(element).toHaveStyle({'min-width': '40px'}, styler);
+      expectEl(element).not.toHaveStyle({'min-height': '40px'}, styler);
 
     }));
   });
@@ -993,7 +1018,7 @@ describe('flex directive', () => {
       });
     });
 
-    it('should set flex basis to input', async(() => {
+    it('should set flex basis to input', fakeAsync(() => {
       componentWithTemplate(`
         <div fxLayout='column'>
           <div fxFlex="25"></div>

--- a/src/lib/flex/layout-align/layout-align.spec.ts
+++ b/src/lib/flex/layout-align/layout-align.spec.ts
@@ -7,7 +7,7 @@
  */
 import {Component, Injectable, OnInit} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {ComponentFixture, TestBed, inject, async} from '@angular/core/testing';
+import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
   MatchMedia,
@@ -34,11 +34,11 @@ describe('layout-align directive', () => {
     fixture = makeCreateTestComponent(() => TestLayoutAlignComponent)(template);
 
     inject([MatchMedia, Platform, StyleUtils],
-      (_matchMedia: MockMatchMedia, _platform: Platform, _styler: StyleUtils) => {
-      matchMedia = _matchMedia;
-      platform = _platform;
-      styler = _styler;
-    })();
+        (_matchMedia: MockMatchMedia, _platform: Platform, _styler: StyleUtils) => {
+          matchMedia = _matchMedia;
+          platform = _platform;
+          styler = _styler;
+        })();
   };
 
   beforeEach(() => {
@@ -150,11 +150,11 @@ describe('layout-align directive', () => {
       it('should add correct styles for `fxLayoutAlign="start start"` usage', () => {
         createTestComponent(`<div fxLayoutAlign='start start'></div>`);
         expectNativeEl(fixture).toHaveStyle(
-          extendObject(MAINAXIS_DEFAULTS, {
-            'align-items': 'flex-start',
-            'align-content': 'flex-start'
-          }),
-          styler
+            extendObject(MAINAXIS_DEFAULTS, {
+              'align-items': 'flex-start',
+              'align-content': 'flex-start'
+            }),
+            styler
         );
       });
       it('should add correct styles for `fxLayoutAlign="start center"` usage', () => {
@@ -468,14 +468,14 @@ describe('layout-align directive', () => {
       });
     });
 
-    it('should set flex offset not to input', async(() => {
+    it('should set flex offset not to input', () => {
       createTestComponent(`
         <div fxLayoutAlign='start start'>
           <div fxFlexOffset="25"></div>
         </div>
       `);
       expectNativeEl(fixture).toHaveStyle({'justify-content': 'flex-end'}, styler);
-    }));
+    });
   });
 
 });
@@ -483,11 +483,11 @@ describe('layout-align directive', () => {
 @Injectable({providedIn: FlexModule})
 export class MockLayoutAlignStyleBuilder extends StyleBuilder {
   shouldCache = false;
+
   buildStyles(_input: string) {
     return {'justify-content': 'flex-end'};
   }
 }
-
 
 // *****************************************************************
 // Template Component
@@ -518,7 +518,6 @@ class TestLayoutAlignComponent implements OnInit {
   ngOnInit() {
   }
 }
-
 
 // *****************************************************************
 // Template Component

--- a/src/lib/flex/layout-gap/layout-gap.spec.ts
+++ b/src/lib/flex/layout-gap/layout-gap.spec.ts
@@ -7,7 +7,7 @@
  */
 import {Component, Injectable, OnInit, PLATFORM_ID} from '@angular/core';
 import {CommonModule, isPlatformServer} from '@angular/common';
-import {TestBed, ComponentFixture, async, inject} from '@angular/core/testing';
+import {TestBed, ComponentFixture, inject, async} from '@angular/core/testing';
 import {DIR_DOCUMENT} from '@angular/cdk/bidi';
 import {
   MatchMedia,
@@ -172,7 +172,6 @@ describe('layout-gap directive', () => {
         nodes = queryFor(fixture, '[fxFlex]');
         expect(nodes.length).toEqual(3);
 
-        // TODO(CaerusKaru): MutationObserver is not implemented in domino
         if (typeof MutationObserver !== 'undefined') {
           expectEl(nodes[0]).toHaveStyle({'margin-right': '13px'}, styler);
           expectEl(nodes[1]).toHaveStyle({'margin-right': '13px'}, styler);
@@ -208,8 +207,6 @@ describe('layout-gap directive', () => {
         nodes = queryFor(fixture, '[fxFlex]');
 
         expect(nodes.length).toEqual(1);
-
-        // TODO(CaerusKaru): MutationObserver is not implemented in domino
         if (typeof MutationObserver !== 'undefined') {
           expectEl(nodes[0]).not.toHaveStyle({'margin-right': '13px'}, styler);
         }
@@ -529,14 +526,14 @@ describe('layout-gap directive', () => {
       });
     });
 
-    it('should set gap not to input', async(() => {
+    it('should set gap not to input', () => {
       createTestComponent(`
         <div fxLayoutGap='10px'>
           <div fxFlexOffset="25"></div>
         </div>
       `);
       expectNativeEl(fixture).toHaveStyle({'margin-top': '12px'}, styler);
-    }));
+    });
   });
 
 });

--- a/src/lib/flex/layout/layout.spec.ts
+++ b/src/lib/flex/layout/layout.spec.ts
@@ -7,7 +7,7 @@
  */
 import {Component, Injectable, OnInit} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {ComponentFixture, TestBed, inject, async} from '@angular/core/testing';
+import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {
   MatchMedia,
   MockMatchMedia,
@@ -351,14 +351,14 @@ describe('layout directive', () => {
       });
     });
 
-    it('should set layout not to input', async(() => {
+    it('should set layout not to input', () => {
       createTestComponent(`
         <div fxLayout='column'>
           <div fxFlexOffset="25"></div>
         </div>
       `);
       expectNativeEl(fixture).toHaveStyle({'display': 'inline-flex'}, styler);
-    }));
+    });
   });
 
 });

--- a/src/lib/server/server-provider.ts
+++ b/src/lib/server/server-provider.ts
@@ -16,7 +16,7 @@ import {
   MatchMedia,
   StylesheetMap,
   ServerMatchMedia,
-  prioritySort,
+  sortAscendingPriority
 } from '@angular/flex-layout/core';
 
 
@@ -36,15 +36,12 @@ export function generateStaticFlexLayoutStyles(serverSheet: StylesheetMap,
   // be referenced in the static media queries
   const classMap = new Map<HTMLElement, string>();
 
-  // Get the initial stylings for all of the directives, and initialize
-  // the fallback block of stylings, then reverse the breakpoints list
-  // to traverse in the proper order
+  // Get the initial stylings for all of the directives,
+  // and initialize the fallback block of stylings
   const defaultStyles = new Map(serverSheet.stylesheet);
   let styleText = generateCss(defaultStyles, 'all', classMap);
 
-  breakpoints.sort(prioritySort);
-  breakpoints.reverse();
-  breakpoints.forEach((bp, i) => {
+  [...breakpoints].sort(sortAscendingPriority).forEach((bp, i) => {
     serverSheet.clearStyles();
     (matchMedia as ServerMatchMedia).activateBreakpoint(bp);
     const stylesheet = new Map(serverSheet.stylesheet);
@@ -165,3 +162,4 @@ function getClassName(element: HTMLElement, classMap: Map<HTMLElement, string>) 
 
   return className;
 }
+


### PR DESCRIPTION
Use breakpoint priority as the only sorting/scanning mechanism;
used to ensure correct MediaChange event notifications.

* prioritize breakpoints: non-overlaps hightest, lt- lowest
  * consistently sort breakpoints ascending by priority
  * highest priority === smallest range
  * remove hackery with reverse(), etc.
* memoize BreakPointRegistry findBy lookups
* fix MatchMedia::observe() to support lazy breakpoint registration
* fix fragile logic in MediaMarshaller
* fix breakpoint registration usage
* clarify update/clear builder function callbacks
* fix MediaObserver breakpoint registration usage

Fixes #648, Fixes #426