### PR TITLE
fix(show-hide): display set to "initial" value if parent has no display set

### DIFF
--- a/src/lib/extended/show-hide/show-hide.ts
+++ b/src/lib/extended/show-hide/show-hide.ts
@@ -37,7 +37,7 @@ export interface ShowHideParent {
 export class ShowHideStyleBuilder extends StyleBuilder {
   buildStyles(show: string, parent: ShowHideParent) {
     const shouldShow = show === 'true';
-    return {'display': shouldShow ? parent.display : 'none'};
+    return {'display': shouldShow ? parent.display || 'initial' : 'none'};
   }
 }
 


### PR DESCRIPTION
When SSR creates media screen styles it sets the default display to `parent.display`, but if the parent has its `display` property unset, it results in an empty display which breaks the correct functionality as the next closest match is made.

Fixed by setting display to `initial` as default instead of an empty value.

fixes #1163