### PR TITLE
build: update tslint rules to remove usage of whitelist in comments

### DIFF
--- a/tools/tslint-rules/noRxjsPatchImportsRule.ts
+++ b/tools/tslint-rules/noRxjsPatchImportsRule.ts
@@ -7,7 +7,7 @@ const ERROR_MESSAGE = 'Uses of RxJS patch imports are forbidden.';
 
 /**
  * Rule that prevents uses of RxJS patch imports (e.g. `import 'rxjs/add/operator/map').
- * Supports whitelisting via `"no-patch-imports": [true, "\.spec\.ts$"]`.
+ * Supports allowing usage in specific files via `"no-patch-imports": [true, "\.spec\.ts$"]`.
  */
 export class Rule extends Lint.Rules.AbstractRule {
   apply(sourceFile: ts.SourceFile) {

--- a/tools/tslint-rules/noViewEncapsulationRule.ts
+++ b/tools/tslint-rules/noViewEncapsulationRule.ts
@@ -9,7 +9,7 @@ const ERROR_MESSAGE = 'Components must turn off view encapsulation.';
 
 /**
  * Rule that enforces that view encapsulation is turned off on all components.
- * Files can be whitelisted via `"no-view-encapsulation": [true, "\.spec\.ts$"]`.
+ * Supports allowing usage in specific files via `"no-view-encapsulation": [true, "\.spec\.ts$"]`.
  */
 export class Rule extends Lint.Rules.AbstractRule {
   apply(sourceFile: ts.SourceFile) {

--- a/tools/tslint-rules/validateDecoratorsRule.ts
+++ b/tools/tslint-rules/validateDecoratorsRule.ts
@@ -5,7 +5,7 @@ import * as minimatch from 'minimatch';
 
 /**
  * Rule that enforces certain decorator properties to be defined and to match a pattern.
- * Supports whitelisting via the third argument. E.g.
+ * Supports allowing usage in specific files via the third argument. E.g.
  *
  * ```
  * "validate-decorators": [true, {


### PR DESCRIPTION
Remove usage of the term whitelist in commenting for noRxjsPatchImportsRule,
noViewEncapsulationRule and validateDecoratorRule.