### PR TITLE
feat(core): implement MediaTrigger to allow manual activations

### DIFF
--- a/src/lib/core/README.md
+++ b/src/lib/core/README.md
@@ -1,8 +1,8 @@
 The `core` entrypoint contains all of the common utilities to build Layout 
-components. Its primary exports are the `MediaQuery` utilities (`MatchMedia`,
-`MediaObserver`) and the module that encapsulates the imports of these
+components. Its primary exports are the `MediaQuery` utility 
+`MediaObserver` and the module that encapsulates the imports of these
 providers, the `CoreModule`, and the base directive for layout
-components, `BaseDirective`. These utilies can be imported separately
+components, `BaseDirective2`. These utilities can be imported separately
 from the root module to take advantage of tree shaking.
 
 ```typescript
@@ -19,7 +19,7 @@ export class AppModule {}
 ```
 
 ```typescript
-import {BaseDirective} from '@angular/flex-layout/core';
+import {BaseDirective2} from '@angular/flex-layout/core';
 
-export class NewLayoutDirective extends BaseDirective {}
+export class NewLayoutDirective extends BaseDirective2 {}
 ```

--- a/src/lib/core/media-trigger/index.ts
+++ b/src/lib/core/media-trigger/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './media-trigger';

--- a/src/lib/core/media-trigger/media-trigger.spec.ts
+++ b/src/lib/core/media-trigger/media-trigger.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {TestBed, inject, fakeAsync, tick} from '@angular/core/testing';
+
+import {MediaTrigger} from './media-trigger';
+import {MediaChange} from '../media-change';
+import {MatchMedia} from '../match-media/match-media';
+import {MockMatchMedia, MockMatchMediaProvider} from '../match-media/mock/mock-match-media';
+import {MediaObserver} from '../media-observer/media-observer';
+
+describe('media-trigger', () => {
+  let mediaObserver: MediaObserver;
+  let mediaTrigger: MediaTrigger;
+  let matchMedia: MockMatchMedia;
+
+  const activateQuery = (aliases: string[]) => {
+    mediaTrigger.activate(aliases);
+    tick(100);  // Since MediaObserver has 50ms debounceTime
+  };
+
+  describe('', () => {
+    beforeEach(() => {
+      // Configure testbed to prepare services
+      TestBed.configureTestingModule({
+        providers: [
+          MockMatchMediaProvider,
+          MediaTrigger
+        ]
+      });
+    });
+
+    beforeEach(inject([MediaObserver, MediaTrigger, MatchMedia],
+        (_mediaObserver: MediaObserver, _mediaTrigger: MediaTrigger, _matchMedia: MockMatchMedia) => { // tslint:disable-line:max-line-length
+          mediaObserver = _mediaObserver;
+          mediaTrigger = _mediaTrigger;
+          matchMedia = _matchMedia;
+
+          _matchMedia.useOverlaps = true;
+        }));
+
+    it('can trigger activations with list of breakpoint aliases', fakeAsync(() => {
+      let activations: MediaChange[] = [];
+      let subscription = mediaObserver.asObservable().subscribe(
+          (changes: MediaChange[]) => {
+            activations = [...changes];
+          });
+
+      // assign default activation(s) with overlaps allowed
+      matchMedia.activate('xl');
+      const originalActivations = matchMedia.activations.length;
+
+      // Activate mediaQuery associated with 'md' alias
+      activateQuery(['sm']);
+      expect(activations.length).toEqual(1);
+      expect(activations[0].mqAlias).toEqual('sm');
+
+      // Activations are sorted by descending priority
+      activateQuery(['lt-lg', 'md']);
+      expect(activations.length).toEqual(2);
+      expect(activations[0].mqAlias).toEqual('md');
+      expect(activations[1].mqAlias).toEqual('lt-lg');
+
+      // Clean manual activation overrides
+      mediaTrigger.restore();
+      tick(100);
+      expect(activations.length).toEqual(originalActivations);
+
+      subscription.unsubscribe();
+    }));
+  });
+});

--- a/src/lib/core/media-trigger/media-trigger.ts
+++ b/src/lib/core/media-trigger/media-trigger.ts
@@ -1,0 +1,205 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
+import {DOCUMENT, isPlatformBrowser} from '@angular/common';
+
+import {fromEvent, Subscription} from 'rxjs';
+import {take} from 'rxjs/operators';
+
+import {mergeAlias} from '../add-alias';
+import {MediaChange} from '../media-change';
+import {MatchMedia} from '../match-media/match-media';
+import {BreakPointRegistry, OptionalBreakPoint} from '../breakpoints/break-point-registry';
+import {sortDescendingPriority} from '../utils/sort';
+import {LAYOUT_CONFIG, LayoutConfigOptions} from '../tokens/library-config';
+
+/**
+ * Class
+ */
+@Injectable({providedIn: 'root'})
+export class MediaTrigger {
+
+  constructor(
+      protected breakpoints: BreakPointRegistry,
+      protected matchMedia: MatchMedia,
+      @Inject(LAYOUT_CONFIG) protected layoutConfig: LayoutConfigOptions,
+      @Inject(PLATFORM_ID) protected _platformId: Object,
+      @Inject(DOCUMENT) protected _document: any) {
+  }
+
+  /**
+   * Manually activate range of breakpoints
+   * @param list array of mediaQuery or alias strings
+   */
+  activate(list: string[]) {
+    list = list.map(it => it.trim()); // trim queries
+
+    this.saveActivations();
+    this.deactivateAll();
+    this.setActivations(list);
+
+    this.prepareAutoRestore();
+  }
+
+  /**
+   * Restore original, 'real' breakpoints and emit events
+   * to trigger stream notification
+   */
+  restore() {
+    if (this.hasCachedRegistryMatches) {
+      const extractQuery = (change: MediaChange) => change.mediaQuery;
+      const list = this.originalActivations.map(extractQuery);
+      try {
+
+        this.deactivateAll();
+        this.restoreRegistryMatches();
+        this.setActivations(list);
+
+      } finally {
+        this.originalActivations = [];
+        if (this.resizeSubscription) {
+          this.resizeSubscription.unsubscribe();
+        }
+      }
+    }
+  }
+
+  // ************************************************
+  // Internal Methods
+  // ************************************************
+
+  /**
+   * Whenever window resizes, immediately auto-restore original
+   * activations (if we are simulating activations)
+   */
+  private prepareAutoRestore() {
+    const isBrowser = isPlatformBrowser(this._platformId) && this._document;
+    const enableAutoRestore = isBrowser && this.layoutConfig.mediaTriggerAutoRestore;
+
+    if (enableAutoRestore) {
+      const resize$ = fromEvent(window, 'resize').pipe(take(1));
+      this.resizeSubscription = resize$.subscribe(this.restore.bind(this));
+    }
+  }
+
+  /**
+   * Notify all matchMedia subscribers of de-activations
+   *
+   * Note: we must force 'matches' updates for
+   *       future matchMedia::activation lookups
+   */
+  private deactivateAll() {
+    const list = this.currentActivations;
+
+    this.forceRegistryMatches(list, false);
+    this.simulateMediaChanges(list, false);
+  }
+
+  /**
+   * Cache current activations as sorted, prioritized list of MediaChanges
+   */
+  private saveActivations() {
+    if (!this.hasCachedRegistryMatches) {
+      const toMediaChange = (query: string) => new MediaChange(true, query);
+      const mergeMQAlias = (change: MediaChange) => {
+        const bp: OptionalBreakPoint = this.breakpoints.findByQuery(change.mediaQuery);
+        return mergeAlias(change, bp);
+      };
+
+      this.originalActivations = this.currentActivations
+          .map(toMediaChange)
+          .map(mergeMQAlias)
+          .sort(sortDescendingPriority);
+
+      this.cacheRegistryMatches();
+    }
+  }
+
+  /**
+   * Force set manual activations for specified mediaQuery list
+   */
+  private setActivations(list: string[]) {
+    if (!!this.originalRegistry) {
+      this.forceRegistryMatches(list, true);
+    }
+    this.simulateMediaChanges(list);
+  }
+
+  /**
+   * For specified mediaQuery list manually simulate activations or deactivations
+   */
+  private simulateMediaChanges(queries: string[], matches = true) {
+    const toMediaQuery = (query: string) => {
+      const locator = this.breakpoints;
+      const bp = locator.findByAlias(query) || locator.findByQuery(query);
+      return bp ? bp.mediaQuery : query;
+    };
+    const emitChangeEvent = (query: string) => this.emitChangeEvent(matches, query);
+
+    queries.map(toMediaQuery).forEach(emitChangeEvent);
+  }
+
+  /**
+   * Replace current registry with simulated registry...
+   * Note: this is required since MediaQueryList::matches is 'readOnly'
+   */
+  private forceRegistryMatches(queries: string[], matches: boolean) {
+    const registry = new Map<string, MediaQueryList>();
+    queries.forEach(query => {
+      registry.set(query, {matches: matches} as MediaQueryList);
+    });
+
+    this.matchMedia.registry = registry;
+  }
+
+  /**
+   * Save current MatchMedia::registry items.
+   */
+  private cacheRegistryMatches() {
+    const target = this.originalRegistry;
+
+    target.clear();
+    this.matchMedia.registry.forEach((value: MediaQueryList, key: string) => {
+      target.set(key, value);
+    });
+    this.hasCachedRegistryMatches = true;
+  }
+
+  /**
+   * Restore original, 'true' registry
+   */
+  private restoreRegistryMatches() {
+    const target = this.matchMedia.registry;
+
+    target.clear();
+    this.originalRegistry.forEach((value: MediaQueryList, key: string) => {
+      target.set(key, value);
+    });
+
+    this.originalRegistry.clear();
+    this.hasCachedRegistryMatches = false;
+  }
+
+  /**
+   * Manually emit a MediaChange event via the MatchMedia to MediaMarshaller and MediaObserver
+   */
+  private emitChangeEvent(matches: boolean, query: string) {
+    this.matchMedia.source.next(new MediaChange(matches, query));
+  }
+
+  private get currentActivations() {
+    return this.matchMedia.activations;
+  }
+
+  private hasCachedRegistryMatches = false;
+  private originalActivations: MediaChange[] = [];
+  private originalRegistry: Map<string, MediaQueryList> = new Map<string, MediaQueryList>();
+
+  private resizeSubscription!: Subscription;
+}
+

--- a/src/lib/core/public-api.ts
+++ b/src/lib/core/public-api.ts
@@ -21,6 +21,7 @@ export {
   MockMatchMediaProvider as ɵMockMatchMediaProvider,
 } from './match-media/index';
 export * from './media-observer/index';
+export * from './media-trigger/index';
 export * from './utils/index';
 
 export * from './style-utils/style-utils';

--- a/src/lib/core/tokens/library-config.ts
+++ b/src/lib/core/tokens/library-config.ts
@@ -16,6 +16,7 @@ export interface LayoutConfigOptions {
   serverLoaded?: boolean;
   useColumnBasisZero?: boolean;
   printWithBreakpoints?: string[];
+  mediaTriggerAutoRestore?: boolean;
 }
 
 export const DEFAULT_CONFIG: LayoutConfigOptions = {
@@ -25,11 +26,12 @@ export const DEFAULT_CONFIG: LayoutConfigOptions = {
   disableVendorPrefixes: false,
   serverLoaded: false,
   useColumnBasisZero: true,
-  printWithBreakpoints: []
+  printWithBreakpoints: [],
+  mediaTriggerAutoRestore: true
 };
 
 export const LAYOUT_CONFIG = new InjectionToken<LayoutConfigOptions>(
-  'Flex Layout token, config options for the library', {
-    providedIn: 'root',
-    factory: () => DEFAULT_CONFIG
-  });
+    'Flex Layout token, config options for the library', {
+      providedIn: 'root',
+      factory: () => DEFAULT_CONFIG
+    });

--- a/src/lib/server/server-match-media.ts
+++ b/src/lib/server/server-match-media.ts
@@ -111,8 +111,6 @@ export class ServerMediaQueryList implements MediaQueryList {
  */
 @Injectable()
 export class ServerMatchMedia extends MatchMedia {
-  protected _registry: Map<string, ServerMediaQueryList> = new Map();
-
   constructor(protected _zone: NgZone,
               @Inject(PLATFORM_ID) protected _platformId: Object,
               @Inject(DOCUMENT) protected _document: any) {
@@ -121,7 +119,7 @@ export class ServerMatchMedia extends MatchMedia {
 
   /** Activate the specified breakpoint if we're on the server, no-op otherwise */
   activateBreakpoint(bp: BreakPoint) {
-    const lookupBreakpoint = this._registry.get(bp.mediaQuery);
+    const lookupBreakpoint = this.registry.get(bp.mediaQuery) as ServerMediaQueryList;
     if (lookupBreakpoint) {
       lookupBreakpoint.activate();
     }
@@ -129,7 +127,7 @@ export class ServerMatchMedia extends MatchMedia {
 
   /** Deactivate the specified breakpoint if we're on the server, no-op otherwise */
   deactivateBreakpoint(bp: BreakPoint) {
-    const lookupBreakpoint = this._registry.get(bp.mediaQuery);
+    const lookupBreakpoint = this.registry.get(bp.mediaQuery) as ServerMediaQueryList;
     if (lookupBreakpoint) {
       lookupBreakpoint.deactivate();
     }


### PR DESCRIPTION
The Windows MatchMedia API announces breakpoint activations during viewport resizing.
For some scenarios, developers need support for manual activations (without resizing). 

Such features are useful for:
* for SSR
* for designer environments 
  > for immediate rendering of layouts for specific (1..n) breakpoints
