### PR TITLE
fix(ssr): reset class counter to zero before each render

### DIFF
--- a/src/lib/server/server-provider.ts
+++ b/src/lib/server/server-provider.ts
@@ -40,6 +40,9 @@ export function generateStaticFlexLayoutStyles(serverSheet: StylesheetMap,
   // Get the initial stylings for all of the directives,
   // and initialize the fallback block of stylings
   const defaultStyles = new Map(serverSheet.stylesheet);
+  // Reset the class counter, otherwise class numbers will
+  // increase with each server render
+  nextId = 0;
   let styleText = generateCss(defaultStyles, 'all', classMap);
 
   [...breakpoints].sort(sortAscendingPriority).forEach((bp, i) => {


### PR DESCRIPTION
Previously, the unique class generation routine used a
local variable to keep track of individual elements.
However, this counter would never get reset, meaning
that it would get incremented on each subsequent
server render, leading to enormous values for the class
names, erroneously. This resets the counter to zero for
each render.