### PR TITLE
build: use no async option for ngcc

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lib:test:ssr": "gulp test:ssr",
     "universal:build": "gulp ci:prerender",
     "universal:serve": "gulp universal:serve",
-    "postinstall": "ngcc --properties es2015 browser module main --create-ivy-entry-points"
+    "postinstall": "ngcc --properties es2015 browser module main --no-async --create-ivy-entry-points"
   },
   "version": "9.0.0-beta.29",
   "requiredAngularVersion": ">=9.0.0-rc.11",


### PR DESCRIPTION
CI is failing nondeterministically when it runs out of memory
running ngcc.

Closes #1180