### PR TITLE
feat(core): move MatchMedia to internal scope

### DIFF
--- a/src/lib/core/match-media/index.ts
+++ b/src/lib/core/match-media/index.ts
@@ -8,4 +8,3 @@
 
 export * from './match-media';
 export * from './mock/mock-match-media';
-export * from './server-match-media';

--- a/src/lib/core/public-api.ts
+++ b/src/lib/core/public-api.ts
@@ -15,7 +15,11 @@ export * from './add-alias';
 
 export * from './base/index';
 export * from './breakpoints/index';
-export * from './match-media/index';
+export {
+  MatchMedia as ɵMatchMedia,
+  MockMatchMedia as ɵMockMatchMedia,
+  MockMatchMediaProvider as ɵMockMatchMediaProvider,
+} from './match-media/index';
 export * from './media-observer/index';
 export * from './utils/index';
 

--- a/src/lib/extended/class/class.spec.ts
+++ b/src/lib/extended/class/class.spec.ts
@@ -10,10 +10,10 @@ import {CommonModule, isPlatformServer} from '@angular/common';
 import {ComponentFixture, TestBed, fakeAsync, flush, inject} from '@angular/core/testing';
 import {MatButtonModule} from '@angular/material/button';
 import {
-  MatchMedia,
+  ɵMatchMedia as MatchMedia,
   CoreModule,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
 } from '@angular/flex-layout/core';
 
 import {customMatchers, expect} from '../../utils/testing/custom-matchers';

--- a/src/lib/extended/img-src/img-src.spec.ts
+++ b/src/lib/extended/img-src/img-src.spec.ts
@@ -9,9 +9,9 @@ import {Component, PLATFORM_ID} from '@angular/core';
 import {CommonModule, isPlatformServer} from '@angular/common';
 import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   SERVER_TOKEN,
   StyleUtils,
 } from '@angular/flex-layout/core';

--- a/src/lib/extended/show-hide/hide.spec.ts
+++ b/src/lib/extended/show-hide/hide.spec.ts
@@ -9,9 +9,9 @@ import {Component, OnInit} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   MediaObserver,
   SERVER_TOKEN,
   StyleUtils

--- a/src/lib/extended/show-hide/show.spec.ts
+++ b/src/lib/extended/show-hide/show.spec.ts
@@ -9,9 +9,9 @@ import {Component, Directive, OnInit, PLATFORM_ID} from '@angular/core';
 import {CommonModule, isPlatformBrowser} from '@angular/common';
 import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   MediaObserver,
   SERVER_TOKEN,
   StyleUtils,

--- a/src/lib/extended/style/style.spec.ts
+++ b/src/lib/extended/style/style.spec.ts
@@ -9,10 +9,10 @@ import {Component} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {
-  MatchMedia,
+  ɵMatchMedia as MatchMedia,
   CoreModule,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   StyleUtils,
 } from '@angular/flex-layout/core';
 import {DefaultLayoutDirective} from '@angular/flex-layout/flex';

--- a/src/lib/flex/flex-offset/flex-offset.spec.ts
+++ b/src/lib/flex/flex-offset/flex-offset.spec.ts
@@ -10,7 +10,7 @@ import {CommonModule, isPlatformServer} from '@angular/common';
 import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
 import {DIR_DOCUMENT} from '@angular/cdk/bidi';
 import {
-  MockMatchMediaProvider,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   SERVER_TOKEN,
   StyleBuilder,
   StyleUtils,

--- a/src/lib/flex/flex-order/flex-order.spec.ts
+++ b/src/lib/flex/flex-order/flex-order.spec.ts
@@ -9,9 +9,9 @@ import {Component} from '@angular/core';
 import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
 import {CommonModule} from '@angular/common';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   SERVER_TOKEN,
   StyleUtils,
 } from '@angular/flex-layout/core';

--- a/src/lib/flex/flex/flex.spec.ts
+++ b/src/lib/flex/flex/flex.spec.ts
@@ -10,9 +10,9 @@ import {CommonModule, isPlatformServer} from '@angular/common';
 import {ComponentFixture, TestBed, inject, fakeAsync} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   StyleBuilder,
   StyleUtils,
 } from '@angular/flex-layout/core';

--- a/src/lib/flex/layout-align/layout-align.spec.ts
+++ b/src/lib/flex/layout-align/layout-align.spec.ts
@@ -10,9 +10,9 @@ import {CommonModule} from '@angular/common';
 import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   SERVER_TOKEN,
   StyleBuilder,
   StyleUtils,

--- a/src/lib/flex/layout-gap/layout-gap.spec.ts
+++ b/src/lib/flex/layout-gap/layout-gap.spec.ts
@@ -10,9 +10,9 @@ import {CommonModule, isPlatformServer} from '@angular/common';
 import {TestBed, ComponentFixture, inject, async} from '@angular/core/testing';
 import {DIR_DOCUMENT} from '@angular/cdk/bidi';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   SERVER_TOKEN,
   StyleBuilder,
   StyleUtils,

--- a/src/lib/flex/layout/layout.spec.ts
+++ b/src/lib/flex/layout/layout.spec.ts
@@ -9,9 +9,9 @@ import {Component, Injectable, OnInit} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   SERVER_TOKEN,
   StyleBuilder,
   StyleUtils,

--- a/src/lib/grid/align-columns/align-columns.spec.ts
+++ b/src/lib/grid/align-columns/align-columns.spec.ts
@@ -10,9 +10,9 @@ import {CommonModule} from '@angular/common';
 import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   StyleUtils,
 } from '@angular/flex-layout/core';
 

--- a/src/lib/grid/align-rows/align-rows.spec.ts
+++ b/src/lib/grid/align-rows/align-rows.spec.ts
@@ -9,9 +9,9 @@ import {Component, OnInit} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   StyleUtils,
 } from '@angular/flex-layout/core';
 

--- a/src/lib/grid/area/area.spec.ts
+++ b/src/lib/grid/area/area.spec.ts
@@ -10,9 +10,9 @@ import {CommonModule} from '@angular/common';
 import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   SERVER_TOKEN,
   StyleUtils,
 } from '@angular/flex-layout/core';

--- a/src/lib/grid/areas/areas.spec.ts
+++ b/src/lib/grid/areas/areas.spec.ts
@@ -10,9 +10,9 @@ import {CommonModule} from '@angular/common';
 import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   SERVER_TOKEN,
   StyleUtils,
 } from '@angular/flex-layout/core';

--- a/src/lib/grid/auto/auto.spec.ts
+++ b/src/lib/grid/auto/auto.spec.ts
@@ -10,9 +10,9 @@ import {CommonModule} from '@angular/common';
 import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   SERVER_TOKEN,
   StyleUtils,
 } from '@angular/flex-layout/core';

--- a/src/lib/grid/column/column.spec.ts
+++ b/src/lib/grid/column/column.spec.ts
@@ -10,9 +10,9 @@ import {CommonModule} from '@angular/common';
 import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   SERVER_TOKEN,
   StyleUtils,
 } from '@angular/flex-layout/core';

--- a/src/lib/grid/columns/columns.spec.ts
+++ b/src/lib/grid/columns/columns.spec.ts
@@ -10,9 +10,9 @@ import {CommonModule} from '@angular/common';
 import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   SERVER_TOKEN,
   StyleUtils,
 } from '@angular/flex-layout/core';

--- a/src/lib/grid/gap/gap.spec.ts
+++ b/src/lib/grid/gap/gap.spec.ts
@@ -10,9 +10,9 @@ import {CommonModule} from '@angular/common';
 import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   SERVER_TOKEN,
   StyleUtils,
 } from '@angular/flex-layout/core';

--- a/src/lib/grid/grid-align/grid-align.spec.ts
+++ b/src/lib/grid/grid-align/grid-align.spec.ts
@@ -10,9 +10,9 @@ import {CommonModule} from '@angular/common';
 import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   SERVER_TOKEN,
   StyleUtils,
 } from '@angular/flex-layout/core';

--- a/src/lib/grid/row/row.spec.ts
+++ b/src/lib/grid/row/row.spec.ts
@@ -10,9 +10,9 @@ import {CommonModule} from '@angular/common';
 import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   SERVER_TOKEN,
   StyleUtils,
 } from '@angular/flex-layout/core';

--- a/src/lib/grid/rows/rows.spec.ts
+++ b/src/lib/grid/rows/rows.spec.ts
@@ -10,9 +10,9 @@ import {CommonModule} from '@angular/common';
 import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {Platform} from '@angular/cdk/platform';
 import {
-  MatchMedia,
-  MockMatchMedia,
-  MockMatchMediaProvider,
+  ɵMatchMedia as MatchMedia,
+  ɵMockMatchMedia as MockMatchMedia,
+  ɵMockMatchMediaProvider as MockMatchMediaProvider,
   SERVER_TOKEN,
   StyleUtils,
 } from '@angular/flex-layout/core';

--- a/src/lib/server/server-match-media.ts
+++ b/src/lib/server/server-match-media.ts
@@ -7,9 +7,7 @@
  */
 import {DOCUMENT} from '@angular/common';
 import {Inject, Injectable, NgZone, PLATFORM_ID} from '@angular/core';
-
-import {BreakPoint} from '../breakpoints/break-point';
-import {MatchMedia} from './match-media';
+import {BreakPoint, ɵMatchMedia as MatchMedia} from '@angular/flex-layout/core';
 
 /**
  * Special server-only class to simulate a MediaQueryList and

--- a/src/lib/server/server-provider.ts
+++ b/src/lib/server/server-provider.ts
@@ -13,12 +13,12 @@ import {
   CLASS_NAME,
   SERVER_TOKEN,
   BreakPoint,
-  MatchMedia,
+  ɵMatchMedia as MatchMedia,
   StylesheetMap,
-  ServerMatchMedia,
   sortAscendingPriority
 } from '@angular/flex-layout/core';
 
+import {ServerMatchMedia} from './server-match-media';
 
 /**
  * Activate all of the registered breakpoints in sequence, and then


### PR DESCRIPTION
BREAKING CHANGE:

* `MatchMedia` is no longer exported as a public utility. Please use `MediaObserver` instead. 
* `ServerMatchMedia` is no longer exported at all