### PR TITLE
fix(core): import distinctUntilChanged from rxjs/operators

### DIFF
--- a/projects/libs/flex-layout/core/media-observer/media-observer.ts
+++ b/projects/libs/flex-layout/core/media-observer/media-observer.ts
@@ -6,8 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {Injectable, OnDestroy} from '@angular/core';
-import {Subject, asapScheduler, Observable, of, distinctUntilChanged} from 'rxjs';
-import {debounceTime, filter, map, switchMap, takeUntil} from 'rxjs/operators';
+import {Subject, asapScheduler, Observable, of} from 'rxjs';
+import {
+  debounceTime,
+  distinctUntilChanged,
+  filter,
+  map,
+  switchMap,
+  takeUntil,
+} from 'rxjs/operators';
 
 import {mergeAlias} from '../add-alias';
 import {MediaChange} from '../media-change';


### PR DESCRIPTION
RxJS x7 supports top-level exports, but since we still support
RxJS v6, we need to continue to import from the operators
subexport.

Fixes #1389 