### PR TITLE
fix(core): MediaObserver can report 1..n activations

### DIFF
--- a/src/apps/demo-app/src/app/media-query-status/media-query-status.component.ts
+++ b/src/apps/demo-app/src/app/media-query-status/media-query-status.component.ts
@@ -1,25 +1,25 @@
-import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {Component} from '@angular/core';
 import {MediaChange, MediaObserver} from '@angular/flex-layout';
 import {Observable} from 'rxjs';
 
 @Component({
   selector: 'media-query-status',
   template: `
-    <div class="mqInfo" *ngIf="media$ | async as event">
-      <span title="Active MediaQuery">{{  extractQuery(event) }}</span>
+    <div class="mqInfo">
+      Active MediaQuery(s):
+      <ul>
+        <li *ngFor="let change of (media$ | async) as changes">
+          {{change.mqAlias}} = {{change.mediaQuery}}
+        </li>
+      </ul>
     </div>
   `,
   styleUrls: ['./media-query-status.component.scss'],
-  changeDetection : ChangeDetectionStrategy.OnPush
 })
 export class MediaQueryStatusComponent {
-  media$: Observable<MediaChange>;
+  media$: Observable<MediaChange[]>;
 
-  constructor(mediaObserver: MediaObserver) {
-    this.media$ = mediaObserver.media$;
-  }
-
-  extractQuery(change: MediaChange): string {
-    return change ? `'${change.mqAlias}' = (${change.mediaQuery})` : '';
+  constructor(media: MediaObserver) {
+    this.media$ = media.asObservable();
   }
 }

--- a/src/apps/demo-app/src/app/responsive/responsive-row-column/responsive-row-column.component.ts
+++ b/src/apps/demo-app/src/app/responsive/responsive-row-column/responsive-row-column.component.ts
@@ -17,13 +17,13 @@ export class ResponsiveRowColumnComponent implements OnDestroy {
   };
   isVisible = true;
 
-  private activeMQC: MediaChange;
+  private activeMQC: MediaChange[];
   private subscription: Subscription;
 
-  constructor(mediaObserver: MediaObserver) {
-    this.subscription = mediaObserver.media$
-      .subscribe((e: MediaChange) => {
-        this.activeMQC = e;
+  constructor(mediaService: MediaObserver) {
+    this.subscription = mediaService.asObservable()
+      .subscribe((events: MediaChange[]) => {
+        this.activeMQC = events;
       });
   }
 
@@ -32,16 +32,18 @@ export class ResponsiveRowColumnComponent implements OnDestroy {
   }
 
   toggleLayoutFor(col: number) {
-    switch (col) {
-      case 1:
-        const set1 = `firstCol${this.activeMQC ? this.activeMQC.suffix : ''}`;
-        this.cols[set1] = (this.cols[set1] === 'column') ? 'row' : 'column';
-        break;
+    this.activeMQC.forEach((change: MediaChange) => {
+      switch (col) {
+        case 1:
+            const set1 = `firstCol${change ? change.suffix : ''}`;
+            this.cols[set1] = (this.cols[set1] === 'column') ? 'row' : 'column';
+          break;
 
-      case 2:
-        const set2 = 'secondCol';
-        this.cols[set2] = (this.cols[set2] === 'row') ? 'column' : 'row';
-        break;
-    }
+        case 2:
+          const set2 = 'secondCol';
+          this.cols[set2] = (this.cols[set2] === 'row') ? 'column' : 'row';
+          break;
+      }
+    });
   }
 }

--- a/src/lib/core/add-alias.ts
+++ b/src/lib/core/add-alias.ts
@@ -7,15 +7,18 @@
  */
 import {MediaChange} from './media-change';
 import {BreakPoint} from './breakpoints/break-point';
-import {extendObject} from '../utils/object-extend';
 
 /**
  * For the specified MediaChange, make sure it contains the breakpoint alias
  * and suffix (if available).
  */
 export function mergeAlias(dest: MediaChange, source: BreakPoint | null): MediaChange {
-  return extendObject(dest || {}, source ? {
-        mqAlias: source.alias,
-        suffix: source.suffix
-      } : {});
+  dest = dest ? dest.clone() : new MediaChange();
+  if (source) {
+    dest.mqAlias = source.alias;
+    dest.mediaQuery = source.mediaQuery;
+    dest.suffix = source.suffix as string;
+    dest.priority = source.priority as number;
+  }
+  return dest;
 }

--- a/src/lib/core/match-media/match-media.ts
+++ b/src/lib/core/match-media/match-media.ts
@@ -33,6 +33,19 @@ export class MatchMedia {
   }
 
   /**
+   * Publish list of all current activations
+   */
+  get activations(): string[] {
+    const results: string[] = [];
+    this._registry.forEach((mql: MediaQueryList, key: string) => {
+      if (mql.matches) {
+        results.push(key);
+      }
+    });
+    return results;
+  }
+
+  /**
    * For the specified mediaQuery?
    */
   isActive(mediaQuery: string): boolean {
@@ -60,7 +73,7 @@ export class MatchMedia {
    * subscribers of notifications.
    */
   observe(mqList?: string[], filterOthers = false): Observable<MediaChange> {
-    if (mqList) {
+    if (mqList && mqList.length) {
       const matchMedia$: Observable<MediaChange> = this._observable$.pipe(
           filter((change: MediaChange) => {
             return !filterOthers ? true : (mqList.indexOf(change.mediaQuery) > -1);

--- a/src/lib/core/media-change.ts
+++ b/src/lib/core/media-change.ts
@@ -23,7 +23,8 @@ export class MediaChange {
   constructor(public matches = false,
               public mediaQuery = 'all',
               public mqAlias = '',
-              public suffix = '') {
+              public suffix = '',
+              public priority = 0) {
   }
 
   /** Create an exact copy of the MediaChange */

--- a/src/lib/core/media-observer/media-observer.ts
+++ b/src/lib/core/media-observer/media-observer.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {Injectable} from '@angular/core';
-import {Observable} from 'rxjs';
-import {filter, map} from 'rxjs/operators';
+import {Observable, of} from 'rxjs';
+import {debounceTime, filter, map, switchMap} from 'rxjs/operators';
 
 import {mergeAlias} from '../add-alias';
 import {MediaChange} from '../media-change';
@@ -16,21 +16,19 @@ import {PrintHook} from '../media-marshaller/print-hook';
 import {BreakPointRegistry, OptionalBreakPoint} from '../breakpoints/break-point-registry';
 
 /**
- * Class internalizes a MatchMedia service and exposes an Observable interface.
-
- * This exposes an Observable with a feature to subscribe to mediaQuery
- * changes and a validator method (`isActive(<alias>)`) to test if a mediaQuery (or alias) is
- * currently active.
+ * MediaObserver enables applications to listen for 1..n mediaQuery activations and to determine
+ * if a mediaQuery is currently activated.
  *
- * !! Only mediaChange activations (not de-activations) are announced by the MediaObserver
+ * Since a breakpoint change will first deactivate 1...n mediaQueries and then possibly activate
+ * 1..n mediaQueries, the MediaObserver will debounce notifications and report ALL *activations*
+ * in 1 event notification. The reported activations will be sorted in descending priority order.
  *
  * This class uses the BreakPoint Registry to inject alias information into the raw MediaChange
  * notification. For custom mediaQuery notifications, alias information will not be injected and
  * those fields will be ''.
  *
- * !! This is not an actual Observable. It is a wrapper of an Observable used to publish additional
- * methods like `isActive(<alias>). To access the Observable and use RxJS operators, use
- * `.media$` with syntax like mediaObserver.media$.map(....).
+ * Note: Developers should note that only mediaChange activations (not de-activations)
+ *       are announced by the MediaObserver.
  *
  *  @usage
  *
@@ -43,40 +41,69 @@ import {BreakPointRegistry, OptionalBreakPoint} from '../breakpoints/break-point
  *    status: string = '';
  *
  *    constructor(mediaObserver: MediaObserver) {
- *      const onChange = (change: MediaChange) => {
- *        this.status = change ? `'${change.mqAlias}' = (${change.mediaQuery})` : '';
- *      };
+ *      const media$ = mediaObserver.asObservable().pipe(
+ *        filter((changes: MediaChange[]) => true)   // silly noop filter
+ *      );
  *
- *      // Subscribe directly or access observable to use filter/map operators
- *      // e.g. mediaObserver.media$.subscribe(onChange);
+ *      media$.subscribe((changes: MediaChange[]) => {
+ *        let status = '';
+ *        changes.forEach( change => {
+ *          status += `'${change.mqAlias}' = (${change.mediaQuery}) <br/>` ;
+ *        });
+ *        this.status = status;
+ *     });
  *
- *      mediaObserver.media$()
- *        .pipe(
- *          filter((change: MediaChange) => true)   // silly noop filter
- *        ).subscribe(onChange);
  *    }
  *  }
  */
 @Injectable({providedIn: 'root'})
 export class MediaObserver {
+
   /**
-   * Whether to announce gt-<xxx> breakpoint activations
+   * @deprecated Use `asObservable()` instead.
+   * @breaking-change 7.0.0-beta.24
+   * @deletion-target v7.0.0-beta.25
    */
-  filterOverlaps = true;
-  readonly media$: Observable<MediaChange>;
+  get media$(): Observable<MediaChange> {
+    return this._media$.pipe(
+      filter((changes: MediaChange[]) => changes.length > 0),
+      map((changes: MediaChange[]) => changes[0])
+    );
+  }
+
+  /** Filter MediaChange notifications for overlapping breakpoints */
+  filterOverlaps = false;
 
   constructor(protected breakpoints: BreakPointRegistry,
-      protected mediaWatcher: MatchMedia,
-      protected hook: PrintHook) {
-    this.media$ = this.watchActivations();
+              protected matchMedia: MatchMedia,
+              protected hook: PrintHook) {
+    this._media$ = this.watchActivations();
+  }
+
+
+  // ************************************************
+  // Public Methods
+  // ************************************************
+
+  /**
+   * Observe changes to current activation 'list'
+   */
+  asObservable(): Observable<MediaChange[]> {
+    return this._media$;
   }
 
   /**
-   * Test if specified query/alias is active.
+   * Allow programmatic query to determine if specified query/alias is active.
    */
   isActive(alias: string): boolean {
-    return this.mediaWatcher.isActive(this.toMediaQuery(alias));
+    const query = toMediaQuery(alias, this.breakpoints);
+    return this.matchMedia.isActive(query);
   }
+
+  /**
+   * Subscribers to activation list can use this function to easily exclude overlaps
+   */
+
 
   // ************************************************
   // Internal Methods
@@ -93,53 +120,79 @@ export class MediaObserver {
   }
 
   /**
-   * Prepare internal observable
+   * Only pass/announce activations (not de-activations)
+   *
+   * Since multiple-mediaQueries can be activation in a cycle,
+   * gather all current activations into a single list of changes to observers
+   *
+   * Inject associated (if any) alias information into the MediaChange event
+   * - Exclude mediaQuery activations for overlapping mQs. List bounded mQ ranges only
+   * - Exclude print activations that do not have an associated mediaQuery
    *
    * NOTE: the raw MediaChange events [from MatchMedia] do not
    *       contain important alias information; as such this info
    *       must be injected into the MediaChange
    */
-  private buildObservable(mqList: string[]): Observable<MediaChange> {
-    const locator = this.breakpoints;
-    const onlyActivations = (change: MediaChange) => change.matches;
-    const excludeUnknown = (change: MediaChange) => change.mediaQuery !== '';
-    const excludeCustomPrints = (change: MediaChange) => !change.mediaQuery.startsWith('print');
-    const excludeOverlaps = (change: MediaChange) => {
-      const bp = locator.findByQuery(change.mediaQuery);
-      return !bp ? true : !(this.filterOverlaps && bp.overlapping);
+  private buildObservable(mqList: string[]): Observable<MediaChange[]> {
+    const hasChanges = (changes: MediaChange[]) => {
+      const isValidQuery = (change: MediaChange) => (change.mediaQuery.length > 0);
+      return (changes.filter(isValidQuery).length > 0);
     };
-    const replaceWithPrintAlias = (change: MediaChange) => {
-      if (this.hook.isPrintEvent(change)) {
-        // replace with aliased substitute (if configured)
-        return this.hook.updateEvent(change);
-      }
-      let bp: OptionalBreakPoint = locator.findByQuery(change.mediaQuery);
-      return mergeAlias(change, bp);
+    const excludeOverlaps = (changes: MediaChange[]) => {
+      return !this.filterOverlaps ? changes : changes.filter(change => {
+        const bp = this.breakpoints.findByQuery(change.mediaQuery);
+        return !bp ? true : !bp.overlapping;
+      });
     };
 
     /**
-     * Only pass/announce activations (not de-activations)
-     *
-     * Inject associated (if any) alias information into the MediaChange event
-     * - Exclude mediaQuery activations for overlapping mQs. List bounded mQ ranges only
-     * - Exclude print activations that do not have an associated mediaQuery
      */
-    return this.mediaWatcher.observe(this.hook.withPrintQuery(mqList))
+    return this.matchMedia
+        .observe(this.hook.withPrintQuery(mqList))
         .pipe(
-            filter(onlyActivations),
-            filter(excludeOverlaps),
-            map(replaceWithPrintAlias),
-            filter(excludeCustomPrints),
-            filter(excludeUnknown)
+            filter((change: MediaChange) => change.matches),
+            debounceTime(10),
+            switchMap(_ => of(this.findAllActivations())),
+            map(excludeOverlaps),
+            filter(hasChanges)
         );
   }
 
   /**
-   * Find associated breakpoint (if any)
+   * Find all current activations and prepare single list of activations
+   * sorted by descending priority.
    */
-  private toMediaQuery(query: string) {
-    const locator = this.breakpoints;
-    const bp = locator.findByAlias(query) || locator.findByQuery(query);
-    return bp ? bp.mediaQuery : query;
+  private findAllActivations(): MediaChange[] {
+    const mergeMQAlias = (change: MediaChange) => {
+      let bp: OptionalBreakPoint = this.breakpoints.findByQuery(change.mediaQuery);
+      return mergeAlias(change, bp);
+    };
+    const replaceWithPrintAlias = (change: MediaChange) => {
+      return this.hook.isPrintEvent(change) ? this.hook.updateEvent(change) : change;
+    };
+
+    return this.matchMedia
+        .activations
+        .map(query => new MediaChange(true, query))
+        .map(replaceWithPrintAlias)
+        .map(mergeMQAlias)
+        .sort(sortChangesByPriority);
   }
+
+  private _media$: Observable<MediaChange[]>;
+}
+
+/**
+ * Find associated breakpoint (if any)
+ */
+function toMediaQuery(query: string, locator: BreakPointRegistry) {
+  const bp = locator.findByAlias(query) || locator.findByQuery(query);
+  return bp ? bp.mediaQuery : query;
+}
+
+/** HOF to sort the breakpoints by priority */
+export function sortChangesByPriority(a: MediaChange, b: MediaChange): number {
+  const priorityA = a ? a.priority || 0 : 0;
+  const priorityB = b ? b.priority || 0 : 0;
+  return priorityB - priorityA;
 }

--- a/src/lib/core/public-api.ts
+++ b/src/lib/core/public-api.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export * from './browser-provider';
 export * from './module';
+export * from './browser-provider';
 export * from './media-change';
 export * from './stylesheet-map/index';
 export * from './tokens/index';
+export * from './add-alias';
 
 export * from './base/index';
 export * from './breakpoints/index';

--- a/tslint.json
+++ b/tslint.json
@@ -25,7 +25,7 @@
     "no-trailing-whitespace": true,
     "no-bitwise": true,
     "no-shadowed-variable": true,
-    "no-unused-expression": true,
+    "no-unused-expression": [true],
     "no-var-keyword": true,
     "member-access": [true, "no-public"],
     "no-debugger": true,


### PR DESCRIPTION
Previous versions of MediaObserver suffered from a significant design-flaw. 

Those versions assumed that a breakpoint change would only activate/match a single mediaQuery. Additionally those versions would not (by default) report overlapping activations. Applications interested in notifications for all current activations would therefore not receive proper event-notifications.

The current enhancements provide several features:

* Report 1..n mediaQuery activations (matches == true) in a single event
* Report activations sorted by descending priority
* By default, reports include overlapping breakpoint activations
* Debounce notifications to a single grouped event
  > useful to reduce browser reflow thrashing

BREAKING CHANGE:

The stream data type is now **MediaChange[]** instead of *MediaChange* and`media$` is deprecated in favor of `asObservable()`. 

* `filterOverlaps` now defaults to `false`
* `media$` is now a `Observable< MediaChange[] >` instead of `Observable< MediaChange >`
