### PR TITLE
build: fix SSR flakes and change matchMedia variable name in specs

### DIFF
--- a/src/lib/core/breakpoints/data/orientation-break-points.spec.ts
+++ b/src/lib/core/breakpoints/data/orientation-break-points.spec.ts
@@ -50,7 +50,7 @@ describe('break-point-provider', () => {
     beforeEach(() => {
       // Configure testbed to prepare services
       TestBed.configureTestingModule({
-        imports: [FlexLayoutModule.withConfig({}, EXTRAS)]
+        imports: [FlexLayoutModule.withConfig({serverLoaded: true}, EXTRAS)]
       });
     });
     beforeEach(inject([BREAKPOINTS], (bps: BreakPoint[]) => {
@@ -86,7 +86,10 @@ describe('break-point-provider', () => {
     beforeEach(async (() => {
       // Configure testbed to prepare services
       TestBed.configureTestingModule({
-        imports: [FlexLayoutModule.withConfig({addOrientationBps: true}, EXTRAS)]
+        imports: [FlexLayoutModule.withConfig({
+          addOrientationBps: true,
+          serverLoaded: true,
+        }, EXTRAS)]
       });
     }));
     // tslint:disable-next-line:no-shadowed-variable
@@ -127,7 +130,10 @@ describe('break-point-provider', () => {
     beforeEach(() => {
       // Configure testbed to prepare services
       TestBed.configureTestingModule({
-        imports: [FlexLayoutModule.withConfig({disableDefaultBps: true}, EXTRAS)]
+        imports: [FlexLayoutModule.withConfig({
+          disableDefaultBps: true,
+          serverLoaded: true,
+        }, EXTRAS)]
       });
     });
     beforeEach(inject([BREAKPOINTS], (bps: BreakPoint[]) => {

--- a/src/lib/core/match-media/match-media.spec.ts
+++ b/src/lib/core/match-media/match-media.spec.ts
@@ -14,7 +14,7 @@ import {MatchMedia} from './match-media';
 import {MediaObserver} from '../media-observer/media-observer';
 
 describe('match-media', () => {
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
 
   beforeEach(() => {
     // Configure testbed to prepare services
@@ -24,15 +24,15 @@ describe('match-media', () => {
   });
 
   beforeEach(inject([MatchMedia], (service: MockMatchMedia) => {
-    matchMedia = service;      // inject only to manually activate mediaQuery ranges
+    mediaController = service;      // inject only to manually activate mediaQuery ranges
   }));
   afterEach(() => {
-    matchMedia.clearAll();
+    mediaController.clearAll();
   });
 
   it('can observe the initial, default activation for mediaQuery == "all". ', () => {
     let current: MediaChange = new MediaChange();
-    let subscription = matchMedia
+    let subscription = mediaController
         .observe()
         .subscribe((change: MediaChange) => {
           current = change;
@@ -48,20 +48,20 @@ describe('match-media', () => {
     let query2 = '(min-width: 730px) and (max-width: 950px)';
 
     const queries = [query1, query2];
-    let subscription = matchMedia.observe(queries).subscribe((change: MediaChange) => {
+    let subscription = mediaController.observe(queries).subscribe((change: MediaChange) => {
       current = change;
     });
 
     expect(current.mediaQuery).toEqual('all');    // default mediaQuery is active
-    let activated = matchMedia.activate(query1);    // simulate mediaQuery change to Query1
+    let activated = mediaController.activate(query1);    // simulate mediaQuery change to Query1
     expect(activated).toEqual(true);
     expect(current.mediaQuery).toEqual(query1);
-    expect(matchMedia.isActive(query1)).toBeTruthy();
+    expect(mediaController.isActive(query1)).toBeTruthy();
 
-    activated = matchMedia.activate(query2);        // simulate mediaQuery change to Query2
+    activated = mediaController.activate(query2);        // simulate mediaQuery change to Query2
     expect(activated).toEqual(true);
     expect(current.mediaQuery).toEqual(query2);   // confirm no notification
-    expect(matchMedia.isActive(query2)).toBeTruthy();
+    expect(mediaController.isActive(query2)).toBeTruthy();
 
     subscription.unsubscribe();
   });
@@ -71,20 +71,20 @@ describe('match-media', () => {
     let query1 = 'screen and (min-width: 610px) and (max-width: 620px)';
     let query2 = '(min-width: 730px) and (max-width: 950px)';
 
-    matchMedia.registerQuery([query1, query2]);
+    mediaController.registerQuery([query1, query2]);
 
-    let subscription = matchMedia.observe([query1], true).subscribe((change: MediaChange) => {
+    let subscription = mediaController.observe([query1], true).subscribe((change: MediaChange) => {
       current = change;
     });
 
-    activated = matchMedia.activate(query1);   // simulate mediaQuery change
+    activated = mediaController.activate(query1);   // simulate mediaQuery change
     expect(activated).toEqual(true);
     expect(current.mediaQuery).toEqual(query1);
-    expect(matchMedia.isActive(query1)).toBeTruthy();
+    expect(mediaController.isActive(query1)).toBeTruthy();
 
-    activated = matchMedia.activate(query2);   // simulate mediaQuery change
+    activated = mediaController.activate(query2);   // simulate mediaQuery change
     expect(activated).toEqual(true);
-    expect(matchMedia.isActive(query2)).toBeTruthy();
+    expect(mediaController.isActive(query2)).toBeTruthy();
 
     expect(current.mediaQuery).not.toEqual(query2);   // confirm no notification
     expect(current.mediaQuery).toEqual(query1);
@@ -96,7 +96,7 @@ describe('match-media', () => {
 
 describe('match-media-observable', () => {
   let breakPoints: BreakPointRegistry;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let mediaObserver: MediaObserver;
 
   beforeEach(() => {
@@ -108,20 +108,20 @@ describe('match-media-observable', () => {
 
   beforeEach(inject(
       [MediaObserver, MatchMedia, BreakPointRegistry],
-      (_mediaObserver: MediaObserver, _matchMedia: MockMatchMedia,
+      (_mediaObserver: MediaObserver, _mediaController: MockMatchMedia,
        _breakPoints: BreakPointRegistry) => {
-        matchMedia = _matchMedia;      // inject only to manually activate mediaQuery ranges
+        mediaController = _mediaController; // inject only to manually activate mediaQuery ranges
         breakPoints = _breakPoints;
         mediaObserver = _mediaObserver;
       }));
   afterEach(() => {
-    matchMedia.clearAll();
+    mediaController.clearAll();
   });
 
   it('can observe an existing activation', () => {
     let current: MediaChange = new MediaChange();
     let bp = breakPoints.findByAlias('md')!;
-    matchMedia.activate(bp.mediaQuery);
+    mediaController.activate(bp.mediaQuery);
     let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
       current = change;
     });
@@ -147,8 +147,8 @@ describe('match-media-observable', () => {
       current = change;
     });
 
-    matchMedia.useOverlaps = true;
-    let activated = matchMedia.activate(customQuery);
+    mediaController.useOverlaps = true;
+    let activated = mediaController.activate(customQuery);
     expect(activated).toEqual(true);
     expect(current.mediaQuery).toEqual(customQuery);
 
@@ -162,7 +162,7 @@ describe('match-media-observable', () => {
       current = change;
     });
 
-    let activated = matchMedia.activate(bp.mediaQuery);
+    let activated = mediaController.activate(bp.mediaQuery);
     expect(activated).toEqual(true);
 
     expect(current.mediaQuery).toEqual(bp.mediaQuery);
@@ -187,9 +187,9 @@ describe('match-media-observable', () => {
       }
     });
 
-    matchMedia.activate(breakPoints.findByAlias('md')!.mediaQuery);
-    matchMedia.activate(breakPoints.findByAlias('gt-md')!.mediaQuery);
-    matchMedia.activate(breakPoints.findByAlias('lg')!.mediaQuery);
+    mediaController.activate(breakPoints.findByAlias('md')!.mediaQuery);
+    mediaController.activate(breakPoints.findByAlias('gt-md')!.mediaQuery);
+    mediaController.activate(breakPoints.findByAlias('lg')!.mediaQuery);
 
     // 'all' mediaQuery is already active; total count should be (3)
     expect(activationCount).toEqual(4);

--- a/src/lib/core/match-media/match-media.ts
+++ b/src/lib/core/match-media/match-media.ts
@@ -61,7 +61,7 @@ export class MatchMedia {
    */
   observe(mqList?: string[], filterOthers = false): Observable<MediaChange> {
     if (mqList) {
-      const matchMedia$: Observable<MediaChange> = this._observable$.pipe(
+      const mediaController$: Observable<MediaChange> = this._observable$.pipe(
           filter((change: MediaChange) => {
             return !filterOthers ? true : (mqList.indexOf(change.mediaQuery) > -1);
           })
@@ -77,7 +77,7 @@ export class MatchMedia {
         }
         observer.complete();
       });
-      return merge(registration$, matchMedia$);
+      return merge(registration$, mediaController$);
     }
 
     return this._observable$;
@@ -167,9 +167,9 @@ function buildQueryCss(mediaQueries: string[], _document: Document) {
 }
 
 function constructMql(query: string, isBrowser: boolean): MediaQueryList {
-  const canListen = isBrowser && !!(<any>window).matchMedia('all').addListener;
+  const canListen = isBrowser && !!(<Window>window).matchMedia('all').addListener;
 
-  return canListen ? (<any>window).matchMedia(query) : {
+  return canListen ? (<Window>window).matchMedia(query) : {
     matches: query === 'all' || query === '',
     media: query,
     addListener: () => {

--- a/src/lib/core/match-media/mock/mock-match-media.spec.ts
+++ b/src/lib/core/match-media/mock/mock-match-media.spec.ts
@@ -16,7 +16,7 @@ import {BreakPointRegistry} from '../../breakpoints/break-point-registry';
 
 describe('mock-match-media', () => {
   let breakPoints: BreakPointRegistry;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
 
   beforeEach(() => {
     // Configure testbed to prepare services
@@ -26,28 +26,28 @@ describe('mock-match-media', () => {
   });
 
   beforeEach(inject([MatchMedia, BreakPointRegistry],
-      (_matchMedia: MockMatchMedia, _breakPoints: BreakPointRegistry) => {
-        matchMedia = _matchMedia;
+      (_mediaController: MockMatchMedia, _breakPoints: BreakPointRegistry) => {
+        mediaController = _mediaController;
         breakPoints = _breakPoints;
 
         breakPoints.items.forEach((bp: BreakPoint) => {
-          matchMedia.observe([bp.mediaQuery]);
+          mediaController.observe([bp.mediaQuery]);
         });
       }));
 
   afterEach(() => {
-    matchMedia.clearAll();
+    mediaController.clearAll();
   });
 
   it('can observe custom mediaQuery ranges', () => {
     let current: MediaChange = new MediaChange();
     let customQuery = 'screen and (min-width: 610px) and (max-width: 620px';
-    let subscription = matchMedia.observe([customQuery])
+    let subscription = mediaController.observe([customQuery])
         .subscribe((change: MediaChange) => {
           current = change;
         });
 
-    let activated = matchMedia.activate(customQuery);
+    let activated = mediaController.activate(customQuery);
     expect(activated).toEqual(true);
     expect(current.mediaQuery).toEqual(customQuery);
 
@@ -56,12 +56,12 @@ describe('mock-match-media', () => {
 
   it('can observe a media query change for each breakpoint', () => {
     let current: MediaChange;
-    let subscription = matchMedia.observe().subscribe((change: MediaChange) => {
+    let subscription = mediaController.observe().subscribe((change: MediaChange) => {
       current = change;
     });
 
     breakPoints.items.forEach((bp: BreakPoint) => {
-      matchMedia.activate(bp.mediaQuery);
+      mediaController.activate(bp.mediaQuery);
       expect(current).not.toBeFalsy();
       expect(current.mediaQuery).toEqual(bp.mediaQuery);
     });
@@ -75,22 +75,22 @@ describe('mock-match-media', () => {
         bpGtSM = breakPoints.findByAlias('gt-sm'),
         bpLg = breakPoints.findByAlias('lg');
 
-    let subscription = matchMedia.observe().subscribe((change: MediaChange) => {
+    let subscription = mediaController.observe().subscribe((change: MediaChange) => {
       current = change;
     });
 
-    matchMedia.activate(bpGtSM!.mediaQuery);
+    mediaController.activate(bpGtSM!.mediaQuery);
 
     expect(current).not.toBeFalsy();
     expect(current.mediaQuery).toEqual(bpGtSM!.mediaQuery);
-    expect(matchMedia.isActive(bpGtSM!.mediaQuery)).toBeTruthy();
+    expect(mediaController.isActive(bpGtSM!.mediaQuery)).toBeTruthy();
 
     mqcGtSM = current;
 
-    matchMedia.activate(bpLg!.mediaQuery);
+    mediaController.activate(bpLg!.mediaQuery);
     expect(current.mediaQuery).not.toEqual(mqcGtSM.mediaQuery);
-    expect(matchMedia.isActive(bpLg!.mediaQuery)).toBeTruthy();
-    expect(matchMedia.isActive(bpGtSM!.mediaQuery)).toBeFalsy();
+    expect(mediaController.isActive(bpLg!.mediaQuery)).toBeTruthy();
+    expect(mediaController.isActive(bpGtSM!.mediaQuery)).toBeFalsy();
 
     subscription.unsubscribe();
   });
@@ -99,7 +99,7 @@ describe('mock-match-media', () => {
     let current: MediaChange = new MediaChange(),
         bpGtSM = breakPoints.findByAlias('gt-sm'),
         bpLg = breakPoints.findByAlias('lg');
-    let subscription = matchMedia
+    let subscription = mediaController
         .observe([bpLg!.mediaQuery])
         .subscribe((change: MediaChange) => {
           current = change;
@@ -107,14 +107,14 @@ describe('mock-match-media', () => {
 
     expect(current.matches).toBeTruthy(); // Match 'all'
 
-    matchMedia.activate(bpGtSM!.mediaQuery);
+    mediaController.activate(bpGtSM!.mediaQuery);
 
     expect(current.matches).toBeTruthy();
 
-    matchMedia.activate(bpLg!.mediaQuery);
+    mediaController.activate(bpLg!.mediaQuery);
     expect(current).toBeTruthy();
     expect(current.mediaQuery).toEqual(bpLg!.mediaQuery);
-    expect(matchMedia.isActive(bpLg!.mediaQuery)).toBeTruthy();
+    expect(mediaController.isActive(bpLg!.mediaQuery)).toBeTruthy();
 
     subscription.unsubscribe();
   });
@@ -125,7 +125,7 @@ describe('mock-match-media', () => {
         bpLg = breakPoints.findByAlias('lg');
 
     // By default the 'all' is initially active.
-    let subscription = matchMedia.observe().subscribe((change: MediaChange) => {
+    let subscription = mediaController.observe().subscribe((change: MediaChange) => {
       if (change.matches) {
         ++activates;
       } else {
@@ -135,15 +135,15 @@ describe('mock-match-media', () => {
 
     expect(activates).toEqual(1);
 
-    matchMedia.activate(bpGtSM!.mediaQuery);
+    mediaController.activate(bpGtSM!.mediaQuery);
     expect(activates).toEqual(2);
     expect(deactivates).toEqual(0);
 
-    matchMedia.activate(bpLg!.mediaQuery);
+    mediaController.activate(bpLg!.mediaQuery);
     expect(activates).toEqual(3);
     expect(deactivates).toEqual(1);
 
-    matchMedia.activate(bpGtSM!.mediaQuery);
+    mediaController.activate(bpGtSM!.mediaQuery);
     expect(activates).toEqual(4);
     expect(deactivates).toEqual(2);
 
@@ -155,7 +155,7 @@ describe('mock-match-media', () => {
     let bpGtSM = breakPoints.findByAlias('gt-sm'),
         bpLg = breakPoints.findByAlias('lg');
 
-    let subscription = matchMedia
+    let subscription = mediaController
         .observe([bpGtSM!.mediaQuery], true)
         .subscribe((change: MediaChange) => {
           if (change.matches) {
@@ -166,15 +166,15 @@ describe('mock-match-media', () => {
         });
 
     expect(activates).toEqual(0);   // from alias == '' == 'all'
-    matchMedia.activate(bpGtSM!.mediaQuery);
+    mediaController.activate(bpGtSM!.mediaQuery);
     expect(activates).toEqual(1);
     expect(deactivates).toEqual(0);
 
-    matchMedia.activate(bpLg!.mediaQuery);
+    mediaController.activate(bpLg!.mediaQuery);
     expect(activates).toEqual(1);
     expect(deactivates).toEqual(1);
 
-    matchMedia.activate(bpGtSM!.mediaQuery);
+    mediaController.activate(bpGtSM!.mediaQuery);
     expect(activates).toEqual(2);
     expect(deactivates).toEqual(1);
 
@@ -186,23 +186,23 @@ describe('mock-match-media', () => {
     let bpGtSM = breakPoints.findByAlias('gt-sm'),
         bpLg = breakPoints.findByAlias('lg');
 
-    let subscription = matchMedia.observe().subscribe((change: MediaChange) => {
+    let subscription = mediaController.observe().subscribe((change: MediaChange) => {
       if (change.matches) {
         ++activates;
       }
     });
 
     expect(activates).toEqual(1);   // from alias == '' == 'all'
-    matchMedia.activate(bpGtSM!.mediaQuery);
+    mediaController.activate(bpGtSM!.mediaQuery);
     expect(activates).toEqual(2);
 
-    matchMedia.activate(bpLg!.mediaQuery);
+    mediaController.activate(bpLg!.mediaQuery);
     expect(activates).toEqual(3);
 
-    matchMedia.activate(bpGtSM!.mediaQuery);
+    mediaController.activate(bpGtSM!.mediaQuery);
     expect(activates).toEqual(4);
 
-    matchMedia.activate(bpLg!.mediaQuery);
+    mediaController.activate(bpLg!.mediaQuery);
     expect(activates).toEqual(5);
 
     subscription.unsubscribe();
@@ -216,25 +216,25 @@ describe('mock-match-media', () => {
         bpMd = breakPoints.findByAlias('md'),
         bpGtMd = breakPoints.findByAlias('gt-md'),
         bpLg = breakPoints.findByAlias('lg');
-    let subscription = matchMedia.observe().subscribe(() => {
+    let subscription = mediaController.observe().subscribe(() => {
     });
 
-    matchMedia.activate(bpGtSm!.mediaQuery);
-    expect(matchMedia.isActive(bpGtSm!.mediaQuery)).toBeTruthy();
-    expect(matchMedia.isActive(bpLg!.mediaQuery)).toBeFalsy();
+    mediaController.activate(bpGtSm!.mediaQuery);
+    expect(mediaController.isActive(bpGtSm!.mediaQuery)).toBeTruthy();
+    expect(mediaController.isActive(bpLg!.mediaQuery)).toBeFalsy();
 
-    matchMedia.activate(bpLg!.mediaQuery);
-    expect(matchMedia.isActive(bpGtSm!.mediaQuery)).toBeFalsy();
-    expect(matchMedia.isActive(bpLg!.mediaQuery)).toBeTruthy();
+    mediaController.activate(bpLg!.mediaQuery);
+    expect(mediaController.isActive(bpGtSm!.mediaQuery)).toBeFalsy();
+    expect(mediaController.isActive(bpLg!.mediaQuery)).toBeTruthy();
 
-    matchMedia.activate(bpGtSm!.mediaQuery);
-    expect(matchMedia.isActive(bpXs!.mediaQuery)).toBeFalsy();
-    expect(matchMedia.isActive(bpGtXs!.mediaQuery)).toBeFalsy();
-    expect(matchMedia.isActive(bpSm!.mediaQuery)).toBeFalsy();
-    expect(matchMedia.isActive(bpGtSm!.mediaQuery)).toBeTruthy();
-    expect(matchMedia.isActive(bpMd!.mediaQuery)).toBeFalsy();
-    expect(matchMedia.isActive(bpGtMd!.mediaQuery)).toBeFalsy();
-    expect(matchMedia.isActive(bpLg!.mediaQuery)).toBeFalsy();
+    mediaController.activate(bpGtSm!.mediaQuery);
+    expect(mediaController.isActive(bpXs!.mediaQuery)).toBeFalsy();
+    expect(mediaController.isActive(bpGtXs!.mediaQuery)).toBeFalsy();
+    expect(mediaController.isActive(bpSm!.mediaQuery)).toBeFalsy();
+    expect(mediaController.isActive(bpGtSm!.mediaQuery)).toBeTruthy();
+    expect(mediaController.isActive(bpMd!.mediaQuery)).toBeFalsy();
+    expect(mediaController.isActive(bpGtMd!.mediaQuery)).toBeFalsy();
+    expect(mediaController.isActive(bpLg!.mediaQuery)).toBeFalsy();
 
     subscription.unsubscribe();
   });
@@ -243,15 +243,15 @@ describe('mock-match-media', () => {
     let current: MediaChange = new MediaChange(),
         bpXS = breakPoints.findByAlias('xs');
 
-    matchMedia.activate(bpXS!.mediaQuery);
-    let subscription = matchMedia.observe([bpXS!.mediaQuery])
+    mediaController.activate(bpXS!.mediaQuery);
+    let subscription = mediaController.observe([bpXS!.mediaQuery])
         .subscribe((change: MediaChange) => {
           current = change;
         });
 
     expect(current).toBeTruthy();
     expect(current.mediaQuery).toEqual(bpXS!.mediaQuery);
-    expect(matchMedia.isActive(bpXS!.mediaQuery)).toBeTruthy();
+    expect(mediaController.isActive(bpXS!.mediaQuery)).toBeTruthy();
 
     subscription.unsubscribe();
   });

--- a/src/lib/core/media-marshaller/media-marshaller.spec.ts
+++ b/src/lib/core/media-marshaller/media-marshaller.spec.ts
@@ -14,7 +14,7 @@ import {DEFAULT_CONFIG, LAYOUT_CONFIG} from '../tokens/library-config';
 import {MockMatchMedia, MockMatchMediaProvider} from '../match-media/mock/mock-match-media';
 
 describe('media-marshaller', () => {
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let mediaMarshaller: MediaMarshaller;
 
   describe('with layout printing NOT configured', () => {
@@ -29,29 +29,29 @@ describe('media-marshaller', () => {
 
     beforeEach(inject([MatchMedia, MediaMarshaller],
         (service: MockMatchMedia, marshal: MediaMarshaller) => {
-          matchMedia = service;      // inject only to manually activate mediaQuery ranges
+          mediaController = service;      // inject only to manually activate mediaQuery ranges
           mediaMarshaller = marshal;
         }));
     afterEach(() => {
-      matchMedia.clearAll();
+      mediaController.clearAll();
     });
 
     it('activates when match-media activates', () => {
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expect(mediaMarshaller.onMediaChange).toHaveBeenCalled();
     });
 
     it('doesn\'t trigger onMediaChange for same breakpoint activations', () => {
-      matchMedia.activate('xs');
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
+      mediaController.activate('xs');
       expect(mediaMarshaller.updateStyles).toHaveBeenCalledTimes(1);
     });
 
     it('should set correct activated breakpoint', () => {
-      matchMedia.activate('lg');
+      mediaController.activate('lg');
       expect(mediaMarshaller.activatedAlias).toBe('lg');
 
-      matchMedia.activate('gt-md');
+      mediaController.activate('gt-md');
       expect(mediaMarshaller.activatedAlias).toBe('gt-md');
     });
 
@@ -63,7 +63,7 @@ describe('media-marshaller', () => {
       mediaMarshaller.init(fakeElement, fakeKey, builder);
       mediaMarshaller.setValue(fakeElement, fakeKey, 0, 'xs');
       triggered = false;
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expect(triggered).toBeTruthy();
     });
 
@@ -159,30 +159,30 @@ describe('media-marshaller', () => {
 
     beforeEach(inject([MatchMedia, MediaMarshaller],
         (service: MockMatchMedia, marshal: MediaMarshaller) => {
-          matchMedia = service;      // inject only to manually onMediaChange mediaQuery ranges
+          mediaController = service;      // inject only to manually onMediaChange mediaQuery ranges
           mediaMarshaller = marshal;
         }));
 
     afterEach(() => {
-      matchMedia.clearAll();
+      mediaController.clearAll();
     });
 
     it('call onMediaChange when breakpoint activates', () => {
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expect(mediaMarshaller.onMediaChange).toHaveBeenCalled();
     });
 
     it('doesn\'t call updateStyles() when match-media activates the same breakpoint twice', () => {
-      matchMedia.activate('xs');
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
+      mediaController.activate('xs');
       expect(mediaMarshaller.updateStyles).toHaveBeenCalledTimes(1);
     });
 
     it('should set correct activated breakpoint', () => {
-      matchMedia.activate('lg');
+      mediaController.activate('lg');
       expect(mediaMarshaller.activatedAlias).toBe('lg');
 
-      matchMedia.activate('gt-md');
+      mediaController.activate('gt-md');
       expect(mediaMarshaller.activatedAlias).toBe('gt-md');
     });
 
@@ -194,7 +194,7 @@ describe('media-marshaller', () => {
       mediaMarshaller.init(fakeElement, fakeKey, builder);
       mediaMarshaller.setValue(fakeElement, fakeKey, 0, 'xs');
       triggered = false;
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expect(triggered).toBeTruthy();
     });
 
@@ -270,7 +270,7 @@ describe('media-marshaller', () => {
 
     it('will not propagate "print" events to activate', () => {
       // const smMediaQuery = 'screen and (min-width: 600px) and (max-width: 959px)';
-      matchMedia.activate('print');
+      mediaController.activate('print');
       expect(mediaMarshaller.onMediaChange).not.toHaveBeenCalledWith({mediaQuery: 'print'});
     });
 

--- a/src/lib/core/media-observer/media-observer.spec.ts
+++ b/src/lib/core/media-observer/media-observer.spec.ts
@@ -40,23 +40,23 @@ describe('media-observer', () => {
 
     it('can supports the `.isActive()` API', inject(
       [MediaObserver, MatchMedia],
-      (media: MediaObserver, matchMedia: MockMatchMedia) => {
+      (media: MediaObserver, mediaController: MockMatchMedia) => {
         expect(media).toBeDefined();
 
         // Activate mediaQuery associated with 'md' alias
-        matchMedia.activate('md');
+        mediaController.activate('md');
         expect(media.isActive('md')).toBeTruthy();
 
-        matchMedia.activate('lg');
+        mediaController.activate('lg');
         expect(media.isActive('lg')).toBeTruthy();
         expect(media.isActive('md')).toBeFalsy();
 
-        matchMedia.clearAll();
+        mediaController.clearAll();
       }));
 
     it('can supports RxJS operators', inject(
       [MediaObserver, MatchMedia],
-      (mediaService: MediaObserver, matchMedia: MockMatchMedia) => {
+      (mediaService: MediaObserver, mediaController: MockMatchMedia) => {
         let count = 0,
           subscription = mediaService.media$.pipe(
             filter((change: MediaChange) => change.mqAlias == 'md'),
@@ -67,30 +67,30 @@ describe('media-observer', () => {
 
 
         // Activate mediaQuery associated with 'md' alias
-        matchMedia.activate('sm');
+        mediaController.activate('sm');
         expect(count).toEqual(0);
 
-        matchMedia.activate('md');
+        mediaController.activate('md');
         expect(count).toEqual(1);
 
-        matchMedia.activate('lg');
+        mediaController.activate('lg');
         expect(count).toEqual(1);
 
-        matchMedia.activate('md');
+        mediaController.activate('md');
         expect(count).toEqual(2);
 
-        matchMedia.activate('gt-md');
-        matchMedia.activate('gt-lg');
-        matchMedia.activate('invalid');
+        mediaController.activate('gt-md');
+        mediaController.activate('gt-lg');
+        mediaController.activate('invalid');
         expect(count).toEqual(2);
 
         subscription.unsubscribe();
-        matchMedia.clearAll();
+        mediaController.clearAll();
       }));
 
     it('can subscribe to built-in mediaQueries', inject(
       [MediaObserver, MatchMedia],
-      (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
+      (mediaObserver: MediaObserver, mediaController: MockMatchMedia) => {
         let current: MediaChange = new MediaChange(true);
         let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
           current = change;
@@ -105,70 +105,70 @@ describe('media-observer', () => {
 
         try {
           // Allow overlapping activations to be announced to observers
-          matchMedia.autoRegisterQueries = false;
+          mediaController.autoRegisterQueries = false;
           mediaObserver.filterOverlaps = false;
 
           // Activate mediaQuery associated with 'md' alias
-          matchMedia.activate('md');
+          mediaController.activate('md');
           expect(current.mediaQuery).toEqual(findMediaQuery('md'));
 
-          matchMedia.activate('gt-lg');
+          mediaController.activate('gt-lg');
           expect(current.mediaQuery).toEqual(findMediaQuery('gt-lg'));
 
-          matchMedia.activate('unknown');
+          mediaController.activate('unknown');
           expect(current.mediaQuery).toEqual(findMediaQuery('gt-lg'));
 
         } finally {
-          matchMedia.autoRegisterQueries = true;
+          mediaController.autoRegisterQueries = true;
           subscription.unsubscribe();
 
-          matchMedia.clearAll();
+          mediaController.clearAll();
         }
       }));
 
     it('can `.unsubscribe()` properly', inject(
       [MediaObserver, MatchMedia],
-      (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
+      (mediaObserver: MediaObserver, mediaController: MockMatchMedia) => {
         let current: MediaChange = new MediaChange(true);
         let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
           current = change;
         });
 
         // Activate mediaQuery associated with 'md' alias
-        matchMedia.activate('md');
+        mediaController.activate('md');
         expect(current.mediaQuery).toEqual(findMediaQuery('md'));
 
         // Un-subscribe
         subscription.unsubscribe();
 
-        matchMedia.activate('lg');
+        mediaController.activate('lg');
         expect(current.mqAlias).toBe('md');
 
-        matchMedia.activate('xs');
+        mediaController.activate('xs');
         expect(current.mqAlias).toBe('md');
 
-        matchMedia.clearAll();
+        mediaController.clearAll();
       }));
 
     it('can observe a startup activation of XS', inject(
       [MediaObserver, MatchMedia],
-      (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
+      (mediaObserver: MediaObserver, mediaController: MockMatchMedia) => {
         let current: MediaChange = new MediaChange(true);
         let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
           current = change;
         });
 
         // Activate mediaQuery associated with 'md' alias
-        matchMedia.activate('xs');
+        mediaController.activate('xs');
         expect(current.mediaQuery).toEqual(findMediaQuery('xs'));
 
         // Un-subscribe
         subscription.unsubscribe();
 
-        matchMedia.activate('lg');
+        mediaController.activate('lg');
         expect(current.mqAlias).toBe('xs');
 
-        matchMedia.clearAll();
+        mediaController.clearAll();
       }));
   });
 
@@ -194,27 +194,27 @@ describe('media-observer', () => {
 
     it('can activate custom alias with custom mediaQueries', inject(
       [MediaObserver, MatchMedia],
-      (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
+      (mediaObserver: MediaObserver, mediaController: MockMatchMedia) => {
         let current: MediaChange = new MediaChange(true);
         let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
           current = change;
         });
 
         // Activate mediaQuery associated with 'md' alias
-        matchMedia.activate('sm');
+        mediaController.activate('sm');
         expect(current.mediaQuery).toEqual(smMediaQuery);
 
         // MediaObserver will not announce print events
         // unless a printAlias layout has been configured.
-        matchMedia.activate('slate.xl');
+        mediaController.activate('slate.xl');
         expect(current.mediaQuery).toEqual(superXLQuery);
 
-        matchMedia.activate('tablet-gt-xs');
+        mediaController.activate('tablet-gt-xs');
         expect(current.mqAlias).toBe('tablet-gt-xs');
         expect(current.mediaQuery).toBe(gtXsMediaQuery);
 
         subscription.unsubscribe();
-        matchMedia.clearAll();
+        mediaController.clearAll();
       }));
   });
 
@@ -239,7 +239,7 @@ describe('media-observer', () => {
 
      it('can activate when configured with "md" alias', inject(
        [MediaObserver, MatchMedia],
-       (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
+       (mediaObserver: MediaObserver, mediaController: MockMatchMedia) => {
          let current: MediaChange = new MediaChange(true);
          let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
            current = change;
@@ -247,18 +247,18 @@ describe('media-observer', () => {
 
          try {
 
-           matchMedia.activate('lg');
+           mediaController.activate('lg');
 
            // Activate mediaQuery associated with 'md' alias
-           matchMedia.activate('print');
+           mediaController.activate('print');
            expect(current.mqAlias).toBe('md');
            expect(current.mediaQuery).toEqual(mdMediaQuery);
 
-           matchMedia.activate('sm');
+           mediaController.activate('sm');
            expect(current.mqAlias).toBe('sm');
 
          } finally {
-           matchMedia.clearAll();
+           mediaController.clearAll();
             subscription.unsubscribe();
          }
 
@@ -279,7 +279,7 @@ describe('media-observer', () => {
 
      it('will skip print activation without alias', inject(
        [MediaObserver, MatchMedia],
-       (mediaObserver: MediaObserver, matchMedia: MockMatchMedia) => {
+       (mediaObserver: MediaObserver, mediaController: MockMatchMedia) => {
          let current: MediaChange = new MediaChange(true);
          let subscription = mediaObserver.media$.subscribe((change: MediaChange) => {
            current = change;
@@ -287,20 +287,20 @@ describe('media-observer', () => {
 
          try {
 
-           matchMedia.activate('sm');
+           mediaController.activate('sm');
            expect(current.mqAlias).toBe('sm');
 
            // Activate mediaQuery associated with 'md' alias
-           matchMedia.activate('print');
+           mediaController.activate('print');
            expect(current.mqAlias).toBe('sm');
            expect(current.mediaQuery).toEqual(smMediaQuery);
 
-           matchMedia.activate('xl');
+           mediaController.activate('xl');
            expect(current.mqAlias).toBe('xl');
 
          } finally {
             subscription.unsubscribe();
-            matchMedia.clearAll();
+            mediaController.clearAll();
          }
 
        }));

--- a/src/lib/extended/class/class.spec.ts
+++ b/src/lib/extended/class/class.spec.ts
@@ -23,13 +23,13 @@ import {DefaultClassDirective} from './class';
 
 describe('class directive', () => {
   let fixture: ComponentFixture<any>;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let platformId: Object;
   let createTestComponent = (template: string) => {
     fixture = makeCreateTestComponent(() => TestClassComponent)(template);
 
-    inject([MatchMedia, PLATFORM_ID], (_matchMedia: MockMatchMedia, _platformId: Object) => {
-      matchMedia = _matchMedia;
+    inject([MatchMedia, PLATFORM_ID], (_mediaController: MockMatchMedia, _platformId: Object) => {
+      mediaController = _mediaController;
       platformId = _platformId;
     })();
   };
@@ -54,7 +54,7 @@ describe('class directive', () => {
 
     it(`should apply '${selector}' with '${mq}' media query`, () => {
       createTestComponent(`<div ngClass.${mq}="${selector}"></div>`);
-      matchMedia.activate(mq);
+      mediaController.activate(mq);
       expectNativeEl(fixture).toHaveCssClass(selector);
     });
   });
@@ -76,12 +76,12 @@ describe('class directive', () => {
 
       // the CSS classes listed in the string (space delimited) are added,
       // See https://angular.io/api/common/NgClass
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveCssClass('class0');
       expectNativeEl(fixture).toHaveCssClass('what');
       expectNativeEl(fixture).toHaveCssClass('class2');
 
-      matchMedia.activate('lg');
+      mediaController.activate('lg');
       expectNativeEl(fixture).toHaveCssClass('class0');
       expectNativeEl(fixture).not.toHaveCssClass('what');
       expectNativeEl(fixture).not.toHaveCssClass('class2');
@@ -98,12 +98,12 @@ describe('class directive', () => {
 
       // Object keys are CSS classes that get added when the expression given in
       // the value evaluates to a truthy value, otherwise they are removed.
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).not.toHaveCssClass('class0');
       expectNativeEl(fixture).toHaveCssClass('what');
       expectNativeEl(fixture).toHaveCssClass('class2');
 
-      matchMedia.activate('lg');
+      mediaController.activate('lg');
       expectNativeEl(fixture).toHaveCssClass('class0');
       expectNativeEl(fixture).not.toHaveCssClass('what');
       expectNativeEl(fixture).not.toHaveCssClass('class2');
@@ -118,12 +118,12 @@ describe('class directive', () => {
     expectNativeEl(fixture).toHaveCssClass('existing-class');
     expectNativeEl(fixture).toHaveCssClass('class1');
 
-    matchMedia.activate('xs');
+    mediaController.activate('xs');
     expectNativeEl(fixture).toHaveCssClass('xs-class');
     expectNativeEl(fixture).toHaveCssClass('existing-class');
     expectNativeEl(fixture).not.toHaveCssClass('class1');
 
-    matchMedia.activate('lg');
+    mediaController.activate('lg');
     expectNativeEl(fixture).not.toHaveCssClass('xs-class');
     expectNativeEl(fixture).toHaveCssClass('existing-class');
     expectNativeEl(fixture).toHaveCssClass('class1');
@@ -139,11 +139,11 @@ describe('class directive', () => {
     `);
 
     expectNativeEl(fixture).toHaveCssClass('existing-class');
-    matchMedia.activate('xs');
+    mediaController.activate('xs');
     expectNativeEl(fixture).not.toHaveCssClass('existing-class');
     expectNativeEl(fixture).toHaveCssClass('xs-class');
 
-    matchMedia.activate('lg');
+    mediaController.activate('lg');
     expectNativeEl(fixture).not.toHaveCssClass('xs-class');
     expectNativeEl(fixture).toHaveCssClass('existing-class');
   });
@@ -160,12 +160,12 @@ describe('class directive', () => {
     expectNativeEl(fixture).toHaveCssClass('always');
     expectNativeEl(fixture).toHaveCssClass('existing-class');
 
-    matchMedia.activate('xs');
+    mediaController.activate('xs');
     expectNativeEl(fixture).toHaveCssClass('always');
     expectNativeEl(fixture).toHaveCssClass('existing-class');
     expectNativeEl(fixture).toHaveCssClass('xs-class');
 
-    matchMedia.activate('lg');
+    mediaController.activate('lg');
     expectNativeEl(fixture).toHaveCssClass('always');
     expectNativeEl(fixture).toHaveCssClass('existing-class');
     expectNativeEl(fixture).not.toHaveCssClass('xs-class');
@@ -173,10 +173,10 @@ describe('class directive', () => {
 
   it('should support more than one responsive breakpoint on one element', () => {
     createTestComponent(`<div ngClass.xs="xs-class" ngClass.md="mat-class"></div>`);
-    matchMedia.activate('xs');
+    mediaController.activate('xs');
     expectNativeEl(fixture).toHaveCssClass('xs-class');
     expectNativeEl(fixture).not.toHaveCssClass('mat-class');
-    matchMedia.activate('md');
+    mediaController.activate('md');
     expectNativeEl(fixture).not.toHaveCssClass('xs-class');
     expectNativeEl(fixture).toHaveCssClass('mat-class');
   });
@@ -191,12 +191,12 @@ describe('class directive', () => {
     expectNativeEl(fixture, {hasX1: true, hasX2: true, hasX3: true}).not.toHaveCssClass('x2');
     expectNativeEl(fixture, {hasX1: true, hasX2: true, hasX3: true}).toHaveCssClass('x3');
 
-    matchMedia.activate('X');
+    mediaController.activate('X');
     expectNativeEl(fixture, {hasX1: true, hasX2: false, hasX3: false}).toHaveCssClass('x1');
     expectNativeEl(fixture, {hasX1: true, hasX2: false, hasX3: false}).not.toHaveCssClass('x2');
     expectNativeEl(fixture, {hasX1: true, hasX2: false, hasX3: false}).not.toHaveCssClass('x3');
 
-    matchMedia.activate('md');
+    mediaController.activate('md');
     expectNativeEl(fixture, {hasX1: true, hasX2: false, hasX3: true}).toHaveCssClass('x1');
     expectNativeEl(fixture, {hasX1: true, hasX2: false, hasX3: true}).not.toHaveCssClass('x2');
     expectNativeEl(fixture, {hasX1: true, hasX2: false, hasX3: true}).toHaveCssClass('x3');
@@ -204,7 +204,7 @@ describe('class directive', () => {
 
   it('should work with ngClass array notation', () => {
     createTestComponent(`<div [ngClass.xs]="['xs-1', 'xs-2']"></div>`);
-    matchMedia.activate('xs');
+    mediaController.activate('xs');
     expectNativeEl(fixture).toHaveCssClass('xs-1');
     expectNativeEl(fixture).toHaveCssClass('xs-2');
   });
@@ -215,13 +215,13 @@ describe('class directive', () => {
 
     expectNativeEl(fixture).toHaveCssClass('white');
 
-    matchMedia.activate('xs', true);
+    mediaController.activate('xs', true);
     expectNativeEl(fixture).toHaveCssClass('green');
 
-    matchMedia.activate('sm', true);
+    mediaController.activate('sm', true);
     expectNativeEl(fixture).toHaveCssClass('blue');
 
-    matchMedia.activate('xs', true);
+    mediaController.activate('xs', true);
     expectNativeEl(fixture).toHaveCssClass('green');
   });
 

--- a/src/lib/extended/img-src/img-src.spec.ts
+++ b/src/lib/extended/img-src/img-src.spec.ts
@@ -52,7 +52,7 @@ const DEFAULT_SRC = 'https://dummyimage.com/300x300/c72538/ffffff.png';
 
 describe('img-src directive', () => {
   let fixture: ComponentFixture<any>;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let platformId: Object;
   let styler: StyleUtils;
 
@@ -60,8 +60,8 @@ describe('img-src directive', () => {
     fixture = makeCreateTestComponent(() => TestSrcComponent)(template);
 
     inject([MatchMedia, PLATFORM_ID, StyleUtils],
-        (_matchMedia: MockMatchMedia, _platformId: Object, _styler: StyleUtils) => {
-          matchMedia = _matchMedia;
+        (_mediaController: MockMatchMedia, _platformId: Object, _styler: StyleUtils) => {
+          mediaController = _mediaController;
           platformId = _platformId;
           styler = _styler;
         })();
@@ -191,7 +191,7 @@ describe('img-src directive', () => {
           'content': `url(https://dummyimage.com/300x300/c72538/ffffff.png)`
         }, styler);
 
-        matchMedia.activate('md');
+        mediaController.activate('md');
         fixture.detectChanges();
         expectEl(img).toHaveStyle({
           'content': `url(${SRC_URLS['md'][0]})`
@@ -209,7 +209,7 @@ describe('img-src directive', () => {
       let img = queryFor(fixture, 'img')[0];
       let imgEl = img.nativeElement;
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       fixture.detectChanges();
       expect(imgEl).toBeDefined();
       if (isPlatformServer(platformId)) {
@@ -218,7 +218,7 @@ describe('img-src directive', () => {
         }, styler);
 
         // When activating an unused breakpoint, fallback to default [src] value
-        matchMedia.activate('xl');
+        mediaController.activate('xl');
         fixture.detectChanges();
         expectEl(img).toHaveStyle({
           'content': `url(${SRC_URLS['xs'][0]})`
@@ -229,7 +229,7 @@ describe('img-src directive', () => {
         });
 
         // When activating an unused breakpoint, fallback to default [src] value
-        matchMedia.activate('xl');
+        mediaController.activate('xl');
         fixture.detectChanges();
         expect(imgEl).toHaveAttributes({
           src: SRC_URLS['xs'][0]
@@ -242,7 +242,7 @@ describe('img-src directive', () => {
          <img [src.md]="mdSrc">
        `);
       fixture.detectChanges();
-      matchMedia.activate('md');
+      mediaController.activate('md');
       fixture.detectChanges();
 
       let img = queryFor(fixture, 'img')[0];
@@ -257,7 +257,7 @@ describe('img-src directive', () => {
         }, styler);
 
         // When activating an unused breakpoint, fallback to default [src] value
-        matchMedia.activate('xl');
+        mediaController.activate('xl');
         fixture.detectChanges();
         expectEl(img).not.toHaveStyle({
           'content': `url(${SRC_URLS['md'][0]})`
@@ -271,7 +271,7 @@ describe('img-src directive', () => {
         });
 
         // When activating an unused breakpoint, fallback to default [src] value
-        matchMedia.activate('xl');
+        mediaController.activate('xl');
         fixture.detectChanges();
         expect(imgEl).toHaveAttributes({
           src: ''

--- a/src/lib/extended/show-hide/hide.spec.ts
+++ b/src/lib/extended/show-hide/hide.spec.ts
@@ -27,13 +27,13 @@ import {FlexLayoutModule} from '../../module';
 
 describe('hide directive', () => {
   let fixture: ComponentFixture<any>;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let styler: StyleUtils;
   let createTestComponent = (template: string) => {
     fixture = makeCreateTestComponent(() => TestHideComponent)(template);
 
-    inject([MatchMedia, StyleUtils], (_matchMedia: MockMatchMedia, _styler: StyleUtils) => {
-      matchMedia = _matchMedia;
+    inject([MatchMedia, StyleUtils], (_mediaController: MockMatchMedia, _styler: StyleUtils) => {
+      mediaController = _mediaController;
       styler = _styler;
     })();
 
@@ -43,7 +43,7 @@ describe('hide directive', () => {
     fixture = _fixture;
     return (alias?: string): NgMatchers => {
       if (alias) {
-        matchMedia.activate(alias);
+        mediaController.activate(alias);
       }
       fixture.detectChanges();
 
@@ -67,7 +67,7 @@ describe('hide directive', () => {
     });
   });
   afterEach(() => {
-    matchMedia.clearAll();
+    mediaController.clearAll();
   });
 
   describe('without `responsive` features', () => {
@@ -116,7 +116,7 @@ describe('hide directive', () => {
     it('should use "flex" display style when the element also has an fxLayoutAlign', () => {
       createTestComponent(`<div fxLayout fxLayoutAlign="start center" fxHide.xs></div>`);
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
     });
   });
@@ -127,9 +127,9 @@ describe('hide directive', () => {
       createTestComponent(`<div fxHide="" fxHide.xs="false"></div>`);
 
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
     });
 
@@ -138,11 +138,11 @@ describe('hide directive', () => {
       expectNativeEl(fixture).toHaveStyle({'display': 'inline-block'}, styler);
 
       // should hide with this activation
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
       // should reset to original display style
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({'display': 'inline-block'}, styler);
     });
 
@@ -151,7 +151,7 @@ describe('hide directive', () => {
       expectNativeEl(fixture).toHaveStyle({'display': 'inline-block'}, styler);
 
       // should hide with this activation
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
       // should reset to original display style
@@ -165,11 +165,11 @@ describe('hide directive', () => {
       expectNativeEl(fixture).toHaveStyle(originalDisplay, styler);
 
       // should hide with this activation
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
       // should reset to original display style
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle(originalDisplay, styler);
     });
 
@@ -177,10 +177,10 @@ describe('hide directive', () => {
       createTestComponent(`<div [fxHide]="media.isActive('xs')"></div>`);
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('lg');
+      mediaController.activate('lg');
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
     });
 
@@ -188,10 +188,10 @@ describe('hide directive', () => {
       createTestComponent(`<div fxHide="false" [fxHide.md]="media.isActive('xs')"></div>`);
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
     });
 
@@ -242,7 +242,7 @@ describe('hide directive', () => {
       let expectActivation: any =
         makeExpectWithActivation(createTestComponent(template), '.hideOnXs');
 
-      matchMedia.useOverlaps = true;
+      mediaController.useOverlaps = true;
       expectActivation().not.toHaveStyle({'display': 'none'}, styler);
       expectActivation('xs').toHaveStyle({'display': 'none'}, styler);
       expectActivation('md').not.toHaveStyle({'display': 'none'}, styler);
@@ -258,13 +258,13 @@ describe('hide directive', () => {
           </div>
         `);
 
-      matchMedia.useOverlaps = true;
+      mediaController.useOverlaps = true;
       expectNativeEl(fixture).toHaveStyle({'display': 'inline-block'}, styler);
 
-      matchMedia.activate('print');
+      mediaController.activate('print');
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('sm');
+      mediaController.activate('sm');
       expectNativeEl(fixture).toHaveStyle({'display': 'inline-block'}, styler);
     });
 
@@ -278,16 +278,16 @@ describe('hide directive', () => {
     `);
     expectNativeEl(fixture).toHaveStyle({'display': 'inline-block'}, styler);
 
-    matchMedia.activate('md', true);
+    mediaController.activate('md', true);
     expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
-    matchMedia.activate('sm', true);
+    mediaController.activate('sm', true);
     expectNativeEl(fixture).toHaveStyle({'display': 'inline-block'}, styler);
 
-    matchMedia.activate('xs', true);
+    mediaController.activate('xs', true);
     expectNativeEl(fixture).toHaveStyle({'display': 'inline-block'}, styler);
 
-    matchMedia.activate('print', false);
+    mediaController.activate('print', false);
     expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
   });
 
@@ -300,13 +300,13 @@ describe('hide directive', () => {
     `);
     expectNativeEl(fixture).toHaveStyle({'display': 'flex'}, styler);
 
-    matchMedia.activate('md', true);
+    mediaController.activate('md', true);
     expectNativeEl(fixture).toHaveStyle({'display': 'flex'}, styler);
 
-    matchMedia.activate('print', false);
+    mediaController.activate('print', false);
     expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
-    matchMedia.activate('xs', true);
+    mediaController.activate('xs', true);
     expectNativeEl(fixture).toHaveStyle({'display': 'flex'}, styler);
   });
 
@@ -316,13 +316,13 @@ describe('hide directive', () => {
         This content to be shown ONLY when gt-sm
       </div>
     `);
-    matchMedia.activate('xs');
+    mediaController.activate('xs');
     expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
-    matchMedia.activate('sm');
+    mediaController.activate('sm');
     expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
 
-    matchMedia.activate('xs');
+    mediaController.activate('xs');
     expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
   });
 

--- a/src/lib/extended/show-hide/show.spec.ts
+++ b/src/lib/extended/show-hide/show.spec.ts
@@ -33,15 +33,15 @@ import {ShowHideDirective} from './show-hide';
 
 describe('show directive', () => {
   let fixture: ComponentFixture<any>;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let styler: StyleUtils;
   let platformId: Object;
   let createTestComponent = (template: string) => {
     fixture = makeCreateTestComponent(() => TestShowComponent)(template);
 
     inject([MatchMedia, StyleUtils, PLATFORM_ID],
-      (_matchMedia: MockMatchMedia, _styler: StyleUtils, _platformId: Object) => {
-      matchMedia = _matchMedia;
+      (_mediaController: MockMatchMedia, _styler: StyleUtils, _platformId: Object) => {
+      mediaController = _mediaController;
       styler = _styler;
       platformId = _platformId;
     })();
@@ -117,10 +117,10 @@ describe('show directive', () => {
       createTestComponent(`<div fxShow fxShow.xs="false"></div>`);
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
     });
 
@@ -128,20 +128,20 @@ describe('show directive', () => {
       createTestComponent(`<div fxShow fxShow.gt-xs="false"></div>`);
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('md', true);
+      mediaController.activate('md', true);
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
     });
 
     it('should support use of the `media` observable in templates ', () => {
       createTestComponent(`<div [fxShow]="media.isActive('xs')"></div>`);
 
-      matchMedia.useOverlaps = true;
+      mediaController.useOverlaps = true;
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('gt-md');
+      mediaController.activate('gt-md');
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
     });
 
@@ -152,7 +152,7 @@ describe('show directive', () => {
       expectNativeEl(fixture).toHaveStyle({'display': 'inline-block'}, styler);
 
       // should hide with this activation and setting
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       fixture.componentInstance.isHidden = true;
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
     });
@@ -164,7 +164,7 @@ describe('show directive', () => {
       expectNativeEl(fixture).toHaveStyle(visibleStyle, styler);
 
       // mqActivation but the isHidden == false, so show it
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle(visibleStyle, styler);
 
       // should hide with this activation
@@ -179,11 +179,11 @@ describe('show directive', () => {
       expectNativeEl(fixture).toHaveStyle(visibleStyle, styler);
 
       // should hide with this activation
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
       // should reset to original display style
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle(visibleStyle, styler);
     });
 
@@ -193,13 +193,13 @@ describe('show directive', () => {
           Shown on devices larger than 1200px wide only.
         </div>`);
 
-      matchMedia.activate('gt-lg');
+      mediaController.activate('gt-lg');
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('lg');
+      mediaController.activate('lg');
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('gt-lg');
+      mediaController.activate('gt-lg');
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
     });
 
@@ -214,13 +214,13 @@ describe('show directive', () => {
           </div>
         `);
 
-      matchMedia.useOverlaps = true;
+      mediaController.useOverlaps = true;
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('print');
+      mediaController.activate('print');
       expectNativeEl(fixture).toHaveStyle({'display': 'block'}, styler);
 
-      matchMedia.activate('sm');
+      mediaController.activate('sm');
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
     });
 
@@ -235,16 +235,16 @@ describe('show directive', () => {
         </div>
       `);
 
-      matchMedia.useOverlaps = true;
+      mediaController.useOverlaps = true;
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('lg');
+      mediaController.activate('lg');
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('sm');
+      mediaController.activate('sm');
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('print');
+      mediaController.activate('print');
       expectNativeEl(fixture).toHaveStyle({'display': 'block'}, styler);
     });
 
@@ -257,13 +257,13 @@ describe('show directive', () => {
         </div>
       `);
 
-      matchMedia.useOverlaps = true;
+      mediaController.useOverlaps = true;
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('gt-sm');
+      mediaController.activate('gt-sm');
       expectNativeEl(fixture).toHaveStyle({'display': 'flex'}, styler);
 
-      matchMedia.activate('sm');
+      mediaController.activate('sm');
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
     });
 
@@ -282,7 +282,7 @@ describe('show directive', () => {
 
       const elSelector = '[el]';
 
-      matchMedia.useOverlaps = true;
+      mediaController.useOverlaps = true;
       fixture.detectChanges();
 
       // NOTE: platform-server can't compute display for unknown elements
@@ -296,13 +296,13 @@ describe('show directive', () => {
         }, styler);
       }
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       fixture.detectChanges();
       expectEl(queryFor(fixture, elSelector)[0]).toHaveStyle({
         'display': 'none'
       }, styler);
 
-      matchMedia.activate('lg');
+      mediaController.activate('lg');
       fixture.detectChanges();
       // NOTE: platform-server can't compute display for unknown elements
       if (isPlatformBrowser(platformId)) {
@@ -349,7 +349,7 @@ describe('show directive', () => {
       });
     });
     afterEach(() => {
-      matchMedia.clearAll();
+      mediaController.clearAll();
     });
 
     it('should respond to custom breakpoint', () => {
@@ -359,15 +359,15 @@ describe('show directive', () => {
 
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('sm-md');
+      mediaController.activate('sm-md');
 
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('sm');
+      mediaController.activate('sm');
 
       expectNativeEl(fixture).toHaveStyle({'display': 'none'}, styler);
 
-      matchMedia.activate('sm.lg');
+      mediaController.activate('sm.lg');
 
       expectNativeEl(fixture).not.toHaveStyle({'display': 'none'}, styler);
     });

--- a/src/lib/extended/style/style.spec.ts
+++ b/src/lib/extended/style/style.spec.ts
@@ -25,13 +25,13 @@ import {
 
 describe('style directive', () => {
   let fixture: ComponentFixture<any>;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let styler: StyleUtils;
   let createTestComponent = (template: string) => {
     fixture = makeCreateTestComponent(() => TestStyleComponent)(template);
 
-    inject([MatchMedia, StyleUtils], (_matchMedia: MockMatchMedia, _styler: StyleUtils) => {
-      matchMedia = _matchMedia;
+    inject([MatchMedia, StyleUtils], (_mediaController: MockMatchMedia, _styler: StyleUtils) => {
+      mediaController = _mediaController;
       styler = _styler;
     })();
   };
@@ -59,7 +59,7 @@ describe('style directive', () => {
         <div [ngStyle.${testData.mq}]="${testData.styleStr}">
         </div>
     `);
-      matchMedia.activate(testData.mq);
+      mediaController.activate(testData.mq);
       expectNativeEl(fixture).toHaveStyle(testData.styleObj, styler);
     });
   });
@@ -70,7 +70,7 @@ describe('style directive', () => {
         </div>
     `);
     expectNativeEl(fixture).toHaveStyle({color: 'blue'}, styler);
-    matchMedia.activate('xs');
+    mediaController.activate('xs');
     expectNativeEl(fixture).toHaveStyle({color: 'blue', 'font-size': '15px'}, styler);
   });
 
@@ -82,7 +82,7 @@ describe('style directive', () => {
         </div>
     `);
     expectNativeEl(fixture).toHaveStyle({color: 'blue'}, styler);
-    matchMedia.activate('xs');
+    mediaController.activate('xs');
 
     expectNativeEl(fixture).toHaveStyle({
       'color': 'blue',
@@ -110,16 +110,16 @@ describe('style directive', () => {
 
     fixture.detectChanges();
 
-    matchMedia.activate('xs');
+    mediaController.activate('xs');
     expectNativeEl(fixture).toHaveStyle({'display': 'flex'}, styler);
     expectNativeEl(fixture).toHaveStyle({'font-size': '16px'}, styler);
     expectNativeEl(fixture).not.toHaveStyle({'font-size': '12px'}, styler);
 
-    matchMedia.activate('md');
+    mediaController.activate('md');
     expectNativeEl(fixture).not.toHaveStyle({'font-size': '16px'}, styler);
     expectNativeEl(fixture).toHaveStyle({'font-size': '12px'}, styler);
 
-    matchMedia.activate('lg');
+    mediaController.activate('lg');
     expectNativeEl(fixture).not.toHaveStyle({'font-size': '12px'}, styler);
     expectNativeEl(fixture).not.toHaveStyle({'font-size': '16px'}, styler);
     expectNativeEl(fixture).toHaveStyle({'font-size': '10px'}, styler);  // original is gone
@@ -132,7 +132,7 @@ describe('style directive', () => {
         <div [ngStyle.xs]="{'font-size.px': 15}">
         </div>
     `);
-    matchMedia.activate('xs');
+    mediaController.activate('xs');
     expectNativeEl(fixture).toHaveStyle({'font-size': '15px'}, styler);
   });
 
@@ -141,7 +141,7 @@ describe('style directive', () => {
         <div [ngStyle.xs]="{'font-size.px': fontSize}">
         </div>
     `);
-    matchMedia.activate('xs');
+    mediaController.activate('xs');
     expectNativeEl(fixture, {fontSize: 19}).toHaveStyle({'font-size': '19px'}, styler);
   });
 

--- a/src/lib/flex/flex-order/flex-order.spec.ts
+++ b/src/lib/flex/flex-order/flex-order.spec.ts
@@ -22,13 +22,13 @@ import {expectNativeEl, makeCreateTestComponent} from '../../utils/testing/helpe
 
 describe('flex-order', () => {
   let fixture: ComponentFixture<any>;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let styler: StyleUtils;
   let createTestComponent = (template: string) => {
     fixture = makeCreateTestComponent(() => TestOrderComponent)(template);
 
-    inject([MatchMedia, StyleUtils], (_matchMedia: MockMatchMedia, _styler: StyleUtils) => {
-      matchMedia = _matchMedia;
+    inject([MatchMedia, StyleUtils], (_mediaController: MockMatchMedia, _styler: StyleUtils) => {
+      mediaController = _mediaController;
       styler = _styler;
     })();
   };
@@ -60,11 +60,11 @@ describe('flex-order', () => {
       expectNativeEl(fixture).not.toHaveStyle({
         'order': '1',
       }, styler);
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({
         'order': '1',
       }, styler);
-      matchMedia.activate('sm');
+      mediaController.activate('sm');
       expectNativeEl(fixture).not.toHaveStyle({
         'order': '1',
       }, styler);

--- a/src/lib/flex/flex/flex.spec.ts
+++ b/src/lib/flex/flex/flex.spec.ts
@@ -31,7 +31,7 @@ import {
 
 describe('flex directive', () => {
   let fixture: ComponentFixture<any>;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let styler: StyleUtils;
   let platform: Platform;
   let platformId: Object;
@@ -39,9 +39,9 @@ describe('flex directive', () => {
     fixture = makeCreateTestComponent(() => TestFlexComponent)(template);
 
     inject([MatchMedia, StyleUtils, Platform, PLATFORM_ID],
-      (_matchMedia: MockMatchMedia, _styler: StyleUtils, _platform: Platform,
+      (_mediaController: MockMatchMedia, _styler: StyleUtils, _platform: Platform,
        _platformId: Object) => {
-      matchMedia = _matchMedia;
+      mediaController = _mediaController;
       styler = _styler;
       platform = _platform;
       platformId = _platformId;
@@ -62,11 +62,10 @@ describe('flex directive', () => {
     });
   });
 
-  afterEach(() => {
-    matchMedia.clearAll();
-  });
-
   describe('with static features', () => {
+    afterEach(() => {
+      mediaController.clearAll();
+    });
 
     it('should add correct styles for default `fxFlex` usage', () => {
       componentWithTemplate(`<div fxFlex></div>`);
@@ -85,7 +84,7 @@ describe('flex directive', () => {
         </div>
       `);
       fixture.detectChanges();
-      matchMedia.activate('sm', true);
+      mediaController.activate('sm', true);
       let element = queryFor(fixture, '[fxFlex]')[0];
       expectEl(element).toHaveStyle({'width': '15px'}, styler);
       expectEl(element).toHaveStyle({'box-sizing': 'border-box'}, styler);
@@ -100,7 +99,7 @@ describe('flex directive', () => {
         </div>
       `);
       fixture.detectChanges();
-      matchMedia.activate('sm', true);
+      mediaController.activate('sm', true);
       let element = queryFor(fixture, '[fxFlex]')[0];
       expectEl(element).toHaveStyle({'width': '15px'}, styler);
       expectEl(element).toHaveStyle({'box-sizing': 'border-box'}, styler);
@@ -185,7 +184,7 @@ describe('flex directive', () => {
           <div fxFlex="10 1 auto" [ngStyle.lt-md]="{'width.px': 15}" *ngIf="true"></div>
         </div>
       `);
-      matchMedia.activate('sm', true);
+      mediaController.activate('sm', true);
       fixture.detectChanges();
 
       let element = queryFor(fixture, '[fxFlex]')[0];
@@ -193,7 +192,7 @@ describe('flex directive', () => {
       expectEl(element).toHaveStyle({'box-sizing': 'border-box'}, styler);
       expectEl(element).toHaveStyle({'flex': '10 1 auto'}, styler);
 
-      matchMedia.activate('md', true);
+      mediaController.activate('md', true);
       fixture.detectChanges();
 
       expectEl(element).not.toHaveStyle({'width': '15px'}, styler);
@@ -630,6 +629,10 @@ describe('flex directive', () => {
 
   describe('with responsive features', () => {
 
+    afterEach(() => {
+      mediaController.clearAll();
+    });
+
     it('should initialize the component with the smallest lt-xxx matching breakpoint', () => {
        componentWithTemplate(`
          <div fxFlex="25px"  fxFlex.lt-lg='50%' fxFlex.lt-sm='33%'>
@@ -644,7 +647,7 @@ describe('flex directive', () => {
       }, styler);
 
 
-       matchMedia.activate('xl', true);
+       mediaController.activate('xl', true);
        fixture.detectChanges();
 
        expectNativeEl(fixture).toHaveStyle({
@@ -652,7 +655,7 @@ describe('flex directive', () => {
          'max-width': '25px'
        }, styler);
 
-       matchMedia.activate('md', true);
+       mediaController.activate('md', true);
        fixture.detectChanges();
 
        expectNativeEl(fixture).toHaveStyle({
@@ -660,7 +663,7 @@ describe('flex directive', () => {
          'max-width': '50%'
        }, styler);
 
-      matchMedia.activate('xs', true);
+      mediaController.activate('xs', true);
       fixture.detectChanges();
 
       expectNativeEl(fixture).toHaveStyle({
@@ -680,7 +683,7 @@ describe('flex directive', () => {
         </div>
       `);
 
-      matchMedia.activate('xl', true);
+      mediaController.activate('xl', true);
       fixture.detectChanges();
 
       expectNativeEl(fixture).toHaveStyle({
@@ -688,7 +691,7 @@ describe('flex directive', () => {
         'max-width': '50%'
       }, styler);
 
-      matchMedia.activate('sm', true);
+      mediaController.activate('sm', true);
       fixture.detectChanges();
 
       expectNativeEl(fixture).toHaveStyle({
@@ -706,8 +709,8 @@ describe('flex directive', () => {
         </div>
       `);
 
-      matchMedia.useOverlaps = true;
-      matchMedia.activate('sm');
+      mediaController.useOverlaps = true;
+      mediaController.activate('sm');
       fixture.detectChanges();
 
       let nodes = queryFor(fixture, '[fxFlex]');
@@ -716,7 +719,7 @@ describe('flex directive', () => {
       expectEl(nodes[1]).toHaveStyle({'flex': '1 1 auto'}, styler);
       expectEl(nodes[2]).toHaveStyle({'flex': '1 1 auto'}, styler);
 
-      matchMedia.activate('xl');
+      mediaController.activate('xl');
       fixture.detectChanges();
 
       nodes = queryFor(fixture, '[fxFlex]');
@@ -724,7 +727,7 @@ describe('flex directive', () => {
       expectEl(nodes[1]).toHaveStyle({'flex': '1 1 100%', 'max-height': '24.4%'}, styler);
       expectEl(nodes[2]).toHaveStyle({'flex': '1 1 100%', 'max-height': '25.6%'}, styler);
 
-      matchMedia.activate('sm');
+      mediaController.activate('sm');
       fixture.detectChanges();
 
       nodes = queryFor(fixture, '[fxFlex]');
@@ -750,7 +753,7 @@ describe('flex directive', () => {
         </div>
       `);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       fixture.detectChanges();
       let nodes = queryFor(fixture, '[fxFlex]');
 
@@ -759,7 +762,7 @@ describe('flex directive', () => {
       expectEl(nodes[1]).toHaveStyle({'flex': '1 1 auto'}, styler);
       expectEl(nodes[2]).toHaveStyle({'flex': '1 1 auto'}, styler);
 
-      matchMedia.activate('sm');
+      mediaController.activate('sm');
       fixture.detectChanges();
       nodes = queryFor(fixture, '[fxFlex]');
 
@@ -767,7 +770,7 @@ describe('flex directive', () => {
       expectEl(nodes[1]).toHaveStyle({'flex': '1 1 auto'}, styler);
       expectEl(nodes[2]).toHaveStyle({'flex': '1 1 auto'}, styler);
 
-      matchMedia.activate('lg', true);
+      mediaController.activate('lg', true);
       fixture.detectChanges();
       nodes = queryFor(fixture, '[fxFlex]');
 
@@ -783,14 +786,14 @@ describe('flex directive', () => {
         </div>
       `);
 
-      matchMedia.activate('md', true);
+      mediaController.activate('md', true);
       fixture.detectChanges();
       let nodes = queryFor(fixture, '[fxFlex]');
 
       expect(nodes.length).toEqual(1);
       expectEl(nodes[0]).toHaveStyle({'flex': '1 1 auto'}, styler);
 
-      matchMedia.activate('sm', true);
+      mediaController.activate('sm', true);
       fixture.detectChanges();
       nodes = queryFor(fixture, '[fxFlex]');
 
@@ -799,7 +802,7 @@ describe('flex directive', () => {
         'max-height': '50%'
       }, styler);
 
-      matchMedia.activate('lg', true);
+      mediaController.activate('lg', true);
       fixture.detectChanges();
       nodes = queryFor(fixture, '[fxFlex]');
 
@@ -862,7 +865,7 @@ describe('flex directive', () => {
     );
     it('should restore `fxFlex` value after breakpoint activations',
       inject([MatchMedia, StyleUtils],
-        (_matchMedia: MockMatchMedia, _styler: StyleUtils) => {
+        (_mediaController: MockMatchMedia, _styler: StyleUtils) => {
           fixture = TestBed.createComponent(TestQueryWithFlexComponent);
           fixture.detectChanges();
 
@@ -877,7 +880,7 @@ describe('flex directive', () => {
           expect(nodes.length).toEqual(1);
           expectEl(nodes[0]).toHaveStyle({'max-width': '35%'}, _styler);
 
-          _matchMedia.activate('sm');
+          _mediaController.activate('sm');
           fixture.detectChanges();
 
           // Test for breakpoint value changes
@@ -885,7 +888,7 @@ describe('flex directive', () => {
           nodes = queryFor(fixture, '[fxFlex]');
           expectEl(nodes[0]).toHaveStyle({'max-width': '71%'}, _styler);
 
-          _matchMedia.activate('lg');
+          _mediaController.activate('lg');
           fixture.detectChanges();
 
           // Confirm activatedValue was restored properly when `sm` deactivated
@@ -910,7 +913,7 @@ describe('flex directive', () => {
     });
 
     afterEach(() => {
-      matchMedia.clearAll();
+      mediaController.clearAll();
     });
 
     it('should work with non-direct-parent fxLayouts', fakeAsync(() => {
@@ -949,6 +952,10 @@ describe('flex directive', () => {
         declarations: [TestFlexComponent, TestQueryWithFlexComponent],
         providers: [MockMatchMediaProvider]
       });
+    });
+
+    afterEach(() => {
+      mediaController.clearAll();
     });
 
     it('should work with non-direct-parent fxLayouts', fakeAsync(() => {
@@ -990,6 +997,10 @@ describe('flex directive', () => {
       });
     });
 
+    afterEach(() => {
+      mediaController.clearAll();
+    });
+
     it('should set flex basis to auto', () => {
       componentWithTemplate(`
         <div fxLayout='column'>
@@ -1026,6 +1037,10 @@ describe('flex directive', () => {
           }
         ]
       });
+    });
+
+    afterEach(() => {
+      mediaController.clearAll();
     });
 
     it('should set flex basis to input', fakeAsync(() => {

--- a/src/lib/flex/layout-align/layout-align.spec.ts
+++ b/src/lib/flex/layout-align/layout-align.spec.ts
@@ -27,15 +27,15 @@ import {LayoutAlignStyleBuilder} from './layout-align';
 
 describe('layout-align directive', () => {
   let fixture: ComponentFixture<any>;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let platform: Platform;
   let styler: StyleUtils;
   let createTestComponent = (template: string) => {
     fixture = makeCreateTestComponent(() => TestLayoutAlignComponent)(template);
 
     inject([MatchMedia, Platform, StyleUtils],
-        (_matchMedia: MockMatchMedia, _platform: Platform, _styler: StyleUtils) => {
-          matchMedia = _matchMedia;
+        (_mediaController: MockMatchMedia, _platform: Platform, _styler: StyleUtils) => {
+          mediaController = _mediaController;
           platform = _platform;
           styler = _styler;
         })();
@@ -264,7 +264,7 @@ describe('layout-align directive', () => {
     it('should ignore responsive changes when not configured', () => {
       createTestComponent(`<div fxLayoutAlign='center center'></div>`);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
 
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'center',
@@ -284,7 +284,7 @@ describe('layout-align directive', () => {
         'align-content': 'center'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
 
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'flex-end',
@@ -307,7 +307,7 @@ describe('layout-align directive', () => {
         'max-height': '100%'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
 
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'flex-end',
@@ -327,7 +327,7 @@ describe('layout-align directive', () => {
         'max-height': '100%'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
 
       expectNativeEl(fixture).not.toHaveStyle({
         'max-height': '100%'
@@ -348,14 +348,14 @@ describe('layout-align directive', () => {
         'max-height': '100%'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
 
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'flex-end',
         'max-width': '100%'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
 
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'center',
@@ -370,21 +370,21 @@ describe('layout-align directive', () => {
          </section>
       `);
 
-      matchMedia.activate('lt-md');
+      mediaController.activate('lt-md');
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'center',
         'align-items': 'center',
         'align-content': 'center'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).not.toHaveStyle({
         'justify-content': 'center',
         'align-items': 'center',
         'align-content': 'center'
       }, styler);
 
-      matchMedia.activate('lt-md');
+      mediaController.activate('lt-md');
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'center',
         'align-items': 'center',
@@ -402,40 +402,40 @@ describe('layout-align directive', () => {
           </div>
       `);
 
-      matchMedia.useOverlaps = true;
+      mediaController.useOverlaps = true;
 
       expectNativeEl(fixture).toHaveStyle({
         'flex-direction': 'row',
         'justify-content': 'flex-start'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({
         'flex-direction': 'column',
         'justify-content': 'center'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({
         'flex-direction': 'row',
         'justify-content': 'flex-start'
       }, styler);
 
       // Should fallback to value for 'gt-xs' or default
-      matchMedia.activate('lg', true);
+      mediaController.activate('lg', true);
       expectNativeEl(fixture).toHaveStyle({
         'flex-direction': 'row',
         'justify-content': 'flex-end'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({
         'flex-direction': 'row',
         'justify-content': 'flex-start'
       }, styler);
 
       // Should fallback to value for 'gt-xs' or default
-      matchMedia.activate('xl', true);
+      mediaController.activate('xl', true);
       expectNativeEl(fixture).toHaveStyle({
         'flex-direction': 'row',
         'justify-content': 'flex-end'

--- a/src/lib/flex/layout-gap/layout-gap.spec.ts
+++ b/src/lib/flex/layout-gap/layout-gap.spec.ts
@@ -34,12 +34,12 @@ describe('layout-gap directive', () => {
   let fakeDocument: {body: {dir?: string}, documentElement: {dir?: string}};
   let styler: StyleUtils;
   let platformId: Object;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let createTestComponent = (template: string, styles?: any) => {
     fixture = makeCreateTestComponent(() => TestLayoutGapComponent)(template, styles);
     inject([MatchMedia, StyleUtils, PLATFORM_ID],
-      (_matchMedia: MockMatchMedia, _styler: StyleUtils, _platformId: Object) => {
-      matchMedia = _matchMedia;
+      (_mediaController: MockMatchMedia, _styler: StyleUtils, _platformId: Object) => {
+      mediaController = _mediaController;
       styler = _styler;
       platformId = _platformId;
     })();
@@ -353,7 +353,7 @@ describe('layout-gap directive', () => {
       expectEl(nodes[2]).not.toHaveStyle({'margin-right': '13px'}, styler);
       expectEl(nodes[2]).not.toHaveStyle({'margin-right': '0px'}, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       fixture.detectChanges();
       expectEl(nodes[0]).toHaveStyle({'margin-right': '24px'}, styler);
       expectEl(nodes[1]).toHaveStyle({'margin-right': '24px'}, styler);
@@ -378,7 +378,7 @@ describe('layout-gap directive', () => {
       expectEl(nodes[1]).not.toHaveStyle({'margin-right': '*'}, styler);
       expectEl(nodes[2]).not.toHaveStyle({'margin-right': '*'}, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       fixture.detectChanges();
       expectEl(nodes[0]).toHaveStyle({'margin-right': '24px'}, styler);
       expectEl(nodes[1]).toHaveStyle({'margin-right': '24px'}, styler);
@@ -403,7 +403,7 @@ describe('layout-gap directive', () => {
       expectEl(nodes[1]).toHaveStyle({'margin-right': '24px'}, styler);
       expectEl(nodes[2]).not.toHaveStyle({'margin-right': '*'}, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       fixture.detectChanges();
       expectEl(nodes[0]).toHaveStyle({'margin-bottom': '24px'}, styler);
       expectEl(nodes[1]).toHaveStyle({'margin-bottom': '24px'}, styler);
@@ -427,13 +427,13 @@ describe('layout-gap directive', () => {
       expectEl(nodes[1]).toHaveStyle({'margin-right': '13px'}, styler);
       expectEl(nodes[2]).not.toHaveStyle({'margin-right': '*'}, styler);
 
-      matchMedia.activate('sm');
+      mediaController.activate('sm');
       fixture.detectChanges();
       expectEl(nodes[0]).toHaveStyle({'margin-right': '13px'}, styler);
       expectEl(nodes[1]).not.toHaveStyle({'margin-right': '*'}, styler);
       expectEl(nodes[2]).not.toHaveStyle({'margin-right': '*'}, styler);
 
-      matchMedia.activate('lg');
+      mediaController.activate('lg');
       fixture.detectChanges();
       expectEl(nodes[0]).toHaveStyle({'margin-right': '13px'}, styler);
       expectEl(nodes[1]).toHaveStyle({'margin-right': '13px'}, styler);

--- a/src/lib/flex/layout/layout.spec.ts
+++ b/src/lib/flex/layout/layout.spec.ts
@@ -26,13 +26,13 @@ import {LayoutStyleBuilder} from './layout';
 
 describe('layout directive', () => {
   let fixture: ComponentFixture<any>;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let styler: StyleUtils;
   let createTestComponent = (template: string) => {
     fixture = makeCreateTestComponent(() => TestLayoutComponent)(template);
 
-    inject([MatchMedia, StyleUtils], (_matchMedia: MockMatchMedia, _styler: StyleUtils) => {
-      matchMedia = _matchMedia;
+    inject([MatchMedia, StyleUtils], (_mediaController: MockMatchMedia, _styler: StyleUtils) => {
+      mediaController = _mediaController;
       styler = _styler;
     })();
   };
@@ -224,7 +224,7 @@ describe('layout directive', () => {
 
     it('should ignore responsive changes when not configured', () => {
       createTestComponent(`<div fxLayout='column'></div>`);
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({
         'display': 'flex',
         'flex-direction': 'column',
@@ -240,7 +240,7 @@ describe('layout directive', () => {
         'box-sizing': 'border-box'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({
         'display': 'flex',
         'flex-direction': 'column',
@@ -248,7 +248,7 @@ describe('layout directive', () => {
         'flex-wrap': 'wrap-reverse'
       }, styler);
 
-      matchMedia.activate('lg');
+      mediaController.activate('lg');
       expectNativeEl(fixture).not.toHaveStyle({
         'flex-wrap': 'reverse-wrap'
       }, styler);
@@ -260,11 +260,11 @@ describe('layout directive', () => {
         'flex-direction': 'row'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({
         'flex-direction': 'column'
       }, styler);
-      matchMedia.activate('all');
+      mediaController.activate('all');
       expectNativeEl(fixture).toHaveStyle({
         'flex-direction': 'row'
       }, styler);
@@ -278,7 +278,7 @@ describe('layout directive', () => {
        `);
       expectNativeEl(fixture).toHaveStyle({'flex-direction': 'row'}, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({'flex-direction': 'column'}, styler);
 
       fixture.componentInstance.direction = 'row';
@@ -293,11 +293,11 @@ describe('layout directive', () => {
         'flex-direction': 'row'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({
         'flex-direction': 'column'
       }, styler);
-      matchMedia.activate('lg');
+      mediaController.activate('lg');
       expectNativeEl(fixture).toHaveStyle({
         'flex-direction': 'row'
       }, styler);
@@ -310,17 +310,17 @@ describe('layout directive', () => {
         'flex-direction': 'row'
       }, styler);
 
-      matchMedia.activate('gt-sm');
+      mediaController.activate('gt-sm');
       expectNativeEl(fixture).toHaveStyle({
         'flex-direction': 'column'
       }, styler);
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({
         'flex-direction': 'row'
       }, styler);
 
       // Should fallback to value for 'gt-sm'
-      matchMedia.activate('lg', true);
+      mediaController.activate('lg', true);
       expectNativeEl(fixture).toHaveStyle({
         'flex-direction': 'column'
       }, styler);

--- a/src/lib/grid/align-columns/align-columns.spec.ts
+++ b/src/lib/grid/align-columns/align-columns.spec.ts
@@ -24,7 +24,7 @@ import {GridModule} from '../module';
 
 describe('align columns directive', () => {
   let fixture: ComponentFixture<any>;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let styler: StyleUtils;
   let shouldRun = true;
   let createTestComponent = (template: string) => {
@@ -32,8 +32,8 @@ describe('align columns directive', () => {
     fixture = makeCreateTestComponent(() => TestAlignComponent)(template);
 
     inject([MatchMedia, StyleUtils, Platform],
-      (_matchMedia: MockMatchMedia, _styler: StyleUtils, _platform: Platform) => {
-        matchMedia = _matchMedia;
+      (_mediaController: MockMatchMedia, _styler: StyleUtils, _platform: Platform) => {
+        mediaController = _mediaController;
         styler = _styler;
 
         // TODO(CaerusKaru): Grid tests won't work with Edge 14
@@ -252,7 +252,7 @@ describe('align columns directive', () => {
         return;
       }
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
 
       expectNativeEl(fixture).toHaveStyle({
         'align-content': 'center',
@@ -274,7 +274,7 @@ describe('align columns directive', () => {
         'align-items': 'center'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
 
       expectNativeEl(fixture).toHaveStyle({
         'align-content': 'end',
@@ -298,14 +298,14 @@ describe('align columns directive', () => {
         'align-items': 'stretch'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
 
       expectNativeEl(fixture).toHaveStyle({
         'align-content': 'end',
         'align-items': 'stretch'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
 
       expectNativeEl(fixture).toHaveStyle({
         'align-content': 'center',
@@ -325,35 +325,35 @@ describe('align columns directive', () => {
         return;
       }
 
-      matchMedia.useOverlaps = true;
+      mediaController.useOverlaps = true;
 
       expectNativeEl(fixture).toHaveStyle({
         'align-content': 'start'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({
         'align-content': 'center'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({
         'align-content': 'start'
       }, styler);
 
       // Should fallback to value for 'gt-xs' or default
-      matchMedia.activate('lg', true);
+      mediaController.activate('lg', true);
       expectNativeEl(fixture).toHaveStyle({
         'align-content': 'end'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({
         'align-content': 'start'
       }, styler);
 
       // Should fallback to value for 'gt-xs' or default
-      matchMedia.activate('xl', true);
+      mediaController.activate('xl', true);
       expectNativeEl(fixture).toHaveStyle({
         'align-content': 'end'
       }, styler);

--- a/src/lib/grid/align-rows/align-rows.spec.ts
+++ b/src/lib/grid/align-rows/align-rows.spec.ts
@@ -24,7 +24,7 @@ import {Platform} from '@angular/cdk/platform';
 
 describe('align rows directive', () => {
   let fixture: ComponentFixture<any>;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let styler: StyleUtils;
   let shouldRun = true;
   let createTestComponent = (template: string) => {
@@ -32,8 +32,8 @@ describe('align rows directive', () => {
     fixture = makeCreateTestComponent(() => TestAlignComponent)(template);
 
     inject([MatchMedia, StyleUtils, Platform],
-      (_matchMedia: MockMatchMedia, _styler: StyleUtils, _platform: Platform) => {
-      matchMedia = _matchMedia;
+      (_mediaController: MockMatchMedia, _styler: StyleUtils, _platform: Platform) => {
+      mediaController = _mediaController;
       styler = _styler;
 
         // TODO(CaerusKaru): Grid tests won't work with Edge 14
@@ -252,7 +252,7 @@ describe('align rows directive', () => {
         return;
       }
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
 
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'center',
@@ -274,7 +274,7 @@ describe('align rows directive', () => {
         'justify-items': 'center'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
 
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'end',
@@ -298,14 +298,14 @@ describe('align rows directive', () => {
         'justify-items': 'stretch'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
 
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'end',
         'justify-items': 'stretch'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
 
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'center',
@@ -325,35 +325,35 @@ describe('align rows directive', () => {
         return;
       }
 
-      matchMedia.useOverlaps = true;
+      mediaController.useOverlaps = true;
 
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'start'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'center'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'start'
       }, styler);
 
       // Should fallback to value for 'gt-xs' or default
-      matchMedia.activate('lg', true);
+      mediaController.activate('lg', true);
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'end'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'start'
       }, styler);
 
       // Should fallback to value for 'gt-xs' or default
-      matchMedia.activate('xl', true);
+      mediaController.activate('xl', true);
       expectNativeEl(fixture).toHaveStyle({
         'justify-content': 'end'
       }, styler);

--- a/src/lib/grid/area/area.spec.ts
+++ b/src/lib/grid/area/area.spec.ts
@@ -30,16 +30,16 @@ import {GridModule} from '../module';
 describe('grid area child directive', () => {
   let fixture: ComponentFixture<any>;
   let styler: StyleUtils;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let platform: Platform;
   let shouldRun = true;
   let createTestComponent = (template: string, styles?: any) => {
     shouldRun = true;
     fixture = makeCreateTestComponent(() => TestGridAreaComponent)(template, styles);
     inject([StyleUtils, MatchMedia, Platform],
-      (_styler: StyleUtils, _matchMedia: MockMatchMedia, _platform: Platform) => {
+      (_styler: StyleUtils, _mediaController: MockMatchMedia, _platform: Platform) => {
       styler = _styler;
-      matchMedia = _matchMedia;
+      mediaController = _mediaController;
       platform = _platform;
 
       // TODO(CaerusKaru): Grid tests won't work with Edge 14
@@ -171,7 +171,7 @@ describe('grid area child directive', () => {
         expect(correctArea).toBe(true);
       }
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       if (platform.WEBKIT) {
         expectNativeEl(fixture).toHaveStyle({
           'grid-row-start': 'footer',
@@ -187,7 +187,7 @@ describe('grid area child directive', () => {
         expect(correctArea).toBe(true);
       }
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       if (platform.WEBKIT) {
         expectNativeEl(fixture).toHaveStyle({
           'grid-row-start': 'sidebar',

--- a/src/lib/grid/areas/areas.spec.ts
+++ b/src/lib/grid/areas/areas.spec.ts
@@ -25,16 +25,16 @@ import {GridModule} from '../module';
 describe('grid area parent directive', () => {
   let fixture: ComponentFixture<any>;
   let styler: StyleUtils;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let platform: Platform;
   let shouldRun = true;
   let createTestComponent = (template: string, styles?: any) => {
     shouldRun = true;
     fixture = makeCreateTestComponent(() => TestGridAreaComponent)(template, styles);
     inject([StyleUtils, MatchMedia, Platform],
-      (_styler: StyleUtils, _matchMedia: MockMatchMedia, _platform: Platform) => {
+      (_styler: StyleUtils, _mediaController: MockMatchMedia, _platform: Platform) => {
       styler = _styler;
-      matchMedia = _matchMedia;
+      mediaController = _mediaController;
       platform = _platform;
 
       // TODO(CaerusKaru): Grid tests won't work with Edge 14
@@ -190,13 +190,13 @@ describe('grid area parent directive', () => {
           '"header header header" "sidebar content content" "footer footer footer"'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({
         'display': 'grid',
         'grid-template-areas': '"header header" "sidebar content" "footer footer"'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({
         'display': 'grid',
         'grid-template-areas':

--- a/src/lib/grid/auto/auto.spec.ts
+++ b/src/lib/grid/auto/auto.spec.ts
@@ -25,16 +25,16 @@ import {GridModule} from '../module';
 describe('grid auto parent directive', () => {
   let fixture: ComponentFixture<any>;
   let styler: StyleUtils;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let platform: Platform;
   let shouldRun = true;
   let createTestComponent = (template: string, styles?: any) => {
     shouldRun = true;
     fixture = makeCreateTestComponent(() => TestGridAutoComponent)(template, styles);
     inject([StyleUtils, MatchMedia, Platform],
-      (_styler: StyleUtils, _matchMedia: MockMatchMedia, _platform: Platform) => {
+      (_styler: StyleUtils, _mediaController: MockMatchMedia, _platform: Platform) => {
       styler = _styler;
-      matchMedia = _matchMedia;
+      mediaController = _mediaController;
       platform = _platform;
 
       // TODO(CaerusKaru): Grid tests won't work with Edge 14
@@ -300,13 +300,13 @@ describe('grid auto parent directive', () => {
         'grid-auto-flow': 'row'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({
         'display': 'grid',
         'grid-auto-flow': 'column'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({
         'display': 'grid',
         'grid-auto-flow': 'row'

--- a/src/lib/grid/column/column.spec.ts
+++ b/src/lib/grid/column/column.spec.ts
@@ -29,16 +29,16 @@ import {GridModule} from '../module';
 describe('grid column child directive', () => {
   let fixture: ComponentFixture<any>;
   let styler: StyleUtils;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let platform: Platform;
   let shouldRun = true;
   let createTestComponent = (template: string, styles?: any) => {
     shouldRun = true;
     fixture = makeCreateTestComponent(() => TestGridColumnComponent)(template, styles);
     inject([StyleUtils, MatchMedia, Platform],
-      (_styler: StyleUtils, _matchMedia: MockMatchMedia, _platform: Platform) => {
+      (_styler: StyleUtils, _mediaController: MockMatchMedia, _platform: Platform) => {
       styler = _styler;
-      matchMedia = _matchMedia;
+      mediaController = _mediaController;
       platform = _platform;
 
       // TODO(CaerusKaru): Grid tests won't work with Edge 14
@@ -139,14 +139,14 @@ describe('grid column child directive', () => {
         colStyles === 'sidebar sidebar';
       expect(correctCol).toBe(true);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       colStyles = styler.lookupStyle(fixture.debugElement.children[0].nativeElement,
         'grid-column');
       correctCol = colStyles === 'footer' || colStyles === 'footer / footer' ||
         colStyles === 'footer footer';
       expect(correctCol).toBe(true);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       colStyles = styler.lookupStyle(fixture.debugElement.children[0].nativeElement,
         'grid-column');
       correctCol = colStyles === 'sidebar' || colStyles === 'sidebar / sidebar' ||

--- a/src/lib/grid/columns/columns.spec.ts
+++ b/src/lib/grid/columns/columns.spec.ts
@@ -25,16 +25,16 @@ import {GridModule} from '../module';
 describe('grid columns parent directive', () => {
   let fixture: ComponentFixture<any>;
   let styler: StyleUtils;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let platform: Platform;
   let shouldRun = true;
   let createTestComponent = (template: string, styles?: any) => {
     shouldRun = true;
     fixture = makeCreateTestComponent(() => TestGridColumnsComponent)(template, styles);
     inject([StyleUtils, MatchMedia, Platform],
-      (_styler: StyleUtils, _matchMedia: MockMatchMedia, _platform: Platform) => {
+      (_styler: StyleUtils, _mediaController: MockMatchMedia, _platform: Platform) => {
       styler = _styler;
-      matchMedia = _matchMedia;
+      mediaController = _mediaController;
       platform = _platform;
 
       // TODO(CaerusKaru): Grid tests won't work with Edge 14
@@ -164,13 +164,13 @@ describe('grid columns parent directive', () => {
         'grid-template-columns': '100px 1fr'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({
         'display': 'grid',
         'grid-template-columns': '50px 1fr'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({
         'display': 'grid',
         'grid-template-columns': '100px 1fr'

--- a/src/lib/grid/gap/gap.spec.ts
+++ b/src/lib/grid/gap/gap.spec.ts
@@ -25,16 +25,16 @@ import {GridModule} from '../module';
 describe('grid gap directive', () => {
   let fixture: ComponentFixture<any>;
   let styler: StyleUtils;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let platform: Platform;
   let shouldRun = true;
   let createTestComponent = (template: string, styles?: any) => {
     shouldRun = true;
     fixture = makeCreateTestComponent(() => TestLayoutGapComponent)(template, styles);
     inject([StyleUtils, MatchMedia, Platform],
-      (_styler: StyleUtils, _matchMedia: MockMatchMedia, _platform: Platform) => {
+      (_styler: StyleUtils, _mediaController: MockMatchMedia, _platform: Platform) => {
       styler = _styler;
-      matchMedia = _matchMedia;
+      mediaController = _mediaController;
       platform = _platform;
 
       // TODO(CaerusKaru): Grid tests won't work with Edge 14
@@ -217,7 +217,7 @@ describe('grid gap directive', () => {
         expect(correctGap).toBe(true);
       }
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       if (platform.WEBKIT) {
         expectNativeEl(fixture).toHaveStyle({
           'display': 'grid',
@@ -232,7 +232,7 @@ describe('grid gap directive', () => {
         expect(correctGap).toBe(true);
       }
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       if (platform.WEBKIT) {
         expectNativeEl(fixture).toHaveStyle({
           'display': 'grid',

--- a/src/lib/grid/grid-align/grid-align.spec.ts
+++ b/src/lib/grid/grid-align/grid-align.spec.ts
@@ -24,7 +24,7 @@ import {makeCreateTestComponent, expectNativeEl} from '../../utils/testing/helpe
 
 describe('align directive', () => {
   let fixture: ComponentFixture<any>;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let styler: StyleUtils;
   let shouldRun = true;
   let createTestComponent = (template: string) => {
@@ -32,8 +32,8 @@ describe('align directive', () => {
     fixture = makeCreateTestComponent(() => TestAlignComponent)(template);
 
     inject([MatchMedia, StyleUtils, Platform],
-      (_matchMedia: MockMatchMedia, _styler: StyleUtils, _platform: Platform) => {
-      matchMedia = _matchMedia;
+      (_mediaController: MockMatchMedia, _styler: StyleUtils, _platform: Platform) => {
+      mediaController = _mediaController;
       styler = _styler;
 
       // TODO(CaerusKaru): Grid tests won't work with Edge 14
@@ -207,7 +207,7 @@ describe('align directive', () => {
         return;
       }
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
 
       expectNativeEl(fixture).toHaveStyle({
         'justify-self': 'center',
@@ -229,7 +229,7 @@ describe('align directive', () => {
         'align-self': 'center'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
 
       expectNativeEl(fixture).toHaveStyle({
         'justify-self': 'end',
@@ -253,14 +253,14 @@ describe('align directive', () => {
         'align-self': 'stretch'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
 
       expectNativeEl(fixture).toHaveStyle({
         'justify-self': 'end',
         'align-self': 'stretch'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
 
       expectNativeEl(fixture).toHaveStyle({
         'justify-self': 'center',
@@ -280,35 +280,35 @@ describe('align directive', () => {
         return;
       }
 
-      matchMedia.useOverlaps = true;
+      mediaController.useOverlaps = true;
 
       expectNativeEl(fixture).toHaveStyle({
         'justify-self': 'start'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({
         'justify-self': 'start'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({
         'justify-self': 'center'
       }, styler);
 
       // Should fallback to value for 'gt-xs' or default
-      matchMedia.activate('lg', true);
+      mediaController.activate('lg', true);
       expectNativeEl(fixture).toHaveStyle({
         'justify-self': 'end'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({
         'justify-self': 'start'
       }, styler);
 
       // Should fallback to value for 'gt-xs' or default
-      matchMedia.activate('xl', true);
+      mediaController.activate('xl', true);
       expectNativeEl(fixture).toHaveStyle({
         'justify-self': 'end'
       }, styler);

--- a/src/lib/grid/row/row.spec.ts
+++ b/src/lib/grid/row/row.spec.ts
@@ -29,16 +29,16 @@ import {GridModule} from '../module';
 describe('grid row child directive', () => {
   let fixture: ComponentFixture<any>;
   let styler: StyleUtils;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let platform: Platform;
   let shouldRun = true;
   let createTestComponent = (template: string, styles?: any) => {
     shouldRun = true;
     fixture = makeCreateTestComponent(() => TestGridRowComponent)(template, styles);
     inject([StyleUtils, MatchMedia, Platform],
-      (_styler: StyleUtils, _matchMedia: MockMatchMedia, _platform: Platform) => {
+      (_styler: StyleUtils, _mediaController: MockMatchMedia, _platform: Platform) => {
       styler = _styler;
-      matchMedia = _matchMedia;
+      mediaController = _mediaController;
       platform = _platform;
 
       // TODO(CaerusKaru): Grid tests won't work with Edge 14
@@ -138,14 +138,14 @@ describe('grid row child directive', () => {
         rowStyles === 'sidebar sidebar';
       expect(correctRow).toBe(true);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       rowStyles = styler.lookupStyle(fixture.debugElement.children[0].nativeElement,
         'grid-row');
       correctRow = rowStyles === 'footer' || rowStyles === 'footer / footer' ||
         rowStyles === 'footer footer';
       expect(correctRow).toBe(true);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       rowStyles = styler.lookupStyle(fixture.debugElement.children[0].nativeElement,
         'grid-row');
       correctRow = rowStyles === 'sidebar' || rowStyles === 'sidebar / sidebar' ||

--- a/src/lib/grid/rows/rows.spec.ts
+++ b/src/lib/grid/rows/rows.spec.ts
@@ -25,16 +25,16 @@ import {GridModule} from '../module';
 describe('grid rows parent directive', () => {
   let fixture: ComponentFixture<any>;
   let styler: StyleUtils;
-  let matchMedia: MockMatchMedia;
+  let mediaController: MockMatchMedia;
   let platform: Platform;
   let shouldRun = true;
   let createTestComponent = (template: string, styles?: any) => {
     shouldRun = true;
     fixture = makeCreateTestComponent(() => TestGridRowsComponent)(template, styles);
     inject([StyleUtils, MatchMedia, Platform],
-      (_styler: StyleUtils, _matchMedia: MockMatchMedia, _platform: Platform) => {
+      (_styler: StyleUtils, _mediaController: MockMatchMedia, _platform: Platform) => {
       styler = _styler;
-      matchMedia = _matchMedia;
+      mediaController = _mediaController;
       platform = _platform;
 
       // TODO(CaerusKaru): Grid tests won't work with Edge 14
@@ -164,13 +164,13 @@ describe('grid rows parent directive', () => {
         'grid-template-rows': '100px 1fr'
       }, styler);
 
-      matchMedia.activate('xs');
+      mediaController.activate('xs');
       expectNativeEl(fixture).toHaveStyle({
         'display': 'grid',
         'grid-template-rows': '50px 1fr'
       }, styler);
 
-      matchMedia.activate('md');
+      mediaController.activate('md');
       expectNativeEl(fixture).toHaveStyle({
         'display': 'grid',
         'grid-template-rows': '100px 1fr'

--- a/src/lib/server/server-provider.ts
+++ b/src/lib/server/server-provider.ts
@@ -25,11 +25,11 @@ import {
  * retrieve the associated stylings from the virtual stylesheet
  * @param serverSheet the virtual stylesheet that stores styles for each
  *        element
- * @param matchMedia the service to activate/deactivate breakpoints
+ * @param mediaController the service to activate/deactivate breakpoints
  * @param breakpoints the registered breakpoints to activate/deactivate
  */
 export function generateStaticFlexLayoutStyles(serverSheet: StylesheetMap,
-                                               matchMedia: MatchMedia,
+                                               mediaController: MatchMedia,
                                                breakpoints: BreakPoint[]) {
   // Store the custom classes in the following map, that way only
   // one class gets allocated per HTMLElement, and each class can
@@ -43,12 +43,12 @@ export function generateStaticFlexLayoutStyles(serverSheet: StylesheetMap,
 
   [...breakpoints].sort(sortAscendingPriority).forEach((bp, i) => {
     serverSheet.clearStyles();
-    (matchMedia as ServerMatchMedia).activateBreakpoint(bp);
+    (mediaController as ServerMatchMedia).activateBreakpoint(bp);
     const stylesheet = new Map(serverSheet.stylesheet);
     if (stylesheet.size > 0) {
       styleText += generateCss(stylesheet, bp.mediaQuery, classMap);
     }
-    (matchMedia as ServerMatchMedia).deactivateBreakpoint(breakpoints[i]);
+    (mediaController as ServerMatchMedia).deactivateBreakpoint(breakpoints[i]);
   });
 
   return styleText;
@@ -59,14 +59,14 @@ export function generateStaticFlexLayoutStyles(serverSheet: StylesheetMap,
  * components and attach it to the head of the DOM
  */
 export function FLEX_SSR_SERIALIZER_FACTORY(serverSheet: StylesheetMap,
-                                            matchMedia: MatchMedia,
+                                            mediaController: MatchMedia,
                                             _document: Document,
                                             breakpoints: BreakPoint[]) {
   return () => {
     // This is the style tag that gets inserted into the head of the DOM,
     // populated with the manual media queries
     const styleTag = _document.createElement('style');
-    const styleText = generateStaticFlexLayoutStyles(serverSheet, matchMedia, breakpoints);
+    const styleText = generateStaticFlexLayoutStyles(serverSheet, mediaController, breakpoints);
     styleTag.classList.add(`${CLASS_NAME}ssr`);
     styleTag.textContent = styleText;
     _document.head!.appendChild(styleTag);


### PR DESCRIPTION
Previously, in the Flex directive test, there was a global hook to clear matchMedia activations after all tests. The issue was that the matchMedia service wasn't initialized before certain tests ran, and this would result in flakes depending on the order of operations. This has been patched by moving the clear operation into the individual describe blocks to ensure that the variable has been initialized and is only cleared when used.

This also reformats the name for the `MatchMedia` service to `mediaController`, since `matchMedia` is also a browser global.

Finally, this adds the server token to the orientation breakpoints test to prevent warnings from appearing in the console.