### PR TITLE
fix(media-marshaller): do not propagate undefined value

### DIFF
--- a/src/lib/core/media-marshaller/media-marshaller.ts
+++ b/src/lib/core/media-marshaller/media-marshaller.ts
@@ -317,7 +317,7 @@ export class MediaMarshaller {
       const activatedBp = this.activatedBreakpoints[i];
       const valueMap = bpMap.get(activatedBp.alias);
       if (valueMap) {
-        if (key === undefined || valueMap.has(key)) {
+        if (key === undefined || (valueMap.has(key) && valueMap.get(key) !== undefined)) {
           return valueMap;
         }
       }

--- a/src/lib/extended/class/class.spec.ts
+++ b/src/lib/extended/class/class.spec.ts
@@ -198,6 +198,12 @@ describe('class directive', () => {
     expectNativeEl(fixture).toHaveCssClass('mat-class');
   });
 
+  it('should support more than one responsive breakpoint on one element with undefined', () => {
+    createTestComponent(`<div ngClass.lt-lg="mat-class" [ngClass.md]="undefined"></div>`);
+    mediaController.activate('md', true);
+    expectNativeEl(fixture).toHaveCssClass('mat-class');
+  });
+
   it('should work with ngClass object notation', () => {
     createTestComponent(`
       <div [ngClass]="{'x1': hasX1, 'x3': hasX3}"


### PR DESCRIPTION
In certain cases, users may need to dynamically set the value of
an input to `undefined`. This value should then be ignored in
place of another value in the fallback mechanism.

Fixes #1207