### PR TITLE
fix(private): remove fallback from flex-direction auto-prefixer

### DIFF
--- a/projects/libs/flex-layout/_private-utils/auto-prefixer.ts
+++ b/projects/libs/flex-layout/_private-utils/auto-prefixer.ts
@@ -19,7 +19,7 @@
  */
 export function applyCssPrefixes(target: {[key: string]: any | null}) {
   for (let key in target) {
-    let value = target[key] || '';
+    let value = target[key] ?? '';
 
     switch (key) {
       case 'display':
@@ -52,7 +52,6 @@ export function applyCssPrefixes(target: {[key: string]: any | null}) {
         break;
 
       case 'flex-direction':
-        value = value || 'row';
         target['-webkit-flex-direction'] = value;
         target['flex-direction'] = value;
         break;


### PR DESCRIPTION
When we clear styles on the server, we emit an empty value in
order to flush the cache. However, all values still end up
passing through the auto-prefixer, which then converted this
value to the default value of row. However, other components
own the default 'row' value fallback, and so this only serves
to add another layer of logic that gets in the way. Now, we remove
it so that the overlying mechanisms can work as intended in both
browser and server.

Fixes #1394
