### PR TITLE
docs: add a Getting Started section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ The **real** power of Flex Layout, however, is its **responsive** engine. The
 different layouts, sizing, visibilities for different viewport sizes and display devices.
 
 ---
-### Getting started
+### Getting Started
 
-Start by installing the Angular Flex Layout library from `npm`
+Start by installing the Angular Layout library from `npm`
 
-`npm i -s @angular/flex-layout@latest @angular/cdk@latest`
+`npm i -s @angular/flex-layout @angular/cdk`
 
-Next, you'll need to import the flex-layout module in your app's module.
+Next, you'll need to import the Layout module in your app's module.
 
 **app.module.ts**
 
-```
+```ts
 
 import { FlexLayoutModule } from '@angular/flex-layout';
 ...
@@ -39,13 +39,13 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 });
 ```
 
-After that is configured, you can use the attributes on your HTML tags for flex layout:
-```
+After that is configured, you can use the Angular Layout attributes in your HTML tags for flex layout:
+```html
 <div fxLayout="row" fxLayoutAlign="space-between">
 </div>
 ```
 
-Check out [all the available options](https://github.com/angular/flex-layout/wiki/Declarative-API-Overview) for using layout in your application.
+Check out [all of the available options](https://github.com/angular/flex-layout/wiki/Declarative-API-Overview) for using Angular Layout in your application.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,51 @@
-# Angular Flex-Layout  
+# Angular Flex-Layout
 
 [![npm version](https://badge.fury.io/js/%40angular%2Fflex-layout.svg)](https://www.npmjs.com/package/%40angular%2Fflex-layout)
 [![Build status](https://circleci.com/gh/angular/flex-layout.svg?style=svg)](https://circleci.com/gh/angular/flex-layout)
 [![Gitter](https://badges.gitter.im/angular/flex-layout.svg)](https://gitter.im/angular/flex-layout)
 
-Angular Flex Layout provides a sophisticated layout API using Flexbox CSS + mediaQuery. 
-This module provides Angular developers with component layout features using a 
-custom Layout API, mediaQuery observables, and injected DOM flexbox-2016 CSS stylings.  
+Angular Flex Layout provides a sophisticated layout API using Flexbox CSS + mediaQuery.
+This module provides Angular developers with component layout features using a
+custom Layout API, mediaQuery observables, and injected DOM flexbox-2016 CSS stylings.
 
-The Flex Layout engine intelligently automates the process of applying appropriate 
-Flexbox CSS to browser view hierarchies. This automation also addresses many of the 
-complexities and workarounds encountered with the traditional, manual, CSS-only application of box CSS. 
+The Flex Layout engine intelligently automates the process of applying appropriate
+Flexbox CSS to browser view hierarchies. This automation also addresses many of the
+complexities and workarounds encountered with the traditional, manual, CSS-only application of box CSS.
 
-The **real** power of Flex Layout, however, is its **responsive** engine. The 
-[Responsive API](https://github.com/angular/flex-layout/wiki/Responsive-API) enables developers to easily specify 
+The **real** power of Flex Layout, however, is its **responsive** engine. The
+[Responsive API](https://github.com/angular/flex-layout/wiki/Responsive-API) enables developers to easily specify
 different layouts, sizing, visibilities for different viewport sizes and display devices.
+
+---
+### Getting started
+
+Start by installing the Angular Flex Layout library from `npm`
+
+`npm i -s @angular/flex-layout@latest @angular/cdk@latest`
+
+Next, you'll need to import the flex-layout module in your app's module.
+
+**app.module.ts**
+
+```
+
+import { FlexLayoutModule } from '@angular/flex-layout';
+...
+
+@NgModule({
+    ...
+    imports: [ FlexLayoutModule ],
+    ...
+});
+```
+
+After that is configured, you can use the attributes on your HTML tags for flex layout:
+```
+<div fxLayout="row" fxLayoutAlign="space-between">
+</div>
+```
+
+Check out [all the available options](https://github.com/angular/flex-layout/wiki/Declarative-API-Overview) for using layout in your application.
 
 ---
 
@@ -32,7 +63,7 @@ Developers
 *  [Builds + Fast Start](https://github.com/angular/flex-layout/wiki/Fast-Starts)
 *  [Integration with Angular CLI](https://github.com/angular/flex-layout/wiki/Using-Angular-CLI)
 
-Demos 
+Demos
 
 *  [Explore Online](https://tburleson-layouts-demos.firebaseapp.com/)
 *  [Source Code](https://github.com/angular/flex-layout/blob/master/src/apps/demo-app/src/app/app.module.ts)


### PR DESCRIPTION
I added a new **Getting Started** section to the `readme.md` file. I grabbed the data from the wiki combined with what I did this morning to include it into a project. I think having a spot on the readme makes it easier to find, and has become somewhat expected with other projects showing the base use case of getting up and running.


![image](https://user-images.githubusercontent.com/928403/51632236-696bf300-1f14-11e9-8d4e-eda9047ce740.png)
