### PR TITLE
build: update `lock-closed` GitHub action to latest version

### DIFF
--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -9,7 +9,7 @@ jobs:
   lock_closed:
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/lock-closed@c0ac60d
+      - uses: angular/dev-infra/github-actions/lock-closed@0fc6f4d839e93312ed0dd9a2be88d4c11e947a0b
         with:
           lock-bot-key: ${{ secrets.LOCK_BOT_PRIVATE_KEY }}
           locks-per-execution: 100


### PR DESCRIPTION
This commit updates the version of the `dev-infra/lock-closed` GitHub
action to the latest version, that includes the fix from
angular/dev-infra#80.