### PR TITLE
fix(core): ignore null values in breakpoint fallback mechanism

### DIFF
--- a/src/lib/core/media-marshaller/media-marshaller.ts
+++ b/src/lib/core/media-marshaller/media-marshaller.ts
@@ -317,7 +317,7 @@ export class MediaMarshaller {
       const activatedBp = this.activatedBreakpoints[i];
       const valueMap = bpMap.get(activatedBp.alias);
       if (valueMap) {
-        if (key === undefined || (valueMap.has(key) && valueMap.get(key) !== undefined)) {
+        if (key === undefined || (valueMap.has(key) && valueMap.get(key) != null)) {
           return valueMap;
         }
       }


### PR DESCRIPTION
Previously we only ignored `undefined`, now we ignore `null` too.