### PR TITLE
fix(core): properly collect deactivated breakpoints before print

### DIFF
--- a/projects/libs/flex-layout/core/media-marshaller/media-marshaller.ts
+++ b/projects/libs/flex-layout/core/media-marshaller/media-marshaller.ts
@@ -355,6 +355,7 @@ export class MediaMarshaller {
   private observeActivations() {
     const queries = this.breakpoints.items.map(bp => bp.mediaQuery);
 
+    this.hook.registerBeforeAfterPrintHooks(this);
     this.matchMedia
         .observe(this.hook.withPrintQuery(queries))
         .pipe(


### PR DESCRIPTION
Previously we were collecting all deactivating breakpoints before
a print event. The problem with this, of course, is that our
breakpoints are designed as "screen and", which means that
transitioning to a new device type, in this case "print" sends out
deactivating media query events for _all_ of our breakpoints. This
means that our collection was useless because we were essentially
saying deactivate and then restore all breakpoints.

This corrects this behavior by doing two things:
1. If the print media query has not fired, use the activated
breakpoints from the marshaller to decide if the breakpoint
even needs to be deactivated
2. If the print media query has been fired, check a snapshot of
the most recent activations to determine if a breakpoint needs to
be deactivated.

Since we can't guarantee ordering of the events individual browsers
choose to fire in, we support both styles.

Ref #1201 
