### PR TITLE
fix(core): only emit changed events from MediaObserver

### DIFF
--- a/projects/libs/flex-layout/core/match-media/mock/mock-match-media.ts
+++ b/projects/libs/flex-layout/core/match-media/mock/mock-match-media.ts
@@ -40,8 +40,7 @@ export class MockMatchMedia extends MatchMedia {
   }
 
   /** Feature to support manual, simulated activation of a mediaQuery. */
-  activate(mediaQuery: string, useOverlaps = false): boolean {
-    useOverlaps = useOverlaps || this.useOverlaps;
+  activate(mediaQuery: string, useOverlaps = this.useOverlaps): boolean {
     mediaQuery = this._validateQuery(mediaQuery);
 
     if (useOverlaps || !this.isActive(mediaQuery)) {
@@ -55,9 +54,9 @@ export class MockMatchMedia extends MatchMedia {
   }
 
   /** Converts an optional mediaQuery alias to a specific, valid mediaQuery */
-  _validateQuery(queryOrAlias: string) {
+  _validateQuery(queryOrAlias: string): string {
     const bp = this._breakpoints.findByAlias(queryOrAlias);
-    return (bp && bp.mediaQuery) || queryOrAlias;
+    return bp?.mediaQuery ?? queryOrAlias;
   }
 
   /**
@@ -67,36 +66,36 @@ export class MockMatchMedia extends MatchMedia {
   private _activateWithOverlaps(mediaQuery: string, useOverlaps: boolean): boolean {
     if (useOverlaps) {
       const bp = this._breakpoints.findByQuery(mediaQuery);
-      const alias = bp ? bp.alias : 'unknown';
+      const alias = bp?.alias ?? 'unknown';
 
       // Simulate activation of overlapping lt-<XXX> ranges
       switch (alias) {
-        case 'lg'   :
+        case 'lg':
           this._activateByAlias(['lt-xl']);
           break;
-        case 'md'   :
+        case 'md':
           this._activateByAlias(['lt-xl', 'lt-lg']);
           break;
-        case 'sm'   :
+        case 'sm':
           this._activateByAlias(['lt-xl', 'lt-lg', 'lt-md']);
           break;
-        case 'xs'   :
+        case 'xs':
           this._activateByAlias(['lt-xl', 'lt-lg', 'lt-md', 'lt-sm']);
           break;
       }
 
       // Simulate activation of overlapping gt-<xxxx> mediaQuery ranges
       switch (alias) {
-        case 'xl'   :
+        case 'xl':
           this._activateByAlias(['gt-lg', 'gt-md', 'gt-sm', 'gt-xs']);
           break;
-        case 'lg'   :
+        case 'lg':
           this._activateByAlias(['gt-md', 'gt-sm', 'gt-xs']);
           break;
-        case 'md'   :
+        case 'md':
           this._activateByAlias(['gt-sm', 'gt-xs']);
           break;
-        case 'sm'   :
+        case 'sm':
           this._activateByAlias(['gt-xs']);
           break;
       }
@@ -112,7 +111,7 @@ export class MockMatchMedia extends MatchMedia {
   private _activateByAlias(aliases: string[]) {
     const activate = (alias: string) => {
       const bp = this._breakpoints.findByAlias(alias);
-      this._activateByQuery(bp ? bp.mediaQuery : alias);
+      this._activateByQuery(bp?.mediaQuery ?? alias);
     };
     aliases.forEach(activate);
   }

--- a/projects/libs/flex-layout/core/media-marshaller/media-marshaller.ts
+++ b/projects/libs/flex-layout/core/media-marshaller/media-marshaller.ts
@@ -135,7 +135,7 @@ export class MediaMarshaller {
     if (bpMap) {
       const values = this.getActivatedValues(bpMap, key);
       if (values) {
-        return values.get(key) !== undefined ?? false;
+        return values.get(key) !== undefined || false;
       }
     }
     return false;

--- a/projects/libs/flex-layout/core/media-observer/media-observer.spec.ts
+++ b/projects/libs/flex-layout/core/media-observer/media-observer.spec.ts
@@ -23,8 +23,8 @@ describe('media-observer', () => {
   let media$: Observable<MediaChange>;
   let mediaObserver: MediaObserver;
   let mediaController: MockMatchMedia;
-  const activateQuery = (alias: string) => {
-      mediaController.activate(alias);
+  const activateQuery = (alias: string, useOverlaps?: boolean) => {
+      mediaController.activate(alias, useOverlaps);
       tick(100);  // Since MediaObserver has 50ms debounceTime
   };
 
@@ -97,6 +97,27 @@ describe('media-observer', () => {
       activateQuery('gt-lg');
       activateQuery('invalid');
       expect(count).toEqual(2);
+
+      subscription.unsubscribe();
+    }));
+
+    it('only gets one substantive update per media change set', fakeAsync(() => {
+      let count = 0;
+      const subscription = mediaObserver.asObservable()
+        .subscribe(_changes => {
+          count += 1;
+        });
+
+      // Not a duplicate. This is intentional.
+      activateQuery('sm', true);
+      activateQuery('sm', true);
+      expect(count).toEqual(1);
+
+      activateQuery('md', true);
+      expect(count).toEqual(2);
+
+      activateQuery('xl', true);
+      expect(count).toEqual(3);
 
       subscription.unsubscribe();
     }));


### PR DESCRIPTION
It is unfortunately the case in a real-world browser environment
that overlapping breakpoints trigger separate events in our change
monitoring schema. This is (nearly) unavoidable, but what we can
do is ensure that we only emit distinct events for our event
aggregator, MediaObserver. We now only emit when we get an entirely
distinct set of media changes from the previous state.

Fixes #1041