### PR TITLE
docs(mediaObserver): create new mediaObserver documentation to replace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 # dependencies
 node_modules
 /bower_components
+.prettierrc.js
 
 # IDEs
 /.idea

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+    singleQuote: true
+};

--- a/docs/documentation/mediaObserver.md
+++ b/docs/documentation/mediaObserver.md
@@ -46,7 +46,7 @@ import { distinctUntilChanged } from 'rxjs/operators';
 export class AppComponent implements OnInit, OnDestroy {
   constructor(private mediaObserver: MediaObserver) {}
   private mediaSubscription!: Subscription;
-  private activeMediaQuery: string = '';
+  private activeMediaQuery: = '';
 
   ngOnInit(): void {
     this.mediaSubscription = this.mediaObserver
@@ -128,7 +128,7 @@ const PRINT_MOBILE = 'print and (max-width: 600px)';
 @Component({
   selector: 'responsive-component',
   template: `
-    <div class='ad-content' *ngIf='media.isActive('xs')'>
+    <div class="ad-content" *ngIf="media.isActive('xs')">
       Only shown if on mobile viewport sizes
     </div>
   `,

--- a/docs/documentation/mediaObserver.md
+++ b/docs/documentation/mediaObserver.md
@@ -46,7 +46,7 @@ import { distinctUntilChanged } from 'rxjs/operators';
 export class AppComponent implements OnInit, OnDestroy {
   constructor(private mediaObserver: MediaObserver) {}
   private mediaSubscription!: Subscription;
-  private activeMediaQuery: = '';
+  private activeMediaQuery = '';
 
   ngOnInit(): void {
     this.mediaSubscription = this.mediaObserver

--- a/docs/documentation/mediaObserver.md
+++ b/docs/documentation/mediaObserver.md
@@ -1,0 +1,151 @@
+The injectable **MediaObserver** service will provide mediaQuery **activations** notifications for all
+[registered BreakPoints](https://github.com/angular/flex-layout/wiki/Custom-Breakpoints).
+
+This service is essentially an Observable that exposes both features to subscribe to mediaQuery
+changes and a validator method `.isActive()` to test if a mediaQuery (or alias) is
+currently active.
+
+> Only mediaChange activations (not deactivations) are announced by the MediaObserver
+
+---
+
+### API Summary
+
+The injectable **MediaObserver** service has two (2) APIs:
+
+- `asObservable(): Observable<MediaChange>`
+- `isActive(query: string): boolean`
+
+---
+
+#### 1. **`MediaObserver::asObservable`**
+
+Developers use Angular DI to inject a reference to the **MediaObserver** service as a **constructor** parameter.
+
+The **MediaObserver** is not an actual **Observable**. It is a wrapper of an Observable used to publish additional methods like `isActive(<alias>).
+
+```typescript
+asObservable(): Observable<MediaChange>
+```
+
+Use the `.asObservable()` accessor method to access the **Observable** and use **RxJS** operators; such as `media.asObservable().filter(....)`.
+
+> Do not forget to **import** the specific RxJS operators you wish to use!
+
+```typescript
+import { Component, OnDestroy, OnInit } from "@angular/core";
+import { MediaChange, MediaObserver } from "@angular/flex-layout";
+import { Subscription } from "rxjs";
+import { distinctUntilChanged } from "rxjs/operators";
+
+@Component({
+  selector: "app-root",
+  templateUrl: "./app.component.html",
+  styleUrls: ["./app.component.css"],
+})
+export class AppComponent implements OnInit, OnDestroy {
+  title = "Angular Flex-Layout";
+
+  constructor(private mediaObserver: MediaObserver) {}
+  private mediaSubscription!: Subscription;
+  private activeMediaQuery: string = "";
+
+  ngOnInit(): void {
+    this.mediaSubscription = this.mediaObserver
+      .asObservable()
+      .subscribe((change) => {
+        change.forEach((item) => {
+          this.activeMediaQuery = item
+            ? `'${item.mqAlias}' = (${item.mediaQuery})`
+            : "";
+          if (item.mqAlias === "xs") {
+            this.loadMobileContent();
+          }
+          console.log("activeMediaQuery", this.activeMediaQuery);
+        });
+      });
+  }
+
+  loadMobileContent() {
+    // Do something special since the viewport is currently
+    // using mobile display sizes.
+  }
+
+  ngOnDestroy(): void {
+    this.mediaSubscription.unsubscribe();
+  }
+}
+```
+
+This class uses the BreakPoint Registry to inject alias information into the raw MediaChange
+notification. For custom mediaQuery notifications, alias information will not be injected and
+those fields will be an empty string [''].
+
+> This method is useful when the developer is not interested in using RxJS operators (eg `.map()`, `.filter()`).
+
+#### 2. **`MediaObserver::asObservable()`**
+
+```typescript
+import { Component } from "@angular/core";
+import { Subscription } from "rxjs/Subscription";
+import { filter } from "rxjs/operators/filter";
+
+import { MediaChange, MediaObserver } from "@angular/flex-layout";
+
+@Component({
+  selector: "responsive-component",
+})
+export class MyDemo {
+  constructor(media: MediaObserver) {
+    media
+      .asObservable()
+      .pipe(filter((change: MediaChange[]) => change[0].mqAlias == 'xs'))
+      .subscribe(() => {
+        this.loadMobileContent();
+      });
+
+  loadMobileContent() {}
+}
+```
+
+#### 3. **`MediaObserver::isActive()`**
+
+```typescript
+isActive(query: string): boolean
+```
+
+This method is useful both for expressions in component templates and in component imperative logic. The query can be an alias or a mediaQuery.
+
+For example:
+
+- `print and (max-width: 600px)` is a mediaQuery for printing with mobile viewport sizes.
+- `xs` is an alias associated with the mediaQuery for mobile viewport sizes.
+
+```typescript
+import { Component, OnInit } from "@angular/core";
+import { MediaChange, MediaObserver } from "@angular/flex-layout";
+
+const PRINT_MOBILE = "print and (max-width: 600px)";
+
+@Component({
+  selector: "responsive-component",
+  template: `
+    <div class="ad-content" *ngIf="media.isActive('xs')">
+      Only shown if on mobile viewport sizes
+    </div>
+  `,
+})
+export class MyDemo implements OnInit {
+  constructor(public media: MediaObserver) {}
+
+  ngOnInit() {
+    if (this.media.isActive("xs") && !this.media.isActive(PRINT_MOBILE)) {
+      this.loadMobileContent();
+    }
+  }
+
+  loadMobileContent() {
+    /* .... */
+  }
+}
+```

--- a/docs/documentation/mediaObserver.md
+++ b/docs/documentation/mediaObserver.md
@@ -45,7 +45,7 @@ import { distinctUntilChanged } from 'rxjs/operators';
 })
 export class AppComponent implements OnInit, OnDestroy {
   constructor(private mediaObserver: MediaObserver) {}
-  private mediaSubscription!: Subscription;
+  private mediaSubscription: Subscription;
   private activeMediaQuery = '';
 
   ngOnInit(): void {

--- a/docs/documentation/mediaObserver.md
+++ b/docs/documentation/mediaObserver.md
@@ -33,22 +33,20 @@ Use the `.asObservable()` accessor method to access the **Observable** and use *
 > Do not forget to **import** the specific RxJS operators you wish to use!
 
 ```typescript
-import { Component, OnDestroy, OnInit } from "@angular/core";
-import { MediaChange, MediaObserver } from "@angular/flex-layout";
-import { Subscription } from "rxjs";
-import { distinctUntilChanged } from "rxjs/operators";
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { MediaChange, MediaObserver } from '@angular/flex-layout';
+import { Subscription } from 'rxjs';
+import { distinctUntilChanged } from 'rxjs/operators';
 
 @Component({
-  selector: "app-root",
-  templateUrl: "./app.component.html",
-  styleUrls: ["./app.component.css"],
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css'],
 })
 export class AppComponent implements OnInit, OnDestroy {
-  title = "Angular Flex-Layout";
-
   constructor(private mediaObserver: MediaObserver) {}
   private mediaSubscription!: Subscription;
-  private activeMediaQuery: string = "";
+  private activeMediaQuery: string = '';
 
   ngOnInit(): void {
     this.mediaSubscription = this.mediaObserver
@@ -57,11 +55,11 @@ export class AppComponent implements OnInit, OnDestroy {
         change.forEach((item) => {
           this.activeMediaQuery = item
             ? `'${item.mqAlias}' = (${item.mediaQuery})`
-            : "";
-          if (item.mqAlias === "xs") {
+            : '';
+          if (item.mqAlias === 'xs') {
             this.loadMobileContent();
           }
-          console.log("activeMediaQuery", this.activeMediaQuery);
+          console.log('activeMediaQuery', this.activeMediaQuery);
         });
       });
   }
@@ -86,14 +84,14 @@ those fields will be an empty string [''].
 #### 2. **`MediaObserver::asObservable()`**
 
 ```typescript
-import { Component } from "@angular/core";
-import { Subscription } from "rxjs/Subscription";
-import { filter } from "rxjs/operators/filter";
+import { Component } from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
+import { filter } from 'rxjs/operators/filter';
 
-import { MediaChange, MediaObserver } from "@angular/flex-layout";
+import { MediaChange, MediaObserver } from '@angular/flex-layout';
 
 @Component({
-  selector: "responsive-component",
+  selector: 'responsive-component',
 })
 export class MyDemo {
   constructor(media: MediaObserver) {
@@ -122,15 +120,15 @@ For example:
 - `xs` is an alias associated with the mediaQuery for mobile viewport sizes.
 
 ```typescript
-import { Component, OnInit } from "@angular/core";
-import { MediaChange, MediaObserver } from "@angular/flex-layout";
+import { Component, OnInit } from '@angular/core';
+import { MediaChange, MediaObserver } from '@angular/flex-layout';
 
-const PRINT_MOBILE = "print and (max-width: 600px)";
+const PRINT_MOBILE = 'print and (max-width: 600px)';
 
 @Component({
-  selector: "responsive-component",
+  selector: 'responsive-component',
   template: `
-    <div class="ad-content" *ngIf="media.isActive('xs')">
+    <div class='ad-content' *ngIf='media.isActive('xs')'>
       Only shown if on mobile viewport sizes
     </div>
   `,
@@ -139,7 +137,7 @@ export class MyDemo implements OnInit {
   constructor(public media: MediaObserver) {}
 
   ngOnInit() {
-    if (this.media.isActive("xs") && !this.media.isActive(PRINT_MOBILE)) {
+    if (this.media.isActive('xs') && !this.media.isActive(PRINT_MOBILE)) {
       this.loadMobileContent();
     }
   }


### PR DESCRIPTION
the ObservableMedia documentation should also be added to the WIKI pages and the ObservableMedia page deprecated or removed.