### PR TITLE
fix(core): add generic type to ModuleWithProviders to support v10

### DIFF
--- a/src/lib/module.ts
+++ b/src/lib/module.ts
@@ -37,7 +37,8 @@ export class FlexLayoutModule {
    * which sets the corresponding tokens accordingly
    */
   static withConfig(configOptions: LayoutConfigOptions,
-                    breakpoints: BreakPoint|BreakPoint[] = []): ModuleWithProviders {
+                    // tslint:disable-next-line:max-line-length
+                    breakpoints: BreakPoint|BreakPoint[] = []): ModuleWithProviders<FlexLayoutModule> {
     return {
       ngModule: FlexLayoutModule,
       providers: configOptions.serverLoaded ?


### PR DESCRIPTION
In Angular v10, ModuleWithProviders generic typing is no longer
optional. To prepare for this, the correct typing is added.