### PR TITLE
feat(flex): detect display precedence in fxLayout directive

### DIFF
--- a/projects/libs/flex-layout/_private-utils/layout-validator.ts
+++ b/projects/libs/flex-layout/_private-utils/layout-validator.ts
@@ -14,14 +14,14 @@ export const LAYOUT_VALUES = ['row', 'column', 'row-reverse', 'column-reverse'];
 export function buildLayoutCSS(value: string) {
   let [direction, wrap, isInline] = validateValue(value);
   return buildCSS(direction, wrap, isInline);
- }
+}
 
 /**
   * Validate the value to be one of the acceptable value options
   * Use default fallback of 'row'
   */
 export function validateValue(value: string): [string, string, boolean] {
-  value = value ? value.toLowerCase() : '';
+  value = value?.toLowerCase() ?? '';
   let [direction, wrap, inline] = value.split(' ');
 
   // First value must be the `flex-direction`
@@ -84,9 +84,9 @@ export function validateWrapValue(value: string) {
  */
 function buildCSS(direction: string, wrap: string | null = null, inline = false) {
   return {
-    'display': inline ? 'inline-flex' : 'flex',
+    display: inline ? 'inline-flex' : 'flex',
     'box-sizing': 'border-box',
     'flex-direction': direction,
-    'flex-wrap': !!wrap ? wrap : null
+    'flex-wrap': wrap || null,
   };
 }

--- a/projects/libs/flex-layout/core/tokens/library-config.ts
+++ b/projects/libs/flex-layout/core/tokens/library-config.ts
@@ -21,6 +21,7 @@ export interface LayoutConfigOptions {
   ssrObserveBreakpoints?: string[];
   multiplier?: Multiplier;
   defaultUnit?: string;
+  detectLayoutDisplay?: boolean;
 }
 
 export const DEFAULT_CONFIG: Required<LayoutConfigOptions> = {
@@ -38,6 +39,7 @@ export const DEFAULT_CONFIG: Required<LayoutConfigOptions> = {
   // Instead, we disable it by default, which requires this ugly cast.
   multiplier: undefined as unknown as Multiplier,
   defaultUnit: 'px',
+  detectLayoutDisplay: false,
 };
 
 export const LAYOUT_CONFIG = new InjectionToken<LayoutConfigOptions>(

--- a/projects/libs/flex-layout/flex/layout/layout.spec.ts
+++ b/projects/libs/flex-layout/flex/layout/layout.spec.ts
@@ -39,7 +39,7 @@ describe('layout directive', () => {
 
     // Configure testbed to prepare services
     TestBed.configureTestingModule({
-      imports: [CommonModule, FlexLayoutModule],
+      imports: [CommonModule, FlexLayoutModule.withConfig({detectLayoutDisplay: true})],
       declarations: [TestLayoutComponent],
       providers: [
         MockMatchMediaProvider,
@@ -62,6 +62,14 @@ describe('layout directive', () => {
       createTestComponent(`<div fxLayout='row'></div>`);
       expectNativeEl(fixture).toHaveStyle({
         'display': 'flex',
+        'flex-direction': 'row',
+        'box-sizing': 'border-box'
+      }, styler);
+    });
+    it('should not override pre-existing styles', () => {
+      createTestComponent(`<div fxLayout style="display: none;"></div>`);
+      expectNativeEl(fixture).toHaveStyle({
+        'display': 'none',
         'flex-direction': 'row',
         'box-sizing': 'border-box'
       }, styler);


### PR DESCRIPTION
In some cases, a user may intentionally hide a directive using
styling that exists outside of the scope of this library. However,
fxLayout had no way of detecting this, or establishing a precedence
for pre-existing styles. This adds detection and special caching
for pre-styled display attributes on an element. This means that if,
at any point in the change detection of the directive for its entire
lifespan, it detects that the style has been set to `display: none`,
it will use that as the display value in place of what it otherwise
would have used.

Please note: this means that you need to be more careful when using
this functionality! If, for instance, you have functionality that
sets `display: none` on a directive, that functionality needs to
now take over restoring the correct style for the directive. This
is essentially an escape hatch from the library: saying that you
know better how to manage these directives.

To use this feature, do the following:

```ts
@NgModule({
  imports: [
    FlexLayoutModule.withConfig({detectLayoutDisplay: true}),
  ],
})
export class AppModule {}
```

Your markup should then adapt automatically to the new behavior.

Fixes #1043