### PR TITLE
feat: change tslib from direct dependency to peerDependency

### DIFF
--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -27,10 +27,8 @@
     "@angular/core": "0.0.0-NG",
     "@angular/common": "0.0.0-NG",
     "@angular/platform-browser": "0.0.0-NG",
-    "rxjs": "^6.0.0"
-  },
-  "dependencies": {
-    "tslib": "^1.7.1"
+    "rxjs": "^6.0.0",
+    "tslib": "^1.9.0"
   },
   "sideEffects": false
 }


### PR DESCRIPTION
BREAKING CHANGE:

We no longer directly have a direct depedency on `tslib`. Instead it is now listed a `peerDependency`.

Users not using the CLI will need to manually install `tslib` via;
```
yarn add tslib
```
or
```
npm install tslib --save
```

Reference: TOOL-836