### PR TITLE
feat(core): remove deprecated MediaObserver::media$

### DIFF
--- a/projects/libs/flex-layout/core/add-alias.ts
+++ b/projects/libs/flex-layout/core/add-alias.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {MediaChange} from './media-change';
-import {BreakPoint} from './breakpoints/break-point';
+import {OptionalBreakPoint} from './breakpoints';
 
 /**
  * For the specified MediaChange, make sure it contains the breakpoint alias
  * and suffix (if available).
  */
-export function mergeAlias(dest: MediaChange, source: BreakPoint | null): MediaChange {
-  dest = dest ? dest.clone() : new MediaChange();
+export function mergeAlias(dest: MediaChange, source: OptionalBreakPoint): MediaChange {
+  dest = dest?.clone() ?? new MediaChange();
   if (source) {
     dest.mqAlias = source.alias;
     dest.mediaQuery = source.mediaQuery;

--- a/projects/libs/flex-layout/core/media-observer/media-observer.ts
+++ b/projects/libs/flex-layout/core/media-observer/media-observer.ts
@@ -62,14 +62,6 @@ import {coerceArray} from '../utils/array';
  */
 @Injectable({providedIn: 'root'})
 export class MediaObserver implements OnDestroy {
-
-  /**
-   * @deprecated Use `asObservable()` instead.
-   * @breaking-change 8.0.0-beta.25
-   * @deletion-target 10.0.0
-   */
-  readonly media$: Observable<MediaChange>;
-
   /** Filter MediaChange notifications for overlapping breakpoints */
   filterOverlaps = false;
 
@@ -77,10 +69,6 @@ export class MediaObserver implements OnDestroy {
               protected matchMedia: MatchMedia,
               protected hook: PrintHook) {
     this._media$ = this.watchActivations();
-    this.media$ = this._media$.pipe(
-      filter((changes: MediaChange[]) => changes.length > 0),
-      map((changes: MediaChange[]) => changes[0])
-    );
   }
 
   /**
@@ -192,9 +180,8 @@ export class MediaObserver implements OnDestroy {
       const bp: OptionalBreakPoint = this.breakpoints.findByQuery(change.mediaQuery);
       return mergeAlias(change, bp);
     };
-    const replaceWithPrintAlias = (change: MediaChange) => {
-      return this.hook.isPrintEvent(change) ? this.hook.updateEvent(change) : change;
-    };
+    const replaceWithPrintAlias = (change: MediaChange) =>
+      this.hook.isPrintEvent(change) ? this.hook.updateEvent(change) : change;
 
     return this.matchMedia
         .activations
@@ -221,7 +208,6 @@ function toMediaQuery(query: string, locator: BreakPointRegistry): string | null
  * separated.
  */
 function splitQueries(queries: string[]): string[] {
-  return queries.map((query: string) => query.split(','))
-                .reduce((a1: string[], a2: string[]) => a1.concat(a2))
-                .map(query => query.trim());
+  return queries.flatMap(query => query.split(','))
+    .map(query => query.trim());
 }


### PR DESCRIPTION
This feature has been deprecated and slated for removal for
several versions. Instead, please use MediaObserver::asObservable.
Note that the usage of this feature has changed, as individual
values are no longer emitted, instead favoring emitting
a full change set.

BREAKING CHANGE:
* MediaObserver::media$ has been removed. Please use
  MediaObserver::asObservable instead.
