### PR TITLE
ci: update lock-closed to only run once per day

### DIFF
--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -2,14 +2,14 @@ name: Lock issues that are closed and inactive
 
 on:
   schedule:
-    # Run at the top of every hour
-    - cron: '0 * * * *'
+    # Run everday at 12:00
+    - cron: '0 12 * * *'
 
 jobs:
   lock_closed:
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/lock-closed@7f7ef07
+      - uses: angular/dev-infra/github-actions/lock-closed@c0ac60d
         with:
           lock-bot-key: ${{ secrets.LOCK_BOT_PRIVATE_KEY }}
           locks-per-execution: 100


### PR DESCRIPTION
Now that the backlog of inactive closed issues/prs has been locked, we should only run the action once per day.