### PR TITLE
docs: fix HTML closing tags for fxFlex API page

### DIFF
--- a/docs/documentation/fxFlex-API.md
+++ b/docs/documentation/fxFlex-API.md
@@ -136,7 +136,7 @@ The notation
 
 ```html
 <div fxLayout="row">
-   <div fxFlex><div>
+   <div fxFlex></div>
 </div>
 ```
 
@@ -151,9 +151,9 @@ The notation:
 
 ```html
 <div fxLayout="row">
-   <div fxFlex><div>
-   <div fxFlex><div>
-   <div fxFlex><div>
+   <div fxFlex></div>
+   <div fxFlex></div>
+   <div fxFlex></div>
 </div>
 ```
 


### PR DESCRIPTION
The divider elements was not closed correctly