### PR TITLE
Fail-safe handling of nullable string value in lookupStyle

### DIFF
--- a/src/lib/core/style-utils/style-utils.ts
+++ b/src/lib/core/style-utils/style-utils.ts
@@ -98,7 +98,7 @@ export class StyleUtils {
 
     // Note: 'inline' is the default of all elements, unless UA stylesheet overrides;
     //       in which case getComputedStyle() should determine a valid value.
-    return value.trim();
+    return value ? value.trim() : '';
   }
 
   /**


### PR DESCRIPTION
Hi, we've been doing some research to find out why the flex layout library throws errors on older browsers. More specifically, Safari on iOS 8 and below. 

This issue reports about this error: https://github.com/angular/flex-layout/issues/958 - it says it's a duplicate of https://github.com/angular/flex-layout/issues/947, however, these errors seem slightly unrelated.

The problem is the `lookupStyle` method in the `StyleUtils` service calls `getComputedStyle(element).getPropertyValue(styleName)`. The spec says that `getPropertyValue` should return an empty string if the style is not set, however, on some older browsers it returns `null` instead. This causes an error when the method returns `value.trim()`, since value isn't a string.

This PR adds a safeguard to check for `null` and makes sure the method always return a string.

We've tested this on multiple old browsers on Browserstack and this seems to solve all our issues.