### PR TITLE
feat(server): allow ability to specify breakpoints to activate on server

### DIFF
--- a/src/lib/core/tokens/library-config.ts
+++ b/src/lib/core/tokens/library-config.ts
@@ -17,7 +17,7 @@ export interface LayoutConfigOptions {
   useColumnBasisZero?: boolean;
   printWithBreakpoints?: string[];
   mediaTriggerAutoRestore?: boolean;
-  serverBreakpoints?: string[];
+  ssrObserveBreakpoints?: string[];
 }
 
 export const DEFAULT_CONFIG: LayoutConfigOptions = {
@@ -29,7 +29,7 @@ export const DEFAULT_CONFIG: LayoutConfigOptions = {
   useColumnBasisZero: true,
   printWithBreakpoints: [],
   mediaTriggerAutoRestore: true,
-  serverBreakpoints: [],
+  ssrObserveBreakpoints: [],
 };
 
 export const LAYOUT_CONFIG = new InjectionToken<LayoutConfigOptions>(

--- a/src/lib/core/tokens/library-config.ts
+++ b/src/lib/core/tokens/library-config.ts
@@ -17,6 +17,7 @@ export interface LayoutConfigOptions {
   useColumnBasisZero?: boolean;
   printWithBreakpoints?: string[];
   mediaTriggerAutoRestore?: boolean;
+  serverBreakpoints?: string[];
 }
 
 export const DEFAULT_CONFIG: LayoutConfigOptions = {
@@ -27,7 +28,8 @@ export const DEFAULT_CONFIG: LayoutConfigOptions = {
   serverLoaded: false,
   useColumnBasisZero: true,
   printWithBreakpoints: [],
-  mediaTriggerAutoRestore: true
+  mediaTriggerAutoRestore: true,
+  serverBreakpoints: [],
 };
 
 export const LAYOUT_CONFIG = new InjectionToken<LayoutConfigOptions>(

--- a/src/lib/server/server-provider.ts
+++ b/src/lib/server/server-provider.ts
@@ -55,7 +55,7 @@ export function generateStaticFlexLayoutStyles(serverSheet: StylesheetMap,
     mediaController.deactivateBreakpoint(breakpoints[i]);
   });
 
-  const serverBps = layoutConfig.serverBreakpoints;
+  const serverBps = layoutConfig.ssrObserveBreakpoints;
   if (serverBps) {
     serverBps
       .reduce((acc: BreakPoint[], serverBp: string) => {

--- a/src/lib/server/server-provider.ts
+++ b/src/lib/server/server-provider.ts
@@ -57,8 +57,16 @@ export function generateStaticFlexLayoutStyles(serverSheet: StylesheetMap,
 
   const serverBps = layoutConfig.serverBreakpoints;
   if (serverBps) {
-    breakpoints
-      .filter(bp => serverBps.find(serverBp => serverBp === bp.alias))
+    serverBps
+      .reduce((acc: BreakPoint[], serverBp: string) => {
+        const foundBp = breakpoints.find(bp => serverBp === bp.alias);
+        if (!foundBp) {
+          console.warn(`FlexLayoutServerModule: breakpoint with alias "${serverBp}`);
+        } else {
+          acc.push(foundBp);
+        }
+        return acc;
+      }, [])
       .forEach(mediaController.activateBreakpoint);
   }
 

--- a/src/lib/server/server-provider.ts
+++ b/src/lib/server/server-provider.ts
@@ -61,7 +61,7 @@ export function generateStaticFlexLayoutStyles(serverSheet: StylesheetMap,
       .reduce((acc: BreakPoint[], serverBp: string) => {
         const foundBp = breakpoints.find(bp => serverBp === bp.alias);
         if (!foundBp) {
-          console.warn(`FlexLayoutServerModule: breakpoint with alias "${serverBp}`);
+          console.warn(`FlexLayoutServerModule: unknown breakpoint alias "${serverBp}"`);
         } else {
           acc.push(foundBp);
         }

--- a/src/lib/server/server-provider.ts
+++ b/src/lib/server/server-provider.ts
@@ -47,12 +47,12 @@ export function generateStaticFlexLayoutStyles(serverSheet: StylesheetMap,
 
   [...breakpoints].sort(sortAscendingPriority).forEach((bp, i) => {
     serverSheet.clearStyles();
-    (mediaController as ServerMatchMedia).activateBreakpoint(bp);
+    mediaController.activateBreakpoint(bp);
     const stylesheet = new Map(serverSheet.stylesheet);
     if (stylesheet.size > 0) {
       styleText += generateCss(stylesheet, bp.mediaQuery, classMap);
     }
-    (mediaController as ServerMatchMedia).deactivateBreakpoint(breakpoints[i]);
+    mediaController.deactivateBreakpoint(breakpoints[i]);
   });
 
   const serverBps = layoutConfig.serverBreakpoints;
@@ -70,7 +70,7 @@ export function generateStaticFlexLayoutStyles(serverSheet: StylesheetMap,
  * components and attach it to the head of the DOM
  */
 export function FLEX_SSR_SERIALIZER_FACTORY(serverSheet: StylesheetMap,
-                                            matchMedia: ServerMatchMedia,
+                                            mediaController: ServerMatchMedia,
                                             _document: Document,
                                             breakpoints: BreakPoint[],
                                             layoutConfig: LayoutConfigOptions) {
@@ -78,7 +78,7 @@ export function FLEX_SSR_SERIALIZER_FACTORY(serverSheet: StylesheetMap,
     // This is the style tag that gets inserted into the head of the DOM,
     // populated with the manual media queries
     const styleTag = _document.createElement('style');
-    const styleText = generateStaticFlexLayoutStyles(serverSheet, matchMedia, breakpoints,
+    const styleText = generateStaticFlexLayoutStyles(serverSheet, mediaController, breakpoints,
       layoutConfig);
     styleTag.classList.add(`${CLASS_NAME}ssr`);
     styleTag.textContent = styleText;
@@ -131,7 +131,8 @@ export type ClassMap = Map<HTMLElement, string>;
 function generateCss(stylesheet: StyleSheet, mediaQuery: string, classMap: ClassMap) {
   let css = '';
   stylesheet.forEach((styles, el) => {
-    let keyVals = '', className = getClassName(el, classMap);
+    let keyVals = '';
+    let className = getClassName(el, classMap);
 
     styles.forEach((v, k) => {
       keyVals += v ? format(`${k}:${v};`) : '';
@@ -152,13 +153,13 @@ function generateCss(stylesheet: StyleSheet, mediaQuery: string, classMap: Class
 function format(...list: string[]): string {
   let result = '';
   list.forEach((css, i) => {
-    result += IS_DEBUG_MODE ? formatSegment(css, i != 0) : css;
+    result += IS_DEBUG_MODE ? formatSegment(css, i !== 0) : css;
   });
   return result;
 }
 
 function formatSegment(css: string, asPrefix: boolean = true): string {
-  return asPrefix ? '\n' + css : css + '\n';
+  return asPrefix ? `\n${css}` : `${css}\n`;
 }
 
 /**
@@ -176,4 +177,3 @@ function getClassName(element: HTMLElement, classMap: Map<HTMLElement, string>) 
 
   return className;
 }
-


### PR DESCRIPTION
On the server, there is no conception of "browser window," because Angular's
browser implementation doesn't implement it. This means MatchMedia breakpoint activations will not work on the server. 

Layout SSR will generate CSS Stylesheets for all known breakpoints. And for the static, delivered-first HTML pages the directives are replaced with their associated, generated CSS classnames. 

But for programmatic usages of `MediaObserver`, we don't have a fallback mechanism to *announce* breakpoint activations. This PR allows a user to specify which activations they want to trigger via the MediaObserver for programmatic view listeners.

This can be done using the following configuration:

```ts
FlexLayoutModule.withConfig({serverBreakpoints: ['xs', 'lt-md']})
```

Fixes #991 