### PR TITLE
build: do not include secondary entry-points in primary UMD bundle

### DIFF
--- a/tools/package-tools/build-bundles.ts
+++ b/tools/package-tools/build-bundles.ts
@@ -1,4 +1,4 @@
-import {join, dirname} from 'path';
+import {join} from 'path';
 import {uglifyJsFile} from './minify-sources';
 import {buildConfig} from './build-config';
 import {BuildPackage} from './build-package';


### PR DESCRIPTION
The APF specification does not capture all corner cases, but conceptually,
generated UMD bundles should match the actual entry-point in the typings tree.
This means that it's technically spec-compliant to include secondary entry-points in a
primary UMD bundle. At the same time though, it's also spec-compliant to not include
secondary entry-points and require UMD consumers to load the secondary entry-point
UMD bundles manually. 

We are going with the latter since that helps with an issue that has surfaced in ngcc.
The plan is to update the APF specification to explicitly guard against cases like that,
so that primary UMD bundles no longer can bundle secondary entry-points. This
change prepares flex-layout for the change to the APF specification.