### PR TITLE
refactor(core): deprecate MediaObserver media$ to use asObservable()

### DIFF
--- a/docs/documentation/BreakPoints.md
+++ b/docs/documentation/BreakPoints.md
@@ -73,7 +73,7 @@ export class MyAppModule {
 }
 ```
 
-With the above changes, when printing on mobile-sized viewports the **`xs.print`** mediaQuery will activate. Please note
+With the above changes, when printing on mobile-sized viewports the **`xs.print`** mediaQuery will onMediaChange. Please note
 that the provider is a **multi-provider**, meaning it can be provided multiple times and in a variety of
 presentations. The type signature of `BREAKPOINT` is the following:
 

--- a/src/apps/demo-app/src/app/responsive/responsive-row-column/responsive-row-column.component.ts
+++ b/src/apps/demo-app/src/app/responsive/responsive-row-column/responsive-row-column.component.ts
@@ -20,8 +20,8 @@ export class ResponsiveRowColumnComponent implements OnDestroy {
   private activeMQC: MediaChange;
   private subscription: Subscription;
 
-  constructor(mediaObserver: MediaObserver) {
-    this.subscription = mediaObserver.media$
+  constructor(mediaService: MediaObserver) {
+    this.subscription = mediaService.asObservable()
       .subscribe((e: MediaChange) => {
         this.activeMQC = e;
       });

--- a/src/lib/core/match-media/match-media.spec.ts
+++ b/src/lib/core/match-media/match-media.spec.ts
@@ -27,8 +27,8 @@ describe('match-media', () => {
     matchMedia = service;      // inject only to manually activate mediaQuery ranges
   }));
   afterEach(() => {
-    matchMedia.clearAll();
-  });
+     matchMedia && matchMedia.clearAll();
+    });
 
   it('can observe the initial, default activation for mediaQuery == "all". ', () => {
     let current: MediaChange = new MediaChange();
@@ -115,14 +115,14 @@ describe('match-media-observable', () => {
         mediaObserver = _mediaObserver;
       }));
   afterEach(() => {
-    matchMedia.clearAll();
-  });
+     matchMedia && matchMedia.clearAll();
+    });
 
   it('can observe an existing activation', () => {
     let current: MediaChange = new MediaChange();
     let bp = breakPoints.findByAlias('md')!;
     matchMedia.activate(bp.mediaQuery);
-    let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+    let subscription = mediaObserver.asObservable().subscribe((change: MediaChange) => {
       current = change;
     });
 
@@ -132,7 +132,7 @@ describe('match-media-observable', () => {
 
   it('can observe the initial, default activation for mediaQuery == "all". ', () => {
     let current: MediaChange = new MediaChange();
-    let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+    let subscription = mediaObserver.asObservable().subscribe((change: MediaChange) => {
       current = change;
     });
 
@@ -143,7 +143,7 @@ describe('match-media-observable', () => {
   it('can observe custom mediaQuery ranges', () => {
     let current: MediaChange = new MediaChange();
     let customQuery = 'screen and (min-width: 610px) and (max-width: 620px)';
-    let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+    let subscription = mediaObserver.asObservable().subscribe((change: MediaChange) => {
       current = change;
     });
 
@@ -158,7 +158,7 @@ describe('match-media-observable', () => {
   it('can observe registered breakpoint activations', () => {
     let current: MediaChange = new MediaChange();
     let bp = breakPoints.findByAlias('md') !;
-    let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+    let subscription = mediaObserver.asObservable().subscribe((change: MediaChange) => {
       current = change;
     });
 
@@ -179,7 +179,7 @@ describe('match-media-observable', () => {
     let deactivationCount = 0;
 
     mediaObserver.filterOverlaps = false;
-    let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+    let subscription = mediaObserver.asObservable().subscribe((change: MediaChange) => {
       if (change.matches) {
         ++activationCount;
       } else {

--- a/src/lib/core/match-media/mock/mock-match-media.spec.ts
+++ b/src/lib/core/match-media/mock/mock-match-media.spec.ts
@@ -36,7 +36,7 @@ describe('mock-match-media', () => {
       }));
 
   afterEach(() => {
-    matchMedia.clearAll();
+    matchMedia && matchMedia.clearAll();
   });
 
   it('can observe custom mediaQuery ranges', () => {

--- a/src/lib/core/match-media/mock/mock-match-media.ts
+++ b/src/lib/core/match-media/mock/mock-match-media.ts
@@ -219,7 +219,7 @@ export class MockMediaQueryList implements MediaQueryList {
     return this;
   }
 
-  /** Add a listener to our internal list to activate later */
+  /** Add a listener to our internal list to onMediaChange later */
   addListener(listener: MediaQueryListListener) {
     if (this._listeners.indexOf(listener) === -1) {
       this._listeners.push(listener);

--- a/src/lib/core/match-media/server-match-media.ts
+++ b/src/lib/core/match-media/server-match-media.ts
@@ -63,7 +63,7 @@ export class ServerMediaQueryList implements MediaQueryList {
     return this;
   }
 
-  /** Add a listener to our internal list to activate later */
+  /** Add a listener to our internal list to onMediaChange later */
   addListener(listener: MediaQueryListListener) {
     if (this._listeners.indexOf(listener) === -1) {
       this._listeners.push(listener);
@@ -109,7 +109,7 @@ export class ServerMediaQueryList implements MediaQueryList {
  * Special server-only implementation of MatchMedia that uses the above
  * ServerMediaQueryList as its internal representation
  *
- * Also contains methods to activate and deactivate breakpoints
+ * Also contains methods to onMediaChange and deactivate breakpoints
  */
 @Injectable()
 export class ServerMatchMedia extends MatchMedia {

--- a/src/lib/core/media-marshaller/media-marshaller.spec.ts
+++ b/src/lib/core/media-marshaller/media-marshaller.spec.ts
@@ -33,7 +33,7 @@ describe('media-marshaller', () => {
           mediaMarshaller = marshal;
         }));
     afterEach(() => {
-      matchMedia.clearAll();
+     matchMedia && matchMedia.clearAll();
     });
 
     it('activates when match-media activates', () => {
@@ -164,7 +164,7 @@ describe('media-marshaller', () => {
         }));
 
     afterEach(() => {
-      matchMedia.clearAll();
+     matchMedia && matchMedia.clearAll();
     });
 
     it('call onMediaChange when breakpoint activates', () => {

--- a/src/lib/core/media-observer/media-observer.spec.ts
+++ b/src/lib/core/media-observer/media-observer.spec.ts
@@ -58,7 +58,7 @@ describe('media-observer', () => {
       [MediaObserver, MatchMedia],
       (mediaService: MediaObserver, matchMedia: MockMatchMedia) => {
         let count = 0,
-          subscription = mediaService.media$.pipe(
+          subscription = mediaService.asObservable().pipe(
             filter((change: MediaChange) => change.mqAlias == 'md'),
             map((change: MediaChange) => change.mqAlias)
           ).subscribe(_ => {
@@ -92,7 +92,7 @@ describe('media-observer', () => {
       [MediaObserver, MatchMedia],
       (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
         let current: MediaChange = new MediaChange(true);
-        let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+        let subscription = mediaObserver.asObservable().subscribe((change: MediaChange) => {
           current = change;
         });
 
@@ -130,7 +130,7 @@ describe('media-observer', () => {
       [MediaObserver, MatchMedia],
       (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
         let current: MediaChange = new MediaChange(true);
-        let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+        let subscription = mediaObserver.asObservable().subscribe((change: MediaChange) => {
           current = change;
         });
 
@@ -154,7 +154,7 @@ describe('media-observer', () => {
       [MediaObserver, MatchMedia],
       (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
         let current: MediaChange = new MediaChange(true);
-        let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+        let subscription = mediaObserver.asObservable().subscribe((change: MediaChange) => {
           current = change;
         });
 
@@ -196,7 +196,7 @@ describe('media-observer', () => {
       [MediaObserver, MatchMedia],
       (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
         let current: MediaChange = new MediaChange(true);
-        let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+        let subscription = mediaObserver.asObservable().subscribe((change: MediaChange) => {
           current = change;
         });
 
@@ -241,7 +241,7 @@ describe('media-observer', () => {
        [MediaObserver, MatchMedia],
        (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
          let current: MediaChange = new MediaChange(true);
-         let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+         let subscription = mediaObserver.asObservable().subscribe((change: MediaChange) => {
            current = change;
          });
 
@@ -281,7 +281,7 @@ describe('media-observer', () => {
        [MediaObserver, MatchMedia],
        (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
          let current: MediaChange = new MediaChange(true);
-         let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
+         let subscription = mediaObserver.asObservable().subscribe((change: MediaChange) => {
            current = change;
          });
 

--- a/src/lib/core/media-observer/media-observer.ts
+++ b/src/lib/core/media-observer/media-observer.ts
@@ -30,7 +30,7 @@ import {BreakPointRegistry, OptionalBreakPoint} from '../breakpoints/break-point
  *
  * !! This is not an actual Observable. It is a wrapper of an Observable used to publish additional
  * methods like `isActive(<alias>). To access the Observable and use RxJS operators, use
- * `.media$` with syntax like mediaObserver.media$.map(....).
+ * `.media$` with syntax like mediaObserver.asObservable().map(....).
  *
  *  @usage
  *
@@ -42,15 +42,15 @@ import {BreakPointRegistry, OptionalBreakPoint} from '../breakpoints/break-point
  *  export class AppComponent {
  *    status: string = '';
  *
- *    constructor(mediaObserver: MediaObserver) {
+ *    constructor(media: MediaObserver) {
  *      const onChange = (change: MediaChange) => {
  *        this.status = change ? `'${change.mqAlias}' = (${change.mediaQuery})` : '';
  *      };
  *
  *      // Subscribe directly or access observable to use filter/map operators
- *      // e.g. mediaObserver.media$.subscribe(onChange);
+ *      // e.g. media.asObservable().subscribe(onChange);
  *
- *      mediaObserver.media$()
+ *      media.asObservable()
  *        .pipe(
  *          filter((change: MediaChange) => true)   // silly noop filter
  *        ).subscribe(onChange);
@@ -63,12 +63,24 @@ export class MediaObserver {
    * Whether to announce gt-<xxx> breakpoint activations
    */
   filterOverlaps = true;
-  readonly media$: Observable<MediaChange>;
+
+  /**
+   * @deprecated Use `asObservable()` instead.
+   * @deletion-target v7.0.0-beta.23
+   * @breaking-change 7.0.0-beta.23
+   */
+  get media$(): Observable<MediaChange> {
+    return this._media$;
+  }
 
   constructor(protected breakpoints: BreakPointRegistry,
       protected mediaWatcher: MatchMedia,
       protected hook: PrintHook) {
-    this.media$ = this.watchActivations();
+    this._media$ = this.watchActivations();
+  }
+
+  asObservable(): Observable<MediaChange> {
+    return this._media$;
   }
 
   /**
@@ -142,4 +154,6 @@ export class MediaObserver {
     const bp = locator.findByAlias(query) || locator.findByQuery(query);
     return bp ? bp.mediaQuery : query;
   }
+
+  readonly _media$: Observable<MediaChange>;
 }

--- a/src/lib/extended/show-hide/hide.spec.ts
+++ b/src/lib/extended/show-hide/hide.spec.ts
@@ -67,8 +67,8 @@ describe('hide directive', () => {
     });
   });
   afterEach(() => {
-    matchMedia.clearAll();
-  });
+     matchMedia && matchMedia.clearAll();
+    });
 
   describe('without `responsive` features', () => {
 

--- a/src/lib/extended/show-hide/show.spec.ts
+++ b/src/lib/extended/show-hide/show.spec.ts
@@ -349,7 +349,7 @@ describe('show directive', () => {
       });
     });
     afterEach(() => {
-      matchMedia.clearAll();
+     matchMedia && matchMedia.clearAll();
     });
 
     it('should respond to custom breakpoint', () => {

--- a/src/lib/flex/flex/flex.spec.ts
+++ b/src/lib/flex/flex/flex.spec.ts
@@ -7,7 +7,7 @@
  */
 import {Component, Injectable, PLATFORM_ID, ViewChild} from '@angular/core';
 import {CommonModule, isPlatformServer} from '@angular/common';
-import {ComponentFixture, TestBed, inject, fakeAsync, async} from '@angular/core/testing';
+import {ComponentFixture, TestBed, inject, fakeAsync} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
   MatchMedia,
@@ -48,7 +48,7 @@ describe('flex directive', () => {
     })();
   };
 
-  beforeEach(async (() => {
+  beforeEach(() => {
     jasmine.addMatchers(customMatchers);
 
     // Configure testbed to prepare services
@@ -60,14 +60,10 @@ describe('flex directive', () => {
       declarations: [TestFlexComponent, TestQueryWithFlexComponent],
       providers: [MockMatchMediaProvider]
     });
-  }));
-
-  afterEach(() => {
-    matchMedia.clearAll();
   });
 
   afterEach(() => {
-    matchMedia.clearAll();
+    matchMedia && matchMedia.clearAll();
   });
 
   describe('with static features', () => {
@@ -914,7 +910,7 @@ describe('flex directive', () => {
     });
 
     afterEach(() => {
-      matchMedia.clearAll();
+      matchMedia && matchMedia.clearAll();
     });
 
     it('should work with non-direct-parent fxLayouts', fakeAsync(() => {

--- a/src/lib/flex/flex/flex.spec.ts
+++ b/src/lib/flex/flex/flex.spec.ts
@@ -7,7 +7,7 @@
  */
 import {Component, Injectable, PLATFORM_ID, ViewChild} from '@angular/core';
 import {CommonModule, isPlatformServer} from '@angular/common';
-import {ComponentFixture, TestBed, inject, fakeAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed, inject, fakeAsync, async} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
   MatchMedia,
@@ -48,7 +48,7 @@ describe('flex directive', () => {
     })();
   };
 
-  beforeEach(() => {
+  beforeEach(async (() => {
     jasmine.addMatchers(customMatchers);
 
     // Configure testbed to prepare services
@@ -60,6 +60,10 @@ describe('flex directive', () => {
       declarations: [TestFlexComponent, TestQueryWithFlexComponent],
       providers: [MockMatchMediaProvider]
     });
+  }));
+
+  afterEach(() => {
+    matchMedia.clearAll();
   });
 
   afterEach(() => {

--- a/tslint.json
+++ b/tslint.json
@@ -25,7 +25,7 @@
     "no-trailing-whitespace": true,
     "no-bitwise": true,
     "no-shadowed-variable": true,
-    "no-unused-expression": true,
+    "no-unused-expression": [true, "allow-fast-null-checks"],
     "no-var-keyword": true,
     "member-access": [true, "no-public"],
     "no-debugger": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,7 +855,17 @@ agent-base@^4.1.0:
   dependencies:
     es6-promisify "^5.0.0"
 
-ajv@^6.5.2, ajv@^6.5.5, ajv@^6.6.1:
+ajv@^6.5.2, ajv@^6.5.5:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.2.tgz#caceccf474bf3fc3ce3b147443711a24063cc30d"
+  integrity sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.6.1:
   version "6.6.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.1.tgz#6360f5ed0d80f232cc2b294c362d5dc2e538dd61"
   integrity sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==
@@ -2121,10 +2131,15 @@ colors@1.1.2:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
   integrity sha1-FopHAXVran9RoSzgyXv6KMCE7WM=
 
-colors@^1.1.0, colors@^1.1.2:
+colors@^1.1.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.2.tgz#2df8ff573dfbf255af562f8ce7181d6b971a359b"
   integrity sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==
+
+colors@^1.1.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
+  integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
 
 colour@~0.7.1:
   version "0.7.1"
@@ -5596,10 +5611,15 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-is@^3.0.1, is@^3.2.0, is@^3.2.1:
+is@^3.0.1, is@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/is/-/is-3.2.1.tgz#d0ac2ad55eb7b0bec926a5266f6c662aaa83dca5"
   integrity sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=
+
+is@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/is/-/is-3.3.0.tgz#61cff6dd3c4193db94a3d62582072b44e5645d79"
+  integrity sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==
 
 isarray@0.0.1:
   version "0.0.1"
@@ -7007,9 +7027,9 @@ mute-stream@0.0.5:
   integrity sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=
 
 mute-stream@~0.0.4:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
-  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
 nan@^2.0.0, nan@^2.10.0, nan@^2.9.2:
   version "2.11.1"
@@ -8205,7 +8225,12 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@^1.1.24, psl@^1.1.28:
+psl@^1.1.24:
+  version "1.1.31"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
+  integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==
+
+psl@^1.1.28:
   version "1.1.29"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
   integrity sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==
@@ -8767,12 +8792,19 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@2.6.2, rimraf@2.x.x, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.1, rimraf@~2.6.2:
+rimraf@2, rimraf@2.6.2, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.1, rimraf@~2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
   dependencies:
     glob "^7.0.5"
+
+rimraf@2.x.x, rimraf@^2.2.8:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
 
 rimraf@~2.2.6:
   version "2.2.8"
@@ -9389,9 +9421,9 @@ sprintf-js@~1.0.2:
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 sshpk@^1.7.0:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.15.2.tgz#c946d6bd9b1a39d0e8635763f5242d6ed6dcb629"
-  integrity sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.0.tgz#1d4963a2fbffe58050aa9084ca20be81741c07de"
+  integrity sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"


### PR DESCRIPTION
MediaObserver is a service that provides APIs and also publishes an observable to mediaQuery activations.

* Deprecated MediaObserver `media$` property to use instead the `asObservable()` 